### PR TITLE
Updated link to IonosCloud Provider docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ make build
 
 ## Using the provider
 
-See the [IonosCloud Provider documentation](https://www.terraform.io/docs/providers/ionoscloud/index.html) to get started using the IonosCloud provider.
+See the [IonosCloud Provider documentation](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/latest/docs) to get started using the IonosCloud provider.
 
 ## Developing the Provider
 


### PR DESCRIPTION
Hi,

this is a minor change, the link to the provider docs in the README.md was leading to a 404. The link has been updated to point to the latest version of docs on TF registry.

Cheers,
Janosch