### PR TITLE
fix: fixes #40 - ip_failover just computed for lan resource

### DIFF
--- a/ionoscloud/resource_lan.go
+++ b/ionoscloud/resource_lan.go
@@ -43,7 +43,6 @@ func resourceLan() *schema.Resource {
 			},
 			"ip_failover": {
 				Type:     schema.TypeList,
-				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
fix: fixes #40 - ip_failover just computed for lan resource