### PR TITLE
fix: populate correctly boot_volume and primary_ip on server creation…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 ## 5.2.24 (upcoming release)
 
-### Documentation: 
+### Documentation:
 - Improved terraform registry documentation with a more detailed description of environment and terraform variables
 - Added badges containing the release and go version in README.md
+
+### Fixes:
+- creating server with volume from snapshot did not populate volume_boot
+- primary_ip is now set on server creation
 
 ## 5.2.23
 
 ### Fixes: 
 - Fixed rebuild k8 nodes with the same lan - order of lans is ignored now at diff
+
 
 ## 5.2.22
 
@@ -18,11 +23,11 @@
 
 ### Fixes:
 - Password now saved for user on update
-- Host endpoint no longer overwritten if it starts with `http`(fixed in sdk)
-- Fix for receiving sporadic `EOF` from server.
-- Fix k8 node pool import
-- Fix crash when receiving empty metadata
-- Fix user update, remove sensitive logs, suppress email diff based on case.
+- fix sporadic EOF received when making a lot of concurrent https requests to server (fixed in sdk 6.0.0)
+- fixed #154: allow url to start with "http" (fixed in sdk v5.1.1)
+- fixed #92: user password change (fixed in sdk v5.1.1)
+- fix user update and password field is now sensitive
+- fix crash when no metadata is received from server
 
 ## 5.2.21
 

--- a/ionoscloud/resource_server_test.go
+++ b/ionoscloud/resource_server_test.go
@@ -52,6 +52,8 @@ func TestAccServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "nic.0.firewall.0.source_mac", "00:0a:95:9d:68:17"),
 					resource.TestCheckResourceAttrPair(ServerResource+"."+ServerTestResource, "nic.0.firewall.0.source_ip", "ionoscloud_ipblock.webserver_ipblock", "ips.2"),
 					resource.TestCheckResourceAttrPair(ServerResource+"."+ServerTestResource, "nic.0.firewall.0.target_ip", "ionoscloud_ipblock.webserver_ipblock", "ips.3"),
+					resource.TestCheckResourceAttrSet(ServerResource+"."+ServerTestResource, "primary_ip"),
+					resource.TestCheckResourceAttrSet(ServerResource+"."+ServerTestResource, "boot_volume"),
 				),
 			},
 			{
@@ -84,6 +86,7 @@ func TestAccServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "nic.0.firewall.0.source_mac", "00:0a:95:9d:68:18"),
 					resource.TestCheckResourceAttrPair(ServerResource+"."+ServerTestResource, "nic.0.firewall.0.source_ip", "ionoscloud_ipblock.webserver_ipblock_update", "ips.2"),
 					resource.TestCheckResourceAttrPair(ServerResource+"."+ServerTestResource, "nic.0.firewall.0.target_ip", "ionoscloud_ipblock.webserver_ipblock_update", "ips.3"),
+					resource.TestCheckResourceAttrSet(ServerResource+"."+ServerTestResource, "primary_ip"),
 				),
 			},
 		},
@@ -188,6 +191,7 @@ func TestAccServerWithSnapshot(t *testing.T) {
 					resource.TestCheckResourceAttrPair(ServerResource+"."+ServerTestResource, "nic.0.lan", LanResource+"."+LanTestResource, "id"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "nic.0.dhcp", "true"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "nic.0.firewall_active", "true"),
+					resource.TestCheckResourceAttrSet(ServerResource+"."+ServerTestResource, "boot_volume"),
 				),
 			},
 		},
@@ -538,7 +542,7 @@ resource ` + ServerResource + ` ` + ServerTestResource + ` {
   ram = 1024
   availability_zone = "ZONE_1"
   cpu_family = "INTEL_SKYLAKE"
-  image_name = "terraform_snapshot"
+  image_name = ` + SnapshotResource + `.test_snapshot.id
   volume {
     name = "` + ServerTestResource + `"
     size = 5


### PR DESCRIPTION
… from snapshot id

Primary_ip is now correctly set when creating server.
Boot_volume is not correctly set when creating server from snapshot id.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [X] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [X] Tests added or updated
- [ ] Documentation updated
- [X] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
