### PR TITLE
fixed #19 - set ssh_key_path as computed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.12
+
+- issue #19 - fixed update ssh_key_path although not changed
+
 ## 5.2.11
 
 - documentation updates

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -102,6 +102,7 @@ func resourceServer() *schema.Resource {
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				ConflictsWith: []string{"volume.0.ssh_key_path"},
 				Optional:      true,
+				Computed:      true,
 			},
 			"volume": {
 				Type:     schema.TypeList,
@@ -152,6 +153,7 @@ func resourceServer() *schema.Resource {
 							Elem:       &schema.Schema{Type: schema.TypeString},
 							Optional:   true,
 							Deprecated: "Please use ssh_key_path under server level",
+							Computed:   true,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								if k == "volume.0.ssh_key_path.#" {
 									if d.Get("ssh_key_path.#") == new {


### PR DESCRIPTION
## What does this fix or implement?

fixed #19 - set ssh_key_path to computed to prevent terraform to update it although not changed

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented
- [x] Github Issue linked if any
