### PR TITLE
Fix/revert icmp type and icmp code to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 5.2.20
-
-- **bug fixes**: revert icmp_code and icmp_type to string to allow setting to 0
-
 ## 5.2.19
 
 - **code enhancements**: added http request time log for API calls
@@ -11,7 +7,7 @@
   - optimized test duration by including both match by id and by name in the same test
   - removed duplicated code from import, data_source, resource and tests files
 - **new features**: import for `nic`, data_source for `nic`, `share`
-- **bug fixes**: k8s_node_pool update node_count didn't work and emptying lans and public_ips
+- **bug fixes**: k8s_node_pool update node_count didn't work and emptying lans and public_ips. revert icmp_code and icmp_type to string to allow setting to 0
 
 ## 5.2.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.20
+
+- **bug fixes**: revert icmp_code and icmp_type to string to allow setting to 0
+
 ## 5.2.19
 
 - **code enhancements**: added http request time log for API calls

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -29,7 +29,7 @@ resource "ionoscloud_firewall" "example" {
 * `datacenter_id` - (Required)[string] The Virtual Data Center ID.
 * `server_id` - (Required)[string] The Server ID.
 * `nic_id` - (Required)[string] The NIC ID.
-* `protocol` - (Required)[string] The protocol for the rule. Property cannot be modified after creation (disallowed in update requests).
+* `protocol` - (Required)[string] The protocol for the rule: TCP, UDP, ICMP, ANY. Property cannot be modified after creation (disallowed in update requests).
 * `name` - (Optional)[string] The name of the firewall rule.
 * `source_mac` - (Optional)[string] Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff. Value null allows all source MAC address. Valid format: aa:bb:cc:dd:ee:ff.
 * `source_ip` - (Optional)[string] Only traffic originating from the respective IPv4 address is allowed. Value null allows all source IPs.

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -29,15 +29,15 @@ resource "ionoscloud_firewall" "example" {
 * `datacenter_id` - (Required)[string] The Virtual Data Center ID.
 * `server_id` - (Required)[string] The Server ID.
 * `nic_id` - (Required)[string] The NIC ID.
-* `protocol` - (Required)[string] The protocol for the rule: TCP, UDP, ICMP, ANY. This property is immutable.
+* `protocol` - (Required)[string] The protocol for the rule. Property cannot be modified after creation (disallowed in update requests).
 * `name` - (Optional)[string] The name of the firewall rule.
-* `source_mac` - (Optional)[string] Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff.
-* `source_ip` - (Optional)[string] Only traffic originating from the respective IPv4 address is allowed.
-* `target_ip` - (Optional)[string] Only traffic directed to the respective IP address of the NIC is allowed.
-* `port_range_start` - (Optional)[string] Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen.
-* `port_range_end` - (Optional)[string] Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen.
-* `icmp_type` - (Optional)[int] Defines the allowed type (from 0 to 254) if the protocol ICMP is chosen.
-* `icmp_code` - (Optional)[int] Defines the allowed code (from 0 to 254) if protocol ICMP is chosen.
+* `source_mac` - (Optional)[string] Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff. Value null allows all source MAC address. Valid format: aa:bb:cc:dd:ee:ff.
+* `source_ip` - (Optional)[string] Only traffic originating from the respective IPv4 address is allowed. Value null allows all source IPs.
+* `target_ip` - (Optional)[string] In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed. Value null allows all target IPs.
+* `port_range_start` - (Optional)[int] Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Leave portRangeStart and portRangeEnd null to allow all ports.
+* `port_range_end` - (Optional)[int] Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Leave portRangeStart and portRangeEnd null to allow all ports.
+* `icmp_type` - (Optional)[string] Defines the allowed code (from 0 to 254) if protocol ICMP is chosen. Value null allows all codes.
+* `icmp_code` - (Optional)[string] Defines the allowed type (from 0 to 254) if the protocol ICMP is chosen. Value null allows all types
 
 
 ## Import

--- a/ionoscloud/data_source_firewall.go
+++ b/ionoscloud/data_source_firewall.go
@@ -46,11 +46,11 @@ func dataSourceFirewall() *schema.Resource {
 				Computed: true,
 			},
 			"icmp_type": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"icmp_code": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"datacenter_id": {

--- a/ionoscloud/resource_firewall.go
+++ b/ionoscloud/resource_firewall.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v5"
+	"strconv"
 	"strings"
 )
 
@@ -63,11 +64,11 @@ func resourceFirewall() *schema.Resource {
 				},
 			},
 			"icmp_type": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"icmp_code": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"datacenter_id": {
@@ -96,7 +97,10 @@ func resourceFirewall() *schema.Resource {
 func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ionoscloud.APIClient)
 
-	firewall := getFirewallData(d, "", false)
+	firewall, diags := getFirewallData(d, "", false)
+	if diags != nil {
+		return diags
+	}
 
 	fw, apiResponse, err := client.NicApi.DatacentersServersNicsFirewallrulesPost(ctx, d.Get("datacenter_id").(string), d.Get("server_id").(string), d.Get("nic_id").(string)).Firewallrule(firewall).Execute()
 	logApiRequestTime(apiResponse)
@@ -147,7 +151,10 @@ func resourceFirewallRead(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ionoscloud.APIClient)
 
-	firewall := getFirewallData(d, "", true)
+	firewall, diags := getFirewallData(d, "", true)
+	if diags != nil {
+		return diags
+	}
 
 	_, apiResponse, err := client.NicApi.DatacentersServersNicsFirewallrulesPatch(ctx, d.Get("datacenter_id").(string), d.Get("server_id").(string), d.Get("nic_id").(string), d.Id()).Firewallrule(*firewall.Properties).Execute()
 	logApiRequestTime(apiResponse)
@@ -290,14 +297,14 @@ func setFirewallData(d *schema.ResourceData, firewall *ionoscloud.FirewallRule) 
 		}
 
 		if firewall.Properties.IcmpType != nil {
-			err := d.Set("icmp_type", *firewall.Properties.IcmpType)
+			err := d.Set("icmp_type", strconv.Itoa(int(*firewall.Properties.IcmpType)))
 			if err != nil {
 				return fmt.Errorf("error while setting icmp_type property for firewall %s: %s", d.Id(), err)
 			}
 		}
 
 		if firewall.Properties.IcmpCode != nil {
-			err := d.Set("icmp_code", *firewall.Properties.IcmpCode)
+			err := d.Set("icmp_code", strconv.Itoa(int(*firewall.Properties.IcmpCode)))
 			if err != nil {
 				return fmt.Errorf("error while setting icmp_code property for firewall %s: %s", d.Id(), err)
 			}
@@ -306,7 +313,7 @@ func setFirewallData(d *schema.ResourceData, firewall *ionoscloud.FirewallRule) 
 	return nil
 }
 
-func getFirewallData(d *schema.ResourceData, path string, update bool) ionoscloud.FirewallRule {
+func getFirewallData(d *schema.ResourceData, path string, update bool) (ionoscloud.FirewallRule, diag.Diagnostics) {
 
 	firewall := ionoscloud.FirewallRule{
 		Properties: &ionoscloud.FirewallruleProperties{},
@@ -350,14 +357,22 @@ func getFirewallData(d *schema.ResourceData, path string, update bool) ionosclou
 	}
 
 	if v, ok := d.GetOk(path + "icmp_type"); ok {
-		tempIcmpType := int32(v.(int))
+		intIcmpType, err := strconv.Atoi(v.(string))
+		if err != nil {
+			return firewall, diag.FromErr(fmt.Errorf("could not parse icmpTpye %s: %w", v.(string), err))
+		}
+		tempIcmpType := int32(intIcmpType)
 		firewall.Properties.IcmpType = &tempIcmpType
-
 	}
+
 	if v, ok := d.GetOk(path + "icmp_code"); ok {
-		tempIcmpCode := int32(v.(int))
+		intIcmpCode, err := strconv.Atoi(v.(string))
+		if err != nil {
+			return firewall, diag.FromErr(fmt.Errorf("could not parse icmpCode %s: %w", v.(string), err))
+		}
+		tempIcmpCode := int32(intIcmpCode)
 		firewall.Properties.IcmpCode = &tempIcmpCode
-
 	}
-	return firewall
+
+	return firewall, nil
 }

--- a/ionoscloud/resource_firewall_test.go
+++ b/ionoscloud/resource_firewall_test.go
@@ -49,7 +49,6 @@ func TestAccFirewallBasic(t *testing.T) {
 			{
 				Config: testAccCheckFirewallSetICMPToZero,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(FirewallResource+"."+FirewallTestResource, "source_mac", ""),
 					resource.TestCheckResourceAttr(FirewallResource+"."+FirewallTestResource, "icmp_type", "0"),
 					resource.TestCheckResourceAttr(FirewallResource+"."+FirewallTestResource, "icmp_code", "0"),
 				),

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -515,7 +515,11 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	// get firewall data and add object to server
 	if _, ok := d.GetOk("nic.0.firewall"); ok {
-		firewall = getFirewallData(d, "nic.0.firewall.0.", false)
+		var diags diag.Diagnostics
+		firewall, diags = getFirewallData(d, "nic.0.firewall.0.", false)
+		if diags != nil {
+			return diags
+		}
 		(*serverRequest.Entities.Nics.Items)[0].Entities = &ionoscloud.NicEntities{
 			Firewallrules: &ionoscloud.FirewallRules{
 				Items: &[]ionoscloud.FirewallRule{
@@ -715,9 +719,11 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		nic := getNicData(d, "nic.0.")
 		if d.HasChange("nic.0.firewall") {
-
-			firewall := getFirewallData(d, "nic.0.firewall.0.", true)
-
+			var diags diag.Diagnostics
+			firewall, diags := getFirewallData(d, "nic.0.firewall.0.", true)
+			if diags != nil {
+				return diags
+			}
 			firewallId := d.Get("firewallrule_id").(string)
 
 			_, apiResponse, err := client.NicApi.DatacentersServersNicsFirewallrulesFindById(ctx, dcId, *server.Id, nicId, firewallId).Execute()


### PR DESCRIPTION
## What does this fix or implement?

Reverts icmp_code and icmp_type from int back to string. Terraform has a problem with unseting integer variables. Even GetOkExists will just set '0' when removing a field, instead of setting it to null. For these fields, null values are valid so we would rather keep them as string, at least until Terraform adds a reliable way to unset int fields.

Note: No upgrade state migration function provided, as the changes were not in production very long.

Note2: There is still a bug in Go sdk that prevents unsetting a field. This is being looked at.

Github issue: [link](https://github.com/ionos-cloud/terraform-provider-ionoscloud/issues/144)

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [X] Tests added or updated
- [X] Documentation updated
- [X] Changelog updated and version incremented
- [X] Github Issue linked if any
