### PR TITLE
fix: fixes #29 - corrected parameter name in volume error message

### DIFF
--- a/ionoscloud/resource_volume.go
+++ b/ionoscloud/resource_volume.go
@@ -201,7 +201,7 @@ func resourceVolumeCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if imageName == "" && licenceType == "" && isSnapshot == false {
-		diags := diag.FromErr(fmt.Errorf("either 'image_name', or 'licenceType' must be set"))
+		diags := diag.FromErr(fmt.Errorf("either 'image_name', or 'licence_type' must be set"))
 		return diags
 	}
 


### PR DESCRIPTION
fix: fixes #29 - correcter parameter in volume error message with licence_type instead of licenceType