### PR TITLE
SDK-521 Add v6 branch to sonar scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - release/V6
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
## What does this fix or implement?

Add v6 branch to sonarcloud scan.

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented
- [ ] Github Issue linked if any
