### PR TITLE
userData and backupUnitID in volume server + nil check on apiResponse.Response +  fixed issue #19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.2.12
+## 5.2.13
 
 - added user_data and backup_unit_id in the volume entity from server
 - fix issue #19 - fixed update ssh_key_path although not changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 5.2.12
 
+- added user_data and backup_unit_id in the volume entity from server
+- fix issue #19 - fixed update ssh_key_path although not changed
+
+## 5.2.12
+
 - fix: correctly saving lans when reading a k8s node pool
 
 ## 5.2.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - added user_data and backup_unit_id in the volume entity from server
 - fix issue #19 - fixed update ssh_key_path although not changed
+- issue #93 - updated documentation for image data source
 
 ## 5.2.12
 

--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -13,11 +13,12 @@ The images data source can be used to search for and return an existing image wh
 ## Example Usage
 
 ```hcl
-data "ionoscloud_image" "image_example" {
-  name     = "Ubuntu"
-  type     = "HDD"
-  version  = "14"
-  location = "location_id"
+data "ionoscloud_image" "img" {
+  name = "ubuntu"
+  type = "CDROM"
+  version = "18.04.3-live-server-amd64.iso"
+  location = "de/fkb"
+  cloud_init = "NONE"
 }
 ```
 
@@ -27,7 +28,6 @@ data "ionoscloud_image" "image_example" {
  * `version` - (Optional) Version of the image (see details below).
  * `location` - (Optional) Id of the existing image's location.
  * `type` - (Optional) The image type, HDD or CD-ROM.
- * `image_aliases` - (Optional) Image aliases
  * `cloud_init` - (Optional) Cloud init compatibility ("NONE" or "V1")
 
 If both "name" and "version" are provided the plugin will concatenate the two strings in this format [name]-[version].

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -40,15 +40,16 @@ resource "ionoscloud_volume" "example" {
 * `licence_type` - (Optional)[string] Required if `image_name` is not provided.
 * `name` - (Optional)[string] The name of the volume.
 * `availability_zone` - (Optional)[string] The storage availability zone assigned to the volume: AUTO, ZONE_1, ZONE_2, or ZONE_3.
-* `user_data` - (Optional) The cloud-init configuration for the volume as base64 encoded string. The property is immutable and is only allowed to be set on a new volume creation. This option will work only with cloud-init compatible images.
-* `cpu_hot_plug` - (Optional)[string] Is capable of CPU hot plug (no reboot required)
-* `ram_hot_plug` - (Optional)[string] Is capable of memory hot plug (no reboot required)
-* `nic_hot_plug` - (Optional)[string] Is capable of nic hot plug (no reboot required)
-* `nic_hot_unplug` - (Optional)[string] Is capable of nic hot unplug (no reboot required)
-* `disc_virtio_hot_plug` - (Optional)[string] Is capable of Virt-IO drive hot plug (no reboot required)
-* `disc_virtio_hot_unplug` - (Optional)[string] Is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines.
+* `user_data` - (Optional)[string] The cloud-init configuration for the volume as base64 encoded string. The property is immutable and is only allowed to be set on a new volume creation. This option will work only with cloud-init compatible images.
 * `backup_unit_id`- (Optional)[string] he uuid of the Backup Unit that user has access to. The property is immutable and is only allowed to be set on a new volume creation. It is mandatory to provide either 'public image' or 'imageAlias' in conjunction with this property.
 * `device_number` - (Computed) The LUN ID of the storage volume. Null for volumes not mounted to any VM
+* `cpu_hot_plug` - (Computed)[string] Is capable of CPU hot plug (no reboot required)
+* `ram_hot_plug` - (Computed)[string] Is capable of memory hot plug (no reboot required)
+* `nic_hot_plug` - (Computed)[string] Is capable of nic hot plug (no reboot required)
+* `nic_hot_unplug` - (Computed)[string] Is capable of nic hot unplug (no reboot required)
+* `disc_virtio_hot_plug` - (Computed)[string] Is capable of Virt-IO drive hot plug (no reboot required)
+* `disc_virtio_hot_unplug` - (Computed)[string] Is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines.
+
 ## Import
 
 Resource Volume can be imported using the `resource id`, e.g.

--- a/ionoscloud/import_server_test.go
+++ b/ionoscloud/import_server_test.go
@@ -26,7 +26,7 @@ func TestAccServer_ImportBasic(t *testing.T) {
 				ImportStateIdFunc:       testAccServerImportStateId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image_password", "ssh_key_path.#", "image_name"},
+				ImportStateVerifyIgnore: []string{"image_password", "ssh_key_path.#", "image_name", "volume.0.user_data", "volume.0.backup_unit_id"},
 			},
 		},
 	})

--- a/ionoscloud/import_volume_test.go
+++ b/ionoscloud/import_volume_test.go
@@ -26,7 +26,7 @@ func TestAccVolume_ImportBasic(t *testing.T) {
 				ImportStateIdFunc:       testAccVolumeImportStateId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image_password", "ssh_key_path.#", "image_name"},
+				ImportStateVerifyIgnore: []string{"image_password", "ssh_key_path.#", "image_name", "user_data", "backup_unit_id"},
 			},
 		},
 	})

--- a/ionoscloud/resource_backup_unit.go
+++ b/ionoscloud/resource_backup_unit.go
@@ -112,7 +112,7 @@ func resourceBackupUnitRead(ctx context.Context, d *schema.ResourceData, meta in
 	backupUnit, apiResponse, err := client.BackupUnitApi.BackupunitsFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -191,7 +191,7 @@ func resourceBackupUnitUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	_, apiResponse, err := client.BackupUnitApi.BackupunitsPut(ctx, d.Id()).BackupUnit(request).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -233,7 +233,7 @@ func resourceBackupUnitDelete(ctx context.Context, d *schema.ResourceData, meta 
 	_, apiResponse, err := client.BackupUnitApi.BackupunitsDelete(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -282,7 +282,7 @@ func backupUnitDeleted(client *ionoscloud.APIClient, d *schema.ResourceData, c c
 	_, apiResponse, err := client.BackupUnitApi.BackupunitsFindById(c, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			return true, nil
 		}
 		return true, fmt.Errorf("error checking backup unit deletion status: %s", err)

--- a/ionoscloud/resource_datacenter.go
+++ b/ionoscloud/resource_datacenter.go
@@ -121,7 +121,7 @@ func resourceDatacenterRead(ctx context.Context, d *schema.ResourceData, meta in
 	datacenter, apiResponse, err := client.DataCenterApi.DatacentersFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/ionoscloud/resource_firewall.go
+++ b/ionoscloud/resource_firewall.go
@@ -176,7 +176,7 @@ func resourceFirewallRead(ctx context.Context, d *schema.ResourceData, meta inte
 		d.Get("server_id").(string), d.Get("nic_id").(string), d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/ionoscloud/resource_group.go
+++ b/ionoscloud/resource_group.go
@@ -182,7 +182,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	group, apiResponse, err := client.UserManagementApi.UmGroupsFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/ionoscloud/resource_ipblock.go
+++ b/ionoscloud/resource_ipblock.go
@@ -136,7 +136,7 @@ func resourceIPBlockRead(ctx context.Context, d *schema.ResourceData, meta inter
 	ipBlock, apiResponse, err := client.IPBlocksApi.IpblocksFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/ionoscloud/resource_ipfailover.go
+++ b/ionoscloud/resource_ipfailover.go
@@ -89,7 +89,7 @@ func resourceLanIPFailoverRead(ctx context.Context, d *schema.ResourceData, meta
 	lan, apiResponse, err := client.LanApi.DatacentersLansFindById(ctx, d.Get("datacenter_id").(string), d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/ionoscloud/resource_k8s_cluster.go
+++ b/ionoscloud/resource_k8s_cluster.go
@@ -256,7 +256,7 @@ func resourcek8sClusterRead(ctx context.Context, d *schema.ResourceData, meta in
 	cluster, apiResponse, err := client.KubernetesApi.K8sFindByClusterId(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -469,7 +469,7 @@ func resourcek8sClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 	if err != nil {
 		if _, ok := err.(ionoscloud.GenericOpenAPIError); ok {
-			if apiResponse != nil && apiResponse.StatusCode == 404 {
+			if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 				d.SetId("")
 				return nil
 			}
@@ -514,7 +514,7 @@ func resourcek8sClusterDelete(ctx context.Context, d *schema.ResourceData, meta 
 	_, apiResponse, err := client.KubernetesApi.K8sDelete(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -566,7 +566,7 @@ func k8sClusterDeleted(ctx context.Context, client *ionoscloud.APIClient, d *sch
 
 	if err != nil {
 		if _, ok := err.(ionoscloud.GenericOpenAPIError); ok {
-			if apiResponse != nil && apiResponse.StatusCode == 404 {
+			if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 				return true, nil
 			}
 			return true, fmt.Errorf("error checking k8s cluster deletion status: %s", err)

--- a/ionoscloud/resource_k8s_node_pool.go
+++ b/ionoscloud/resource_k8s_node_pool.go
@@ -329,7 +329,7 @@ func resourcek8sNodePoolRead(ctx context.Context, d *schema.ResourceData, meta i
 	k8sNodepool, apiResponse, err := client.KubernetesApi.K8sNodepoolsFindById(ctx, d.Get("k8s_cluster_id").(string), d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -695,7 +695,7 @@ func resourcek8sNodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 	_, apiResponse, err := client.KubernetesApi.K8sNodepoolsPut(ctx, d.Get("k8s_cluster_id").(string), d.Id()).KubernetesNodePool(request).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -738,7 +738,7 @@ func resourcek8sNodePoolDelete(ctx context.Context, d *schema.ResourceData, meta
 	_, apiResponse, err := client.KubernetesApi.K8sNodepoolsDelete(ctx, d.Get("k8s_cluster_id").(string), d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -798,7 +798,7 @@ func k8sNodepoolDeleted(client *ionoscloud.APIClient, d *schema.ResourceData) (b
 	_, apiResponse, err := client.KubernetesApi.K8sNodepoolsFindById(ctx, d.Get("k8s_cluster_id").(string), d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			return true, nil
 		}
 		return true, fmt.Errorf("error checking k8s node pool deletion status: %s", err)

--- a/ionoscloud/resource_lan.go
+++ b/ionoscloud/resource_lan.go
@@ -145,7 +145,7 @@ func resourceLanRead(ctx context.Context, d *schema.ResourceData, meta interface
 	rsp, apiResponse, err := client.LanApi.DatacentersLansFindById(ctx, dcid, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			log.Printf("[INFO] LAN %s not found", d.Id())
 			d.SetId("")
 			return nil
@@ -296,7 +296,7 @@ func lanDeleted(ctx context.Context, client *ionoscloud.APIClient, d *schema.Res
 	log.Printf("[INFO] Current deletion status for LAN %s: %+v", d.Id(), rsp)
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			return true, nil
 		}
 		return true, err

--- a/ionoscloud/resource_loadbalancer.go
+++ b/ionoscloud/resource_loadbalancer.go
@@ -104,7 +104,7 @@ func resourceLoadbalancerRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	lb, apiResponse, err := client.LoadBalancerApi.DatacentersLoadbalancersFindById(ctx, d.Get("datacenter_id").(string), d.Id()).Execute()
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -178,7 +178,7 @@ func resourceLoadbalancerUpdate(ctx context.Context, d *schema.ResourceData, met
 			_, apiResponse, err := client.LoadBalancerApi.DatacentersLoadbalancersBalancednicsDelete(context.TODO(),
 				d.Get("datacenter_id").(string), d.Id(), o.(string)).Execute()
 			if err != nil {
-				if apiResponse != nil && apiResponse.StatusCode == 404 {
+				if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 					/* 404 - nic was not found - in case the nic is removed, VDC removes the nic from load balancers
 					that contain it, behind the scenes - therefore our call will yield 404 */
 					fmt.Printf("[WARNING] nic ID %s already removed from load balancer %s\n", o.(string), d.Id())

--- a/ionoscloud/resource_nic.go
+++ b/ionoscloud/resource_nic.go
@@ -144,7 +144,7 @@ func resourceNicRead(ctx context.Context, d *schema.ResourceData, meta interface
 
 	if err != nil {
 		if _, ok := err.(ionoscloud.GenericOpenAPIError); ok {
-			if apiResponse != nil && apiResponse.StatusCode == 404 {
+			if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 				d.SetId("")
 				return nil
 			}

--- a/ionoscloud/resource_private_crossconnect.go
+++ b/ionoscloud/resource_private_crossconnect.go
@@ -157,7 +157,7 @@ func resourcePrivateCrossConnectRead(ctx context.Context, d *schema.ResourceData
 	rsp, apiResponse, err := client.PrivateCrossConnectApi.PccsFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -234,7 +234,7 @@ func resourcePrivateCrossConnectUpdate(ctx context.Context, d *schema.ResourceDa
 
 	_, apiResponse, err := client.PrivateCrossConnectApi.PccsPatch(ctx, d.Id()).Pcc(*request.Properties).Execute()
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -276,7 +276,7 @@ func resourcePrivateCrossConnectDelete(ctx context.Context, d *schema.ResourceDa
 
 	_, apiResponse, err := client.PrivateCrossConnectApi.PccsDelete(ctx, d.Id()).Execute()
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -326,7 +326,7 @@ func privateCrossConnectDeleted(ctx context.Context, client *ionoscloud.APIClien
 	_, apiResponse, err := client.PrivateCrossConnectApi.PccsFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			return true, nil
 		}
 		return true, fmt.Errorf("error checking PCC deletion status: %s", err)

--- a/ionoscloud/resource_private_crossconnect.go
+++ b/ionoscloud/resource_private_crossconnect.go
@@ -36,6 +36,7 @@ func resourcePrivateCrossConnect() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "A list containing all the connectable datacenters",
 				Computed:    true,
+				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -60,6 +61,7 @@ func resourcePrivateCrossConnect() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "A list containing the details of all datacenter cross-connected through this private cross-connect",
 				Computed:    true,
+				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"lan_id": {

--- a/ionoscloud/resource_s3_key.go
+++ b/ionoscloud/resource_s3_key.go
@@ -98,7 +98,7 @@ func resourceS3KeyRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	rsp, apiResponse, err := client.UserManagementApi.UmUsersS3keysFindByKeyId(ctx, userId, d.Id()).Execute()
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -154,7 +154,7 @@ func resourceS3KeyUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	_, apiResponse, err := client.UserManagementApi.UmUsersS3keysPut(ctx, userId, d.Id()).S3Key(request).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -178,7 +178,7 @@ func resourceS3KeyDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	_, apiResponse, err := client.UserManagementApi.UmUsersS3keysDelete(ctx, userId, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -219,7 +219,7 @@ func s3KeyDeleted(ctx context.Context, client *ionoscloud.APIClient, d *schema.R
 	_, apiResponse, err := client.UserManagementApi.UmUsersS3keysFindByKeyId(ctx, userId, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			return true, nil
 		}
 		return true, err

--- a/ionoscloud/resource_server_test.go
+++ b/ionoscloud/resource_server_test.go
@@ -252,6 +252,12 @@ resource "ionoscloud_datacenter" "foobar" {
 	location = "us/las"
 }
 
+resource "ionoscloud_backup_unit" "example" {
+	name        = "serverTest"
+	password    = "DemoPassword123$"
+	email       = "example@ionoscloud.com"
+}
+
 resource "ionoscloud_lan" "webserver_lan" {
   datacenter_id = "${ionoscloud_datacenter.foobar.id}"
   public = true
@@ -265,12 +271,14 @@ resource "ionoscloud_server" "webserver" {
   ram = 1024
   availability_zone = "ZONE_1"
   cpu_family = "AMD_OPTERON"
-	image_name ="ubuntu:latest"
+	image_name ="Debian-10-cloud-init.qcow2"
 	image_password = "K3tTj8G14a3EgKyNeeiY"
   volume {
     name = "system"
     size = 5
     disk_type = "SSD"
+	backup_unit_id = ionoscloud_backup_unit.example.id
+    user_data = "foo"
 }
   nic {
     lan = "${ionoscloud_lan.webserver_lan.id}"
@@ -291,6 +299,12 @@ resource "ionoscloud_datacenter" "foobar" {
 	location = "us/las"
 }
 
+resource "ionoscloud_backup_unit" "example" {
+	name        = "serverTest"
+	password    = "DemoPassword123$"
+	email       = "example@ionoscloud.com"
+}
+
 resource "ionoscloud_lan" "webserver_lan" {
   datacenter_id = "${ionoscloud_datacenter.foobar.id}"
   public = true
@@ -305,11 +319,13 @@ resource "ionoscloud_server" "webserver" {
   availability_zone = "ZONE_1"
   cpu_family = "AMD_OPTERON"
   volume {
-		image_name ="ubuntu:latest"
-		image_password = "K3tTj8G14a3EgKyNeeiY"
+	image_name ="Debian-10-cloud-init.qcow2"
+	image_password = "K3tTj8G14a3EgKyNeeiY"
     name = "system"
     size = 5
     disk_type = "SSD"
+	backup_unit_id = ionoscloud_backup_unit.example.id
+    user_data = "foo"
   }
   nic {
     lan = "${ionoscloud_lan.webserver_lan.id}"
@@ -330,6 +346,12 @@ resource "ionoscloud_datacenter" "foobar" {
 	location = "us/las"
 }
 
+resource "ionoscloud_backup_unit" "example" {
+	name        = "serverTest"
+	password    = "DemoPassword123$"
+	email       = "example@ionoscloud.com"
+}
+
 resource "ionoscloud_lan" "webserver_lan" {
   datacenter_id = "${ionoscloud_datacenter.foobar.id}"
   public = true
@@ -343,12 +365,14 @@ resource "ionoscloud_server" "webserver" {
   ram = 1024
   availability_zone = "ZONE_1"
   cpu_family = "AMD_OPTERON"
-  image_name = "ubuntu:latest"
+  image_name = "Debian-10-cloud-init.qcow2"
   image_password = "K3tTj8G14a3EgKyNeeiY"
   volume {
     name = "system"
     size = 5
     disk_type = "SSD"
+	backup_unit_id = ionoscloud_backup_unit.example.id
+    user_data = "foo"
   }
 
   nic {

--- a/ionoscloud/resource_share.go
+++ b/ionoscloud/resource_share.go
@@ -90,7 +90,7 @@ func resourceShareRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	rsp, apiResponse, err := client.UserManagementApi.UmGroupsSharesFindByResourceId(ctx,
 		d.Get("group_id").(string), d.Get("resource_id").(string)).Execute()
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -152,7 +152,7 @@ func resourceShareDelete(ctx context.Context, d *schema.ResourceData, meta inter
 
 	_, apiResponse, err := client.UserManagementApi.UmGroupsSharesDelete(ctx, groupId, resourceId).Execute()
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			diags := diag.FromErr(err)
 			return diags
 		}

--- a/ionoscloud/resource_snapshot.go
+++ b/ionoscloud/resource_snapshot.go
@@ -75,7 +75,7 @@ func resourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta inte
 	rsp, apiResponse, err := client.SnapshotApi.SnapshotsFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/ionoscloud/resource_user.go
+++ b/ionoscloud/resource_user.go
@@ -131,7 +131,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	rsp, apiResponse, err := client.UserManagementApi.UmUsersFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/ionoscloud/resource_volume.go
+++ b/ionoscloud/resource_volume.go
@@ -78,32 +78,26 @@ func resourceVolume() *schema.Resource {
 			},
 			"cpu_hot_plug": {
 				Type:     schema.TypeBool,
-				Optional: true,
 				Computed: true,
 			},
 			"ram_hot_plug": {
 				Type:     schema.TypeBool,
-				Optional: true,
 				Computed: true,
 			},
 			"nic_hot_plug": {
 				Type:     schema.TypeBool,
-				Optional: true,
 				Computed: true,
 			},
 			"nic_hot_unplug": {
 				Type:     schema.TypeBool,
-				Optional: true,
 				Computed: true,
 			},
 			"disc_virtio_hot_plug": {
 				Type:     schema.TypeBool,
-				Optional: true,
 				Computed: true,
 			},
 			"disc_virtio_hot_unplug": {
 				Type:     schema.TypeBool,
-				Optional: true,
 				Computed: true,
 			},
 			"backup_unit_id": {
@@ -250,36 +244,6 @@ func resourceVolumeCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		volume.Properties.LicenceType = &licenceType
 	} else {
 		volume.Properties.LicenceType = nil
-	}
-
-	if v, ok := d.GetOk("cpu_hot_plug"); ok {
-		vBool := v.(bool)
-		volume.Properties.CpuHotPlug = &vBool
-	}
-
-	if v, ok := d.GetOk("ram_hot_plug"); ok {
-		vBool := v.(bool)
-		volume.Properties.RamHotPlug = &vBool
-	}
-
-	if v, ok := d.GetOk("nic_hot_unplug"); ok {
-		vBool := v.(bool)
-		volume.Properties.NicHotPlug = &vBool
-	}
-
-	if v, ok := d.GetOk("nic_hot_unplug"); ok {
-		vBool := v.(bool)
-		volume.Properties.NicHotUnplug = &vBool
-	}
-
-	if v, ok := d.GetOk("disc_virtio_hot_plug"); ok {
-		vBool := v.(bool)
-		volume.Properties.DiscVirtioHotPlug = &vBool
-	}
-
-	if v, ok := d.GetOk("disc_virtio_hot_unplug"); ok {
-		vBool := v.(bool)
-		volume.Properties.DiscVirtioHotUnplug = &vBool
 	}
 
 	if image != "" {
@@ -561,39 +525,6 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		_, newValue := d.GetChange("availability_zone")
 		newValueStr := newValue.(string)
 		properties.AvailabilityZone = &newValueStr
-	}
-	if d.HasChange("cpu_hot_plug") {
-		_, newValue := d.GetChange("cpu_hot_plug")
-		newValueBool := newValue.(bool)
-		properties.CpuHotPlug = &newValueBool
-	}
-	if d.HasChange("ram_hot_plug") {
-		_, newValue := d.GetChange("ram_hot_plug")
-		newValueBool := newValue.(bool)
-		properties.RamHotPlug = &newValueBool
-	}
-	if d.HasChange("nic_hot_plug") {
-		_, newValue := d.GetChange("nic_hot_plug")
-		newValueBool := newValue.(bool)
-		properties.NicHotPlug = &newValueBool
-	}
-
-	if d.HasChange("nic_hot_unplug") {
-		_, newValue := d.GetChange("nic_hot_unplug")
-		newValueBool := newValue.(bool)
-		properties.NicHotUnplug = &newValueBool
-	}
-
-	if d.HasChange("disc_virtio_hot_plug") {
-		_, newValue := d.GetChange("disc_virtio_hot_plug")
-		newValueBool := newValue.(bool)
-		properties.DiscVirtioHotPlug = &newValueBool
-	}
-
-	if d.HasChange("disc_virtio_hot_unplug") {
-		_, newValue := d.GetChange("disc_virtio_hot_unplug")
-		newValueBool := newValue.(bool)
-		properties.DiscVirtioHotUnplug = &newValueBool
 	}
 
 	if d.HasChange("backup_unit_id") {

--- a/ionoscloud/resource_volume_test.go
+++ b/ionoscloud/resource_volume_test.go
@@ -149,6 +149,12 @@ resource "ionoscloud_datacenter" "foobar" {
 	location = "us/las"
 }
 
+resource "ionoscloud_backup_unit" "example" {
+	name        = "serverTest"
+	password    = "DemoPassword123$"
+	email       = "example@ionoscloud.com"
+}
+
 resource "ionoscloud_lan" "webserver_lan" {
   datacenter_id = "${ionoscloud_datacenter.foobar.id}"
   public = true
@@ -177,15 +183,17 @@ resource "ionoscloud_server" "webserver" {
 }
 
 resource "ionoscloud_volume" "database_volume" {
-  datacenter_id = "${ionoscloud_datacenter.foobar.id}"
-  server_id = "${ionoscloud_server.webserver.id}"
-  availability_zone = "ZONE_1"
-  name = "%s"
-  size = 5
-  disk_type = "HDD"
-  bus = "VIRTIO"
-  image_name = "ubuntu:latest"
-  image_password = "K3tTj8G14a3EgKyNeeiY"
+	datacenter_id = "${ionoscloud_datacenter.foobar.id}"
+	server_id = "${ionoscloud_server.webserver.id}"
+	availability_zone = "ZONE_1"
+	name = "%s"
+	size = 5
+	disk_type = "HDD"
+	bus = "VIRTIO"
+	image_name ="Debian-10-cloud-init.qcow2"
+	image_password = "K3tTj8G14a3EgKyNeeiY"
+	backup_unit_id = ionoscloud_backup_unit.example.id
+	user_data = "foo"
 }`
 
 const testacccheckvolumeconfigUpdate = `
@@ -194,6 +202,13 @@ resource "ionoscloud_datacenter" "foobar" {
 	location = "us/las"
 }
 
+resource "ionoscloud_backup_unit" "example" {
+	name        = "serverTest"
+	password    = "DemoPassword123$"
+	email       = "example@ionoscloud.com"
+}
+
+
 resource "ionoscloud_lan" "webserver_lan" {
   datacenter_id = "${ionoscloud_datacenter.foobar.id}"
   public = true
@@ -222,15 +237,17 @@ resource "ionoscloud_server" "webserver" {
 }
 
 resource "ionoscloud_volume" "database_volume" {
-  datacenter_id = "${ionoscloud_datacenter.foobar.id}"
-  server_id = "${ionoscloud_server.webserver.id}"
-  availability_zone = "ZONE_1"
-  name = "updated"
-  size = 5
-  disk_type = "HDD"
-  bus = "VIRTIO"
-  image_name = "ubuntu:latest"
-  image_password = "K3tTj8G14a3EgKyNeeiY"
+	datacenter_id = "${ionoscloud_datacenter.foobar.id}"
+	server_id = "${ionoscloud_server.webserver.id}"
+	availability_zone = "ZONE_1"
+	name = "updated"
+	size = 5
+	disk_type = "HDD"
+	bus = "VIRTIO"
+	image_name ="Debian-10-cloud-init.qcow2"
+	image_password = "K3tTj8G14a3EgKyNeeiY"
+	backup_unit_id = ionoscloud_backup_unit.example.id
+	user_data = "foo"
 }`
 
 const testacccheckvolumeconfigNoPassword = `

--- a/ionoscloud/utils.go
+++ b/ionoscloud/utils.go
@@ -44,7 +44,7 @@ func resourceServerImport(ctx context.Context, d *schema.ResourceData, meta inte
 	server, apiResponse, err := client.ServerApi.DatacentersServersFindById(ctx, datacenterId, serverId).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("unable to find server %q", serverId)
 		}
@@ -222,7 +222,7 @@ func resourceK8sClusterImport(ctx context.Context, d *schema.ResourceData, meta 
 	cluster, apiResponse, err := client.KubernetesApi.K8sFindByClusterId(ctx, clusterId).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("unable to find k8s cluster %q", clusterId)
 		}
@@ -273,7 +273,7 @@ func resourceK8sNodepoolImport(ctx context.Context, d *schema.ResourceData, meta
 
 	if err != nil {
 		if _, ok := err.(ionoscloud.GenericOpenAPIError); ok {
-			if apiResponse != nil && apiResponse.StatusCode == 404 {
+			if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 				d.SetId("")
 				return nil, fmt.Errorf("unable to find k8s node pool %q", npId)
 			}
@@ -376,7 +376,7 @@ func resourcePrivateCrossConnectImport(ctx context.Context, d *schema.ResourceDa
 	pcc, apiResponse, err := client.PrivateCrossConnectApi.PccsFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("unable to find PCC %q", pccId)
 		}
@@ -442,7 +442,7 @@ func resourceBackupUnitImport(ctx context.Context, d *schema.ResourceData, meta 
 	backupUnit, apiResponse, err := client.BackupUnitApi.BackupunitsFindById(ctx, d.Id()).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("unable to find Backup Unit %q", buId)
 		}
@@ -488,7 +488,7 @@ func resourceS3KeyImport(ctx context.Context, d *schema.ResourceData, meta inter
 	s3Key, apiResponse, err := client.UserManagementApi.UmUsersS3keysFindByKeyId(ctx, userId, keyId).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("unable to find S3 key %q", keyId)
 		}
@@ -561,7 +561,7 @@ func resourceVolumeImporter(ctx context.Context, d *schema.ResourceData, meta in
 	volume, apiResponse, err := client.VolumeApi.DatacentersVolumesFindById(ctx, dcId, volumeId).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("volume does not exist %q", volumeId)
 		}
@@ -687,7 +687,7 @@ func resourceGroupImporter(ctx context.Context, d *schema.ResourceData, meta int
 	group, apiResponse, err := client.UserManagementApi.UmGroupsFindById(ctx, grpId).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("an error occured while trying to fetch the group %q", grpId)
 		}
@@ -820,7 +820,7 @@ func resourceUserImporter(ctx context.Context, d *schema.ResourceData, meta inte
 	user, apiResponse, err := client.UserManagementApi.UmUsersFindById(ctx, userId).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("an error occured while trying to fetch the user %q", userId)
 		}
@@ -875,7 +875,7 @@ func resourceShareImporter(ctx context.Context, d *schema.ResourceData, meta int
 	share, apiResponse, err := client.UserManagementApi.UmGroupsSharesFindByResourceId(ctx, grpId, rscId).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("an error occured while trying to fetch the share of resource %q for group %q", rscId, grpId)
 		}
@@ -923,7 +923,7 @@ func resourceIpFailoverImporter(ctx context.Context, d *schema.ResourceData, met
 	lan, apiResponse, err := client.LanApi.DatacentersLansFindById(ctx, dcId, lanId).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("an error occured while trying to fetch the lan %q", lanId)
 		}
@@ -976,7 +976,7 @@ func resourceLoadbalancerImporter(ctx context.Context, d *schema.ResourceData, m
 	loadbalancer, apiResponse, err := client.LoadBalancerApi.DatacentersLoadbalancersFindById(ctx, dcId, lbId).Execute()
 
 	if err != nil {
-		if apiResponse != nil && apiResponse.StatusCode == 404 {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil, fmt.Errorf("an error occured while trying to fetch the loadbalancer %q", lbId)
 		}

--- a/ionoscloud/utils.go
+++ b/ionoscloud/utils.go
@@ -187,6 +187,15 @@ func resourceServerImport(ctx context.Context, d *schema.ResourceData, meta inte
 			setPropWithNilCheck(volumeItem, "licence_type", volumeObj.Properties.LicenceType)
 			setPropWithNilCheck(volumeItem, "bus", volumeObj.Properties.Bus)
 			setPropWithNilCheck(volumeItem, "availability_zone", volumeObj.Properties.AvailabilityZone)
+			setPropWithNilCheck(volumeItem, "cpu_hot_plug", volumeObj.Properties.CpuHotPlug)
+			setPropWithNilCheck(volumeItem, "ram_hot_plug", volumeObj.Properties.RamHotPlug)
+			setPropWithNilCheck(volumeItem, "nic_hot_plug", volumeObj.Properties.NicHotPlug)
+			setPropWithNilCheck(volumeItem, "nic_hot_unplug", volumeObj.Properties.NicHotUnplug)
+			setPropWithNilCheck(volumeItem, "disc_virtio_hot_plug", volumeObj.Properties.DiscVirtioHotPlug)
+			setPropWithNilCheck(volumeItem, "disc_virtio_hot_unplug", volumeObj.Properties.DiscVirtioHotUnplug)
+			setPropWithNilCheck(volumeItem, "device_number", volumeObj.Properties.DeviceNumber)
+			setPropWithNilCheck(volumeItem, "user_data", volumeObj.Properties.UserData)
+			setPropWithNilCheck(volumeItem, "backup_unit_id", volumeObj.Properties.BackupunitId)
 
 			volumesList := []map[string]interface{}{volumeItem}
 			if err := d.Set("volume", volumesList); err != nil {


### PR DESCRIPTION
## What does this fix or implement?

- Added userData and backupUnitId in the server volume 
- Added nil check for apiResponse.Response
- Fix issue #19 - fixed update ssh_key_path although not changed
- Fix issue  #93 - updated documentation with an usable example and removed image_aliases from the list of arguments used for search

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] Tests added or updated
- [x] Documentation updated
- [x] Changelog updated and version incremented
- [x] Github Issue linked if any
