### PR TITLE
fix: Add versioning to go.mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 6.0.2 (upcoming release)
 
+### Fixes:
+- Add versioning to allow module import.
+
 ### Documentation:
 - Improved terraform registry documentation with a more detailed description of environment and terraform variables
 - Added badges containing the release and go version in README.md

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ionos-cloud/terraform-provider-ionoscloud
+module github.com/ionos-cloud/terraform-provider-ionoscloud/v6
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/ionos-cloud/terraform-provider-ionoscloud/ionoscloud"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/ionoscloud"
 	"log"
 )
 


### PR DESCRIPTION
## What does this fix or implement?

Add v6 to go.mod to allow import of module.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [X] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
