### PR TITLE
fixed #112 - can't attach existing volume to server after recreating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.2.17
 
+- **bug fixes**: fixed issue #112 can't attach existing volume to server after recreating server 
 - **bug fixes**: cannot empty `api_subnet_allow_list` and `s3_buckets`
 - **code enhancements**: for `k8s_cluster`:
   - made tests comprehensive

--- a/ionoscloud/resource_volume.go
+++ b/ionoscloud/resource_volume.go
@@ -507,9 +507,8 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		properties.Name = &newValueStr
 	}
 	if d.HasChange("disk_type") {
-		_, newValue := d.GetChange("disk_type")
-		newValueStr := newValue.(string)
-		properties.Type = &newValueStr
+		diags := diag.FromErr(fmt.Errorf("disk_type property is immutable"))
+		return diags
 	}
 	if d.HasChange("size") {
 		_, newValue := d.GetChange("size")
@@ -554,7 +553,8 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	if d.HasChange("server_id") {
 		_, newValue := d.GetChange("server_id")
 		serverID := newValue.(string)
-		_, apiResponse, err := client.ServerApi.DatacentersServersVolumesPost(ctx, dcId, serverID).Volume(volume).Execute()
+		volumeToAttach := ionoscloud.Volume{Id: volume.Id}
+		_, apiResponse, err := client.ServerApi.DatacentersServersVolumesPost(ctx, dcId, serverID).Volume(volumeToAttach).Execute()
 		if err != nil {
 			diags := diag.FromErr(fmt.Errorf("an error occured while attaching a volume dcId: %s server_id: %s ID: %s %s", dcId, serverID, *volume.Id, err))
 			return diags

--- a/ionoscloud/resource_volume_test.go
+++ b/ionoscloud/resource_volume_test.go
@@ -235,7 +235,7 @@ resource "ionoscloud_lan" "webserver_lan" {
   name = "public"
 }
 
-resource "ionoscloud_server" "webserver" {
+resource "ionoscloud_server" "webserver1" {
   name = "webserver"
   datacenter_id = "${ionoscloud_datacenter.foobar.id}"
   cores = 1
@@ -258,7 +258,7 @@ resource "ionoscloud_server" "webserver" {
 
 resource "ionoscloud_volume" "database_volume" {
 	datacenter_id = "${ionoscloud_datacenter.foobar.id}"
-	server_id = "${ionoscloud_server.webserver.id}"
+	server_id = "${ionoscloud_server.webserver1.id}"
 	availability_zone = "ZONE_1"
 	name = "updated"
 	size = 5


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

- fixed #112 by sending in the attach request just the id of the volume

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented
- [x] Github Issue linked if any
