### PR TITLE
fix conversion coming from a v5 state

### DIFF
--- a/ionoscloud/resource_k8s_node_pool.go
+++ b/ionoscloud/resource_k8s_node_pool.go
@@ -242,7 +242,10 @@ func resourceK8sNodePool0() *schema.Resource {
 
 func resourceK8sNodePoolUpgradeV0(_ context.Context, state map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
 	oldState := state
-	oldData := oldState["lans"].([]interface{})
+	var oldData []interface{}
+	if d, ok := oldState["lans"].([]interface{}); ok {
+		oldData = d
+	}
 
 	var lans []interface{}
 	for index, lanId := range oldData {


### PR DESCRIPTION
## What does this fix or implement?

When migrating from an old state from provider version5, the state conversion fails causing a panic, since lans can be nil there. I put some small check around the interface conversion. Not sure if that's the ideal solution / how many additional checks should be done.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented
- [ ] Github Issue linked if any
