### PR TITLE
ignoring k8s version drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.12
+
+- ignoring k8s version drift for k8s clusters updated remotely
+
 ## 5.2.11
 
 - documentation updates

--- a/docs/data-sources/k8s_cluster.md
+++ b/docs/data-sources/k8s_cluster.md
@@ -31,7 +31,9 @@ The following attributes are returned by the datasource:
 
 * `id` - id of the cluster
 * `name` - name of the cluster
-* `k8s_version` - Kubernetes version
+* `k8s_version` - Kubernetes version - please note that this attribute ignores 
+   drift - i.e. if the remote cluster's k8s version is changed, this will not trigger
+   a plan diff.
 * `maintenance_window` - A maintenance window comprise of a day of the week and a time for maintenance to be allowed
   * `time` - A clock time in the day when maintenance is allowed
   * `day_of_the_week` - Day of the week when maintenance is allowed

--- a/ionoscloud/resource_k8s_cluster_test.go
+++ b/ionoscloud/resource_k8s_cluster_test.go
@@ -177,7 +177,7 @@ func testAccCheckk8sClusterExists(n string, k8sCluster *ionoscloud.KubernetesClu
 const testAccCheckk8sClusterConfigBasic = `
 resource "ionoscloud_k8s_cluster" "example" {
   name        = "%s"
-  k8s_version = "1.20.8"
+  k8s_version = "1.20.10"
   maintenance_window {
     day_of_the_week = "Sunday"
     time            = "09:00:00Z"
@@ -187,7 +187,7 @@ resource "ionoscloud_k8s_cluster" "example" {
 const testAccCheckk8sClusterConfigUpdate = `
 resource "ionoscloud_k8s_cluster" "example" {
   name        = "updated"
-  k8s_version = "1.20.8"
+  k8s_version = "1.20.10"
   maintenance_window {
     day_of_the_week = "Monday"
     time            = "10:30:00Z"
@@ -213,17 +213,17 @@ resource "ionoscloud_k8s_cluster" "example" {
 const testAccCheckk8sClusterConfigVersion = `
 resource "ionoscloud_k8s_cluster" "example" {
   name        = "test_version"
-  k8s_version = "1.18.5"
+  k8s_version = "1.20.10"
 }`
 
 const testAccCheckk8sClusterConfigIgnoreVersion = `
 resource "ionoscloud_k8s_cluster" "example" {
   name        = "test_version_ignore"
-  k8s_version = "1.18.9"
+  k8s_version = "1.20.11"
 }`
 
 const testAccCheckk8sClusterConfigChangeVersion = `
 resource "ionoscloud_k8s_cluster" "example" {
   name        = "test_version_change"
-  k8s_version = "1.19.10"
+  k8s_version = "1.21.4"
 }`


### PR DESCRIPTION
## What does this fix or implement?

We're trying to ignore k8s version drift (i.e. remote k8s version changes triggered for example when Ionos updates the k8s version of a customer's cluster), while still applying user plan changes to the k8s version.

## Checklist

- [x] Tests added or updated - _
- [x] Documentation updated
- [x] Changelog updated and version incremented
- [ ] Github Issue linked if any
