### PR TITLE
Docs/server

### DIFF
--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -33,12 +33,14 @@ The following attributes are returned by the datasource:
 * `name`
 * `datacenter_id`
 * `cores`
+* `cpu_family`
 * `ram`
 * `availability_zone`
 * `vm_state`
-* `cpu_family`
+* `image_name`
 * `boot_cdrom`
 * `boot_volume`
+* `ssh_key_path`
 * `cdroms` - list of
   * `id`
   * `name`
@@ -91,7 +93,7 @@ The following attributes are returned by the datasource:
   * `lan`
   * `firewall_active`
   * `nat`
-  * `firewall_rules` - list of 
+  * `firewall_rules` - list of
     * `id`
     * `name`
     * `protocol`

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -58,8 +58,8 @@ resource "ionoscloud_server" "example" {
 - `boot_image` - (Optional)[string] The image or snapshot UUID / name. May also be an image alias. It is required if `licence_type` is not provided.
 - `primary_nic` - (Computed) The associated NIC.
 - `primary_ip` - (Computed) The associated IP address.
-- `ssh_key_path` - (Required)[list] List of paths to files containing a public SSH key that will be injected into IonosCloud provided Linux images. Required for IonosCloud Linux images. Required if `image_password` is not provided.
-- `image_password` - (Optional)[string] Required if `sshkey_path` is not provided.
+- `ssh_key_path` - (Optional)[list] List of paths to files containing a public SSH key that will be injected into IonosCloud provided Linux images. Required for IonosCloud Linux images. Required if `image_password` is not provided.
+- `image_password` - (Optional)[string] Required if `ssh_key_path` is not provided.
 
 ## Import
 

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -24,7 +24,7 @@ resource "ionoscloud_server" "example" {
   cpu_family        = "AMD_OPTERON"
   image_password    = "test1234"
   ssh_key_path      = "${var.private_key_path}"
-  boot_image        = "${var.ubuntu}"
+  image_name        = "${var.ubuntu}"
 
   volume {
     name           = "new"
@@ -47,19 +47,19 @@ resource "ionoscloud_server" "example" {
 - `datacenter_id` - (Required)[string] The ID of a Virtual Data Center.
 - `cores` - (Required)[integer] Number of server CPU cores.
 - `ram` - (Required)[integer] The amount of memory for the server in MB.
+- `image_name` - (Required)[string] The name or ID of the image.
 - `availability_zone` - (Optional)[string] The availability zone in which the server should exist.
 - `licence_type` - (Optional)[string] Sets the OS type of the server.
-- `cpu_family` - (Optional)[string] Sets the CPU type. "AMD_OPTERON" or "INTEL_XEON". Defaults to "AMD_OPTERON".
+- `cpu_family` - (Optional)[string] Sets the CPU type. "AMD_OPTERON", "INTEL_XEON" or "INTEL_SKYLAKE".
 - `volume` - (Required) See the Volume section.
 - `nic` - (Required) See the NIC section.
 - `boot_volume` - (Computed) The associated boot volume.
 - `boot_cdrom` - (Computed) The associated boot drive, if any.
-- `boot_image` - [string] The image or snapshot UUID / name. May also be an image alias. It is required if `licence_type` is not provided.
+- `boot_image` - (Optional)[string] The image or snapshot UUID / name. May also be an image alias. It is required if `licence_type` is not provided.
 - `primary_nic` - (Computed) The associated NIC.
 - `primary_ip` - (Computed) The associated IP address.
-- `image_password` - (Computed) The associated IP address.
 - `ssh_key_path` - (Required)[list] List of paths to files containing a public SSH key that will be injected into IonosCloud provided Linux images. Required for IonosCloud Linux images. Required if `image_password` is not provided.
-- `image_password` - [string] Required if `sshkey_path` is not provided.
+- `image_password` - (Optional)[string] Required if `sshkey_path` is not provided.
 
 ## Import
 


### PR DESCRIPTION
this PR updates the documentation for `ionoscloud_server` to make the usability & experience better: 

### data-sources

- add `image_name`
- add `ssh_key_path`
- correct whitespaces

### sources

- add `image_name`
- add INTEL_SKYLAKE to `cpu_family`
- mark `ssh_key_path` & `image_password` as optional as they are only required if the other is not set
- mark `boot_image` as optional