### PR TITLE
fix: allow user to be updated when only optional field changes

### DIFF
--- a/ionoscloud/data_source_s3_key_test.go
+++ b/ionoscloud/data_source_s3_key_test.go
@@ -41,7 +41,7 @@ resource ` + UserResource + ` "example" {
 
 resource ` + S3KeyResource + ` ` + S3KeyTestResource + ` {
   user_id    = ` + UserResource + `.example.id
-  active     = false
+  active     = true
 }`
 
 var testAccDataSourceS3KeyMatchId = testAccDataSourceS3KeyConfigBasic + `

--- a/ionoscloud/resource_backup_unit.go
+++ b/ionoscloud/resource_backup_unit.go
@@ -36,10 +36,11 @@ func resourceBackupUnit() *schema.Resource {
 				ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
 			},
 			"email": {
-				Type:         schema.TypeString,
-				Description:  "The e-mail address you want assigned to the backup unit.",
-				Required:     true,
-				ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+				Type:             schema.TypeString,
+				Description:      "The e-mail address you want assigned to the backup unit.",
+				Required:         true,
+				ValidateFunc:     validation.All(validation.StringIsNotWhiteSpace),
+				DiffSuppressFunc: DiffToLower,
 			},
 			"login": {
 				Type:        schema.TypeString,
@@ -127,18 +128,17 @@ func resourceBackupUnitUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	request.Properties = &ionoscloud.BackupUnitProperties{}
 
 	log.Printf("[INFO] Attempting update backup unit %s", d.Id())
-
+	oldEmail, newEmail := d.GetChange("email")
+	emailStr := oldEmail.(string)
 	if d.HasChange("email") {
-		oldEmail, newEmail := d.GetChange("email")
 		log.Printf("[INFO] backup unit email changed from %+v to %+v", oldEmail, newEmail)
-
-		newEmailStr := newEmail.(string)
-		request.Properties.Email = &newEmailStr
+		emailStr = newEmail.(string)
 	}
+	request.Properties.Email = &emailStr
 
 	if d.HasChange("password") {
-		oldPassword, newPassword := d.GetChange("password")
-		log.Printf("[INFO] backup unit password changed from %+v to %+v", oldPassword, newPassword)
+		_, newPassword := d.GetChange("password")
+		log.Printf("[INFO] backup unit password changed")
 
 		newPasswordStr := newPassword.(string)
 		request.Properties.Password = &newPasswordStr

--- a/ionoscloud/resource_backup_unit_test.go
+++ b/ionoscloud/resource_backup_unit_test.go
@@ -30,7 +30,16 @@ func TestAccBackupUnitBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckBackupUnitConfigUpdate,
+				Config: testAccCheckBackupUnitConfigUpdatePassword,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBackupUnitExists(BackupUnitResource+"."+BackupUnitTestResource, &backupUnit),
+					resource.TestCheckResourceAttr(BackupUnitResource+"."+BackupUnitTestResource, "name", BackupUnitTestResource),
+					resource.TestCheckResourceAttr(BackupUnitResource+"."+BackupUnitTestResource, "email", "example@ionoscloud.com"),
+					resource.TestCheckResourceAttr(BackupUnitResource+"."+BackupUnitTestResource, "password", "DemoPassword1234$Updated"),
+				),
+			},
+			{
+				Config: testAccCheckBackupUnitConfigUpdateEmail,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBackupUnitExists(BackupUnitResource+"."+BackupUnitTestResource, &backupUnit),
 					resource.TestCheckResourceAttr(BackupUnitResource+"."+BackupUnitTestResource, "name", BackupUnitTestResource),
@@ -116,10 +125,18 @@ resource ` + BackupUnitResource + ` ` + BackupUnitTestResource + ` {
 }
 `
 
-const testAccCheckBackupUnitConfigUpdate = `
+const testAccCheckBackupUnitConfigUpdatePassword = `
 resource ` + BackupUnitResource + ` ` + BackupUnitTestResource + ` {
 	name        = "` + BackupUnitTestResource + `"
-	email       = "example-updated@ionoscloud.com"
 	password    = "DemoPassword1234$Updated"
+	email       = "example@ionoscloud.com"
+}
+`
+
+const testAccCheckBackupUnitConfigUpdateEmail = `
+resource ` + BackupUnitResource + ` ` + BackupUnitTestResource + ` {
+	name        = "` + BackupUnitTestResource + `"
+	password    = "DemoPassword1234$Updated"
+	email       = "example-updated@ionoscloud.com"
 }
 `

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -296,15 +296,10 @@ func resourceServer() *schema.Resource {
 										Optional: true,
 									},
 									"protocol": {
-										Type:     schema.TypeString,
-										Required: true,
-										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-											if strings.ToLower(old) == strings.ToLower(new) {
-												return true
-											}
-											return false
-										},
-										ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+										Type:             schema.TypeString,
+										Required:         true,
+										DiffSuppressFunc: DiffToLower,
+										ValidateFunc:     validation.All(validation.StringIsNotWhiteSpace),
 									},
 									"source_mac": {
 										Type:     schema.TypeString,

--- a/ionoscloud/resource_user.go
+++ b/ionoscloud/resource_user.go
@@ -31,9 +31,10 @@ func resourceUser() *schema.Resource {
 				ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
 			},
 			"email": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validation.All(validation.StringIsNotWhiteSpace),
+				DiffSuppressFunc: DiffToLower,
 			},
 			"password": {
 				Type:         schema.TypeString,
@@ -152,15 +153,30 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ionoscloud.APIClient)
 
+	foundUser, apiResponse, err := client.UserManagementApi.UmUsersFindById(ctx, d.Id()).Execute()
+	logApiRequestTime(apiResponse)
+	if err != nil {
+		diags := diag.FromErr(fmt.Errorf("an error occured while fetching a User ID %s %s", d.Id(), err))
+		return diags
+	}
+
 	userReq := ionoscloud.UserPut{
 		Properties: &ionoscloud.UserPropertiesPut{},
+	}
+	//this is a PUT, so we first fill everything, then we change what has been modified
+	if foundUser.Properties != nil {
+		userReq.Properties.Firstname = foundUser.Properties.Firstname
+		userReq.Properties.Lastname = foundUser.Properties.Lastname
+		userReq.Properties.Email = foundUser.Properties.Email
+		userReq.Properties.Active = foundUser.Properties.Active
+		userReq.Properties.Administrator = foundUser.Properties.Administrator
+		userReq.Properties.ForceSecAuth = foundUser.Properties.ForceSecAuth
 	}
 
 	if d.HasChange("first_name") {
 		_, newValue := d.GetChange("first_name")
 		firstName := newValue.(string)
 		userReq.Properties.Firstname = &firstName
-
 	}
 
 	if d.HasChange("last_name") {
@@ -189,9 +205,8 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		userReq.Properties.ForceSecAuth = &forceSecAuth
 	}
 
-	_, apiResponse, err := client.UserManagementApi.UmUsersPut(ctx, d.Id()).User(userReq).Execute()
+	_, apiResponse, err = client.UserManagementApi.UmUsersPut(ctx, d.Id()).User(userReq).Execute()
 	logApiRequestTime(apiResponse)
-
 	if err != nil {
 		diags := diag.FromErr(fmt.Errorf("an error occured while patching a user ID %s %s", d.Id(), err))
 		return diags

--- a/ionoscloud/resource_user_test.go
+++ b/ionoscloud/resource_user_test.go
@@ -33,6 +33,18 @@ func TestAccUserBasic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccCheckUserConfigUpdateForceSec,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(UserResource+"."+UserTestResource, &user),
+					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "first_name", UserTestResource),
+					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "last_name", UserTestResource),
+					resource.TestCheckResourceAttrSet(UserResource+"."+UserTestResource, "email"),
+					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "administrator", "true"),
+					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "force_sec_auth", "false"),
+					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "active", "true"),
+				),
+			},
+			{
 				Config: testAccCheckUserConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "first_name", UpdatedResources),
@@ -116,6 +128,17 @@ resource ` + UserResource + ` ` + UserTestResource + ` {
   password = "abc123-321CBA"
   administrator = true
   force_sec_auth= true
+  active  = true
+}`
+
+var testAccCheckUserConfigUpdateForceSec = `
+resource ` + UserResource + ` ` + UserTestResource + ` {
+  first_name = "` + UserTestResource + `"
+  last_name = "` + UserTestResource + `"
+  email = "` + GenerateEmail() + `"
+  password = "abc123-321CBA"
+  administrator = true
+  force_sec_auth= false
   active  = true
 }`
 

--- a/ionoscloud/utils.go
+++ b/ionoscloud/utils.go
@@ -216,6 +216,14 @@ func DiffBasedOnVersion(_, old, new string, _ *schema.ResourceData) bool {
 	return false
 }
 
+//DiffToLower terraform suppress differences between lower and upper
+func DiffToLower(_, old, new string, _ *schema.ResourceData) bool {
+	if strings.ToLower(old) == strings.ToLower(new) {
+		return true
+	}
+	return false
+}
+
 func GenerateEmail() string {
 	email := fmt.Sprintf("terraform_test-%d@mailinator.com", time.Now().UnixNano())
 	return email


### PR DESCRIPTION
## What does this fix or implement?

Fix s3 key test, add some scenarios to test for user.
Fix: update user when only optional fields change.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [X] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented
- [ ] Github Issue linked if any
