### PR TITLE
Feat/k8s patch level

### DIFF
--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -28,9 +28,9 @@ resource "ionoscloud_k8s_cluster" "example" {
 The following arguments are supported:
 
 - `name` - (Required)[string] The name of the Kubernetes Cluster.
-- `k8s_version` - (Optional)[string] The desired Kubernetes Version. For supported values, please check the API documentation.
+- `k8s_version` - (Optional)[string] The desired Kubernetes Version. For supported values, please check the API documentation. The provider will ignore changes of patch level.
 - `maintenance_window` - (Optional) See the **maintenance_window** section in the example above
-- `public` - The indicator if the cluster is public or private. Be aware that setting it to false is currently in beta phase.
+- `public` - The indicator if the cluster is public or private. Be aware that setting it to false is currently in beta phase. Default value is true
 - `gateway_ip` - The IP address of the gateway used by the cluster. This is mandatory when `public` is set to `false` and should not be provided otherwise.
 
 ## Import

--- a/docs/resources/k8s_node_pool.md
+++ b/docs/resources/k8s_node_pool.md
@@ -44,7 +44,7 @@ resource "ionoscloud_k8s_node_pool" "demo" {
 The following arguments are supported:
 
 - `name` - (Required)[string] The name of the Kubernetes Cluster.
-- `k8s_version` - (Optional)[string] The desired Kubernetes Version. for supported values, please check the API documentation.
+- `k8s_version` - (Optional)[string] The desired Kubernetes Version. for supported values, please check the API documentation. The provider will ignore changes of patch level.
 - `auto_scaling` - (Optional)[string] Wether the Node Pool should autoscale. For more details, please check the API documentation
 - `lans` - (Optional)[list] A list of numeric LAN id's you want this node pool to be part of. For more details, please check the API documentation, as well as the example above
 - `maintenance_window` - (Optional) See the **maintenance_window** section in the example above

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/go-test/deep v1.0.6 // indirect
@@ -11,8 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
-	github.com/hashicorp/terraform-exec v0.13.3 // indirect
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
 	github.com/ionos-cloud/sdk-go/v5 v5.1.3
 	github.com/jhump/protoreflect v1.6.1 // indirect
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
+	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
 	golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb // indirect

--- a/ionoscloud/resource_k8s_cluster.go
+++ b/ionoscloud/resource_k8s_cluster.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v5"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -33,6 +34,23 @@ func resourcek8sCluster() *schema.Resource {
 				Description: "The desired kubernetes version",
 				Optional:    true,
 				Computed:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					var oldMajor, oldMinor string
+					if old != "" {
+						oldSplit := strings.Split(old, ".")
+						oldMajor = oldSplit[0]
+						oldMinor = oldSplit[1]
+
+						newSplit := strings.Split(new, ".")
+						newMajor := newSplit[0]
+						newMinor := newSplit[1]
+
+						if oldMajor == newMajor && oldMinor == newMinor {
+							return true
+						}
+					}
+					return false
+				},
 			},
 			"maintenance_window": {
 				Type:        schema.TypeList,
@@ -77,7 +95,7 @@ func resourcek8sCluster() *schema.Resource {
 				Description: "The indicator if the cluster is public or private. Be aware that setting it to false is " +
 					"currently in beta phase.",
 				Optional: true,
-				Computed: true,
+				Default:  true,
 			},
 			"gateway_ip": {
 				Type: schema.TypeString,
@@ -121,12 +139,8 @@ func resourcek8sClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 		cluster.Properties.MaintenanceWindow.DayOfTheWeek = &mdVal
 	}
 
-	if public, publicOk := d.GetOkExists("public"); publicOk {
-		public := public.(bool)
-		fmt.Printf("Value %v", public)
-		cluster.Properties.Public = &public
-		fmt.Printf("Value %v", *cluster.Properties.Public)
-	}
+	public := d.Get("public").(bool)
+	cluster.Properties.Public = &public
 
 	if gatewayIp, gatewayIpOk := d.GetOk("gateway_ip"); gatewayIpOk {
 		gatewayIp := gatewayIp.(string)

--- a/ionoscloud/resource_k8s_cluster_test.go
+++ b/ionoscloud/resource_k8s_cluster_test.go
@@ -28,6 +28,7 @@ func TestAcck8sCluster_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckk8sClusterExists("ionoscloud_k8s_cluster.example", &k8sCluster),
 					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "name", k8sClusterName),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "public", "true"),
 				),
 			},
 			{
@@ -35,6 +36,45 @@ func TestAcck8sCluster_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckk8sClusterExists("ionoscloud_k8s_cluster.example", &k8sCluster),
 					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "name", "updated"),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "public", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcck8sCluster_Version(t *testing.T) {
+	var k8sCluster ionoscloud.KubernetesCluster
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckk8sClusterDestroyCheck,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckk8sClusterConfigVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckk8sClusterExists("ionoscloud_k8s_cluster.example", &k8sCluster),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "name", "test_version"),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "k8s_version", "1.18.5"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckk8sClusterConfigIgnoreVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckk8sClusterExists("ionoscloud_k8s_cluster.example", &k8sCluster),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "name", "test_version_ignore"),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "k8s_version", "1.18.5"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckk8sClusterConfigChangeVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckk8sClusterExists("ionoscloud_k8s_cluster.example", &k8sCluster),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "name", "test_version_change"),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_cluster.example", "k8s_version", "1.19.10"),
 				),
 			},
 		},
@@ -122,5 +162,22 @@ resource "ionoscloud_k8s_cluster" "example" {
     day_of_the_week = "Monday"
     time            = "10:30:00Z"
   }
-  
+}`
+
+const testAccCheckk8sClusterConfigVersion = `
+resource "ionoscloud_k8s_cluster" "example" {
+  name        = "test_version"
+  k8s_version = "1.18.5"
+}`
+
+const testAccCheckk8sClusterConfigIgnoreVersion = `
+resource "ionoscloud_k8s_cluster" "example" {
+  name        = "test_version_ignore"
+  k8s_version = "1.18.9"
+}`
+
+const testAccCheckk8sClusterConfigChangeVersion = `
+resource "ionoscloud_k8s_cluster" "example" {
+  name        = "test_version_change"
+  k8s_version = "1.19.10"
 }`

--- a/ionoscloud/resource_k8s_node_pool.go
+++ b/ionoscloud/resource_k8s_node_pool.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v5"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -34,6 +35,23 @@ func resourcek8sNodePool() *schema.Resource {
 				Description:  "The desired kubernetes version",
 				Required:     true,
 				ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					var oldMajor, oldMinor string
+					if old != "" {
+						oldSplit := strings.Split(old, ".")
+						oldMajor = oldSplit[0]
+						oldMinor = oldSplit[1]
+
+						newSplit := strings.Split(new, ".")
+						newMajor := newSplit[0]
+						newMinor := newSplit[1]
+
+						if oldMajor == newMajor && oldMinor == newMinor {
+							return true
+						}
+					}
+					return false
+				},
 			},
 			"auto_scaling": {
 				Type:        schema.TypeList,
@@ -298,7 +316,8 @@ func resourcek8sNodePoolCreate(ctx context.Context, d *schema.ResourceData, meta
 		case <-ctx.Done():
 			diags := diag.FromErr(fmt.Errorf("k8s node pool creation timed out! WARNING: your k8s nodepool will still probably be " +
 				"created after some time but the terraform state won't reflect that; check your Ionos Cloud account for updates"))
-			return diags }
+			return diags
+		}
 	}
 
 	return resourcek8sNodePoolRead(ctx, d, meta)
@@ -656,7 +675,8 @@ func resourcek8sNodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 		case <-ctx.Done():
 			diags := diag.FromErr(fmt.Errorf("k8s node pool update timed out! WARNING: your k8s nodepool will still probably be " +
 				"updated after some time but the terraform state won't reflect that; check your Ionos Cloud account for updates"))
-			return diags}
+			return diags
+		}
 	}
 
 	return resourcek8sNodePoolRead(ctx, d, meta)
@@ -697,7 +717,8 @@ func resourcek8sNodePoolDelete(ctx context.Context, d *schema.ResourceData, meta
 		case <-ctx.Done():
 			diags := diag.FromErr(fmt.Errorf("k8s node pool deletion timed out! WARNING: your k8s nodepool will still probably be " +
 				"deleted after some time but the terraform state won't reflect that; check your Ionos Cloud account for updates"))
-			return 	diags	}
+			return diags
+		}
 	}
 
 	d.SetId("")

--- a/ionoscloud/resource_k8s_node_pool_test.go
+++ b/ionoscloud/resource_k8s_node_pool_test.go
@@ -64,6 +64,41 @@ func TestAcck8sNodepool_Basic(t *testing.T) {
 	})
 }
 
+func TestAcck8sNodepool_Version(t *testing.T) {
+	var k8sNodepool ionoscloud.KubernetesNodePool
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckk8sNodepoolDestroyCheck,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckk8sNodepoolConfigVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckk8sNodepoolExists("ionoscloud_k8s_node_pool.terraform_acctest", &k8sNodepool),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_node_pool.terraform_acctest", "k8s_version", "1.18.5"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckk8sNodepoolConfigIgnoreVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckk8sNodepoolExists("ionoscloud_k8s_node_pool.terraform_acctest", &k8sNodepool),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_node_pool.terraform_acctest", "k8s_version", "1.18.5"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckk8sNodepoolConfigChangeVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckk8sNodepoolExists("ionoscloud_k8s_node_pool.terraform_acctest", &k8sNodepool),
+					resource.TestCheckResourceAttr("ionoscloud_k8s_node_pool.terraform_acctest", "k8s_version", "1.19.10"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckk8sNodepoolDestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ionoscloud.APIClient)
 
@@ -201,4 +236,82 @@ resource "ionoscloud_k8s_node_pool" "terraform_acctest" {
   ram_size          = 2048
   storage_size      = 40
   public_ips        = [ "%s", "%s", "%s" ]
+}`
+
+const testAccCheckk8sNodepoolConfigVersion = `
+resource "ionoscloud_datacenter" "terraform_acctest" {
+  name        = "terraform_acctest"
+  location    = "us/las"
+  description = "Datacenter created through terraform"
+}
+
+resource "ionoscloud_k8s_cluster" "terraform_acctest" {
+  name        = "terraform_acctest"
+  k8s_version = "1.18.5"
+}
+
+resource "ionoscloud_k8s_node_pool" "terraform_acctest" {
+  name        = "test_version"
+  k8s_version = "${ionoscloud_k8s_cluster.terraform_acctest.k8s_version}"
+  datacenter_id     = "${ionoscloud_datacenter.terraform_acctest.id}"
+  k8s_cluster_id    = "${ionoscloud_k8s_cluster.terraform_acctest.id}"
+  cpu_family        = "INTEL_XEON"
+  availability_zone = "AUTO"
+  storage_type      = "SSD"
+  node_count        = 1
+  cores_count       = 2
+  ram_size          = 2048
+  storage_size      = 40
+}`
+
+const testAccCheckk8sNodepoolConfigIgnoreVersion = `
+resource "ionoscloud_datacenter" "terraform_acctest" {
+  name        = "terraform_acctest"
+  location    = "us/las"
+  description = "Datacenter created through terraform"
+}
+
+resource "ionoscloud_k8s_cluster" "terraform_acctest" {
+  name        = "terraform_acctest"
+  k8s_version = "1.18.9"
+}
+
+resource "ionoscloud_k8s_node_pool" "terraform_acctest" {
+  name        = "test_version"
+  k8s_version = "${ionoscloud_k8s_cluster.terraform_acctest.k8s_version}"
+  datacenter_id     = "${ionoscloud_datacenter.terraform_acctest.id}"
+  k8s_cluster_id    = "${ionoscloud_k8s_cluster.terraform_acctest.id}"
+  cpu_family        = "INTEL_XEON"
+  availability_zone = "AUTO"
+  storage_type      = "SSD"
+  node_count        = 1
+  cores_count       = 2
+  ram_size          = 2048
+  storage_size      = 40
+}`
+
+const testAccCheckk8sNodepoolConfigChangeVersion = `
+resource "ionoscloud_datacenter" "terraform_acctest" {
+  name        = "terraform_acctest"
+  location    = "us/las"
+  description = "Datacenter created through terraform"
+}
+
+resource "ionoscloud_k8s_cluster" "terraform_acctest" {
+  name        = "terraform_acctest"
+  k8s_version = "1.19.10"
+}
+
+resource "ionoscloud_k8s_node_pool" "terraform_acctest" {
+  name        = "test_version"
+  k8s_version = "${ionoscloud_k8s_cluster.terraform_acctest.k8s_version}"
+  datacenter_id     = "${ionoscloud_datacenter.terraform_acctest.id}"
+  k8s_cluster_id    = "${ionoscloud_k8s_cluster.terraform_acctest.id}"
+  cpu_family        = "INTEL_XEON"
+  availability_zone = "AUTO"
+  storage_type      = "SSD"
+  node_count        = 1
+  cores_count       = 2
+  ram_size          = 2048
+  storage_size      = 40
 }`

--- a/ionoscloud/resource_s3_key.go
+++ b/ionoscloud/resource_s3_key.go
@@ -37,7 +37,7 @@ func resourceS3Key() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Whether this key should be active or not.",
 				Optional:    true,
-				Default: 	 true,
+				Default:     true,
 			},
 		},
 		Timeouts: &resourceDefaultTimeouts,
@@ -207,7 +207,8 @@ func resourceS3KeyDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		case <-ctx.Done():
 			log.Printf("[INFO] delete timed out")
 			diags := diag.FromErr(fmt.Errorf("s3 key delete timed out! WARNING: your s3 key will still probably be deleted after some time but the terraform state won't reflect that; check your Ionos Cloud account for updates"))
-			return diags}
+			return diags
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- fix: fixes #13 provider ignores now changes of patch level for k8s_version 
- put a default value for public value for node_pool to stop using deprecated GetOkExists 