### PR TITLE
fix: v6 immutable nodepool fields should throw err on plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Improved terraform registry documentation with a more detailed description of environment and terraform variables
 - Added badges containing the release and go version in README.md
 
+### Fixes:
+- Immutable k8s node_pool fields should throw error when running plan also, not only on apply
+
 ## 6.0.1
 
 ### Fixes: 

--- a/ionoscloud/resource_k8s_node_pool.go
+++ b/ionoscloud/resource_k8s_node_pool.go
@@ -23,6 +23,7 @@ func resourceK8sNodePool() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceK8sNodepoolImport,
 		},
+		CustomizeDiff: checkNodePoolImmutableFields,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -222,6 +223,48 @@ func resourceK8sNodePool() *schema.Resource {
 			},
 		},
 	}
+}
+
+func checkNodePoolImmutableFields(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	//we do not want to check in case of resource creation
+	if diff.Id() == "" {
+		return nil
+	}
+	if diff.HasChange("name") {
+		return fmt.Errorf("name attribute is immutable, therefore not allowed in update requests")
+
+	}
+
+	if diff.HasChange("cpu_family") {
+		return fmt.Errorf("cpu_family attribute is immutable, therefore not allowed in update requests")
+
+	}
+
+	if diff.HasChange("availability_zone") {
+		return fmt.Errorf("availability_zone attribute is immutable, therefore not allowed in update requests")
+
+	}
+
+	if diff.HasChange("cores_count") {
+		return fmt.Errorf("cores_count attribute is immutable, therefore not allowed in update requests")
+	}
+
+	if diff.HasChange("ram_size") {
+		return fmt.Errorf("ram_size attribute is immutable, therefore not allowed in update requests")
+
+	}
+
+	if diff.HasChange("storage_size") {
+		return fmt.Errorf("storage_size attribute is immutable, therefore not allowed in update requests")
+
+	}
+
+	if diff.HasChange("storage_type") {
+		return fmt.Errorf("storage_type attribute is immutable, therefore not allowed in update requests")
+
+	}
+	return nil
+
 }
 
 func resourceK8sNodePool0() *schema.Resource {
@@ -509,41 +552,6 @@ func resourcek8sNodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 	nodeCount := int32(d.Get("node_count").(int))
 	request.Properties = &ionoscloud.KubernetesNodePoolPropertiesForPut{
 		NodeCount: &nodeCount,
-	}
-
-	if d.HasChange("name") {
-		diags := diag.FromErr(fmt.Errorf("name attribute is immutable, therefore not allowed in update requests"))
-		return diags
-	}
-
-	if d.HasChange("cpu_family") {
-		diags := diag.FromErr(fmt.Errorf("cpu_family attribute is immutable, therefore not allowed in update requests"))
-		return diags
-	}
-
-	if d.HasChange("availability_zone") {
-		diags := diag.FromErr(fmt.Errorf("availability_zone attribute is immutable, therefore not allowed in update requests"))
-		return diags
-	}
-
-	if d.HasChange("cores_count") {
-		diags := diag.FromErr(fmt.Errorf("cores_count attribute is immutable, therefore not allowed in update requests"))
-		return diags
-	}
-
-	if d.HasChange("ram_size") {
-		diags := diag.FromErr(fmt.Errorf("ram_size attribute is immutable, therefore not allowed in update requests"))
-		return diags
-	}
-
-	if d.HasChange("storage_size") {
-		diags := diag.FromErr(fmt.Errorf("storage_size attribute is immutable, therefore not allowed in update requests"))
-		return diags
-	}
-
-	if d.HasChange("storage_type") {
-		diags := diag.FromErr(fmt.Errorf("storage_size attribute is immutable, therefore not allowed in update requests"))
-		return diags
 	}
 
 	if d.HasChange("k8s_version") {


### PR DESCRIPTION
## What does this fix or implement?

Immutable node_pool fields should throw error on plan also, not only on apply.

Note: this will also throw an error on destroy, so if anyone wants to destroy the resource, they need to first restore the field to the original value and then run destroy.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [X] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
