### PR TITLE
fix: revert icmp_code and icmp_type to string to allow 0 and empty/nu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - removed duplicated code from import, data_source, resource and tests files
 - **bug fixes**: k8s_node_pool update node_count and emptying lans and public_ips didn't work
 - **bug fixes**: fixed bug at creating natgateway_rule - target_subnet was not set properly
+- **bug fixes**: revert icmp_code and icmp_type to string to allow setting to 0
 
 ## 6.0.0-beta.14
 

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -29,16 +29,16 @@ resource "ionoscloud_firewall" "example" {
 * `datacenter_id` - (Required)[string] The Virtual Data Center ID.
 * `server_id` - (Required)[string] The Server ID.
 * `nic_id` - (Required)[string] The NIC ID.
-* `protocol` - (Required)[string] The protocol for the rule: TCP, UDP, ICMP, ANY. Attribute is immutable.
+* `protocol` - (Required)[string] The protocol for the rule: TCP, UDP, ICMP, ANY. Property cannot be modified after creation (disallowed in update requests).
 * `name` - (Optional)[string] The name of the firewall rule.
-* `source_mac` - (Optional)[string] Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff.
-* `source_ip` - (Optional)[string] Only traffic originating from the respective IPv4 address is allowed.
-* `target_ip` - (Optional)[string] Only traffic directed to the respective IP address of the NIC is allowed.
-* `port_range_start` - (Optional)[string] Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen.
-* `port_range_end` - (Optional)[string] Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen.
-* `icmp_type` - (Optional)[int] Defines the allowed type (from 0 to 254) if the protocol ICMP is chosen.
+* `source_mac` - (Optional)[string] Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff. Value null allows all source MAC address. Valid format: aa:bb:cc:dd:ee:ff.
+* `source_ip` -  (Optional)[string] Only traffic originating from the respective IPv4 address is allowed. Value null allows all source IPs.
+* `target_ip` - (Optional)[string] In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed. Value null allows all target IPs.
+* `port_range_start` - (Optional)[int] Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Leave portRangeStart and portRangeEnd null to allow all ports.
+* `port_range_end` - (Optional)[int] Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Leave portRangeStart and portRangeEnd null to allow all ports.
+* `icmp_type` - (Optional)[string] Defines the allowed code (from 0 to 254) if protocol ICMP is chosen. Value null allows all codes.
 * `icmp_code` - (Optional)[int] Defines the allowed code (from 0 to 254) if protocol ICMP is chosen.
-* `type` - (Optional)[string] The type of firewall rule. If is not specified, it will take the default value INGRESS
+* `type` - (Optional)[string] The type of firewall rule. If is not specified, it will take the default value INGRESS.
 
 ## Import
 

--- a/ionoscloud/data_source_firewall.go
+++ b/ionoscloud/data_source_firewall.go
@@ -46,11 +46,11 @@ func dataSourceFirewall() *schema.Resource {
 				Computed: true,
 			},
 			"icmp_type": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"icmp_code": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"type": {

--- a/ionoscloud/resource_firewall_test.go
+++ b/ionoscloud/resource_firewall_test.go
@@ -48,6 +48,13 @@ func TestAccFirewallBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(FirewallResource+"."+FirewallTestResource, "type", "EGRESS"),
 				),
 			},
+			{
+				Config: testAccCheckFirewallSetICMPToZero,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(FirewallResource+"."+FirewallTestResource, "icmp_type", "0"),
+					resource.TestCheckResourceAttr(FirewallResource+"."+FirewallTestResource, "icmp_code", "0"),
+				),
+			},
 		},
 	})
 }
@@ -363,5 +370,53 @@ resource ` + FirewallResource + ` ` + FirewallTestResource + ` {
   source_ip = ionoscloud_ipblock.ipblock_update.ips[0]
   target_ip = ionoscloud_ipblock.ipblock_update.ips[1]
   type = "EGRESS"
+}
+`
+
+const testAccCheckFirewallSetICMPToZero = testAccCheckDatacenterConfigBasic + `
+resource ` + ServerResource + ` ` + ServerTestResource + ` {
+  name = "webserver"
+  datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  cores = 1
+  ram = 1024
+  availability_zone = "ZONE_1"
+  cpu_family = "AMD_OPTERON"
+  image_name = "Ubuntu-20.04"
+  image_password = "test1234"
+  volume {
+    name = "system"
+    size = 14
+    disk_type = "SSD"
+}
+  nic {
+    lan = "1"
+    dhcp = true
+    firewall_active = true
+  }
+}
+resource "ionoscloud_nic" "database_nic" {
+  datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  server_id = ` + ServerResource + `.` + ServerTestResource + `.id
+  lan = 2
+  dhcp = true
+  firewall_active = true
+  name = "updated"
+}
+resource "ionoscloud_ipblock" "ipblock_update" {
+  location = ` + DatacenterResource + `.` + DatacenterTestResource + `.location
+  size = 2
+  name = "firewall_ipblock"
+}
+resource ` + FirewallResource + ` ` + FirewallTestResource + `  {
+  datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  server_id = ` + ServerResource + `.` + ServerTestResource + `.id
+  nic_id = "${ionoscloud_nic.database_nic.id}"
+  protocol = "ICMP"
+  name = "` + UpdatedResources + `"
+  source_mac = "00:0a:95:9d:68:17"
+  source_ip = ionoscloud_ipblock.ipblock_update.ips[0]
+  target_ip = ionoscloud_ipblock.ipblock_update.ips[1]
+  icmp_type = 0
+  icmp_code = 0
 }
 `


### PR DESCRIPTION
## What does this fix or implement?

Revert icmp_type and icmp_code to string to allow setting null and empty values.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [X] Tests added or updated
- [X] Documentation updated
- [X] Changelog updated and version incremented
- [] Github Issue linked if any
