### PR TITLE
fix(server): add user_data to inline volume schema

### DIFF
--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -193,6 +193,11 @@ func resourceServer() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"user_data": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -530,6 +535,13 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		if len(publicKeys) > 0 {
 			volume.SshKeys = &publicKeys
 		}
+	}
+
+	userData := d.Get("volume.0.user_data").(string)
+	if userData != "" {
+		volume.UserData = &userData
+	} else {
+		volume.UserData = nil
 	}
 
 	request.Entities = &ionoscloud.ServerEntities{


### PR DESCRIPTION
The embedded `volume` in `ionos_server` does not accept `user_data` for cloud-init configuration yet. This simple fix works for me against the staging API. 

I'm not entirely sure what's your approach to sanity checking configuration at this point is, so please feel free to add or suggest checks against `image_name` like  the ones in `resource_volume.go`. Also the v6 branch does not build for me without running `go mod tidy && go mod vendor` but I didn't include this in this PR. 