### PR TITLE
fix: fixed diff on availableUpgradeVersions for k8s cluster and nodepool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.2.25 (upcoming release)
+
+### Fix:
+- Fixed diff on availableUpgradeVersions for k8s cluster and nodepool
+
 ## 5.2.24
 
 ### Features:

--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -32,7 +32,6 @@ The following arguments are supported:
 - `maintenance_window` - (Optional) See the **maintenance_window** section in the example above
   - `time` - (Required)[string] A clock time in the day when maintenance is allowed
   - `day_of_the_week` - (Required)[string] Day of the week when maintenance is allowed
-- `available_upgrade_versions` - (Computed) List of available versions for upgrading the cluster
 - `viable_node_pool_versions` - (Computed) List of versions that may be used for node pools under this cluster
 - `api_subnet_allow_list` - (Optional) Access to the K8s API server is restricted to these CIDRs. Cluster-internal traffic is not affected by this restriction. If no allowlist is specified, access is not restricted. If an IP without subnet mask is provided, the default value will be used: 32 for IPv4 and 128 for IPv6.
 - `s3_buckets` - (Optional) List of S3 bucket configured for K8s usage. For now it contains only an S3 bucket used to store K8s API audit logs.

--- a/docs/resources/k8s_node_pool.md
+++ b/docs/resources/k8s_node_pool.md
@@ -70,6 +70,7 @@ The following arguments are supported:
 - `public_ips` - (Optional)[list] A list of public IPs associated with the node pool; must have at least `node_count + 1` elements;  
 - `labels` - (Optional)[map] A key/value map of labels
 - `annotations` - (Optional)[map] A key/value map of annotations
+
 ## Import
 
 A Kubernetes Node Pool resource can be imported using its Kubernetes cluster's uuid as well as its own UUID, both of which you can retreive from the cloud API: `resource id`, e.g.:

--- a/ionoscloud/data_source_k8s_cluster.go
+++ b/ionoscloud/data_source_k8s_cluster.go
@@ -470,6 +470,15 @@ func setAdditionalK8sClusterData(d *schema.ResourceData, cluster *ionoscloud.Kub
 			}
 		}
 
+		if cluster.Properties != nil && cluster.Properties.AvailableUpgradeVersions != nil {
+			availableUpgradeVersions := make([]interface{}, len(*cluster.Properties.AvailableUpgradeVersions), len(*cluster.Properties.AvailableUpgradeVersions))
+			for i, availableUpgradeVersion := range *cluster.Properties.AvailableUpgradeVersions {
+				availableUpgradeVersions[i] = availableUpgradeVersion
+			}
+			if err := d.Set("available_upgrade_versions", availableUpgradeVersions); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/ionoscloud/data_source_k8s_cluster_test.go
+++ b/ionoscloud/data_source_k8s_cluster_test.go
@@ -1,3 +1,4 @@
+//go:build k8s
 // +build k8s
 
 package ionoscloud

--- a/ionoscloud/data_source_k8s_node_pool.go
+++ b/ionoscloud/data_source_k8s_node_pool.go
@@ -222,6 +222,12 @@ func dataSourceK8sReadNodePool(d *schema.ResourceData, meta interface{}) error {
 
 	}
 
+	if nodePool.Properties.AvailableUpgradeVersions != nil && len(*nodePool.Properties.AvailableUpgradeVersions) > 0 {
+		if err := d.Set("available_upgrade_versions", *nodePool.Properties.AvailableUpgradeVersions); err != nil {
+			return err
+		}
+	}
+
 	if err = setK8sNodePoolData(d, &nodePool); err != nil {
 		return err
 	}

--- a/ionoscloud/data_source_k8s_node_pool_test.go
+++ b/ionoscloud/data_source_k8s_node_pool_test.go
@@ -1,3 +1,4 @@
+//go:build k8s
 // +build k8s
 
 package ionoscloud

--- a/ionoscloud/import_k8s_cluster_test.go
+++ b/ionoscloud/import_k8s_cluster_test.go
@@ -1,3 +1,4 @@
+//go:build k8s
 // +build k8s
 
 package ionoscloud

--- a/ionoscloud/import_loadbalancer_test.go
+++ b/ionoscloud/import_loadbalancer_test.go
@@ -1,3 +1,4 @@
+//go:build waiting_for_vdc
 // +build waiting_for_vdc
 
 package ionoscloud

--- a/ionoscloud/resource_k8s_cluster.go
+++ b/ionoscloud/resource_k8s_cluster.go
@@ -55,15 +55,6 @@ func resourcek8sCluster() *schema.Resource {
 					},
 				},
 			},
-			"available_upgrade_versions": {
-				Type:        schema.TypeList,
-				Description: "List of available versions for upgrading the cluster",
-				Optional:    true,
-				Computed:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 			"viable_node_pool_versions": {
 				Type:        schema.TypeList,
 				Description: "List of versions that may be used for node pools under this cluster",
@@ -501,16 +492,6 @@ func setK8sClusterData(d *schema.ResourceData, cluster *ionoscloud.KubernetesClu
 					"day_of_the_week": *cluster.Properties.MaintenanceWindow.DayOfTheWeek,
 				},
 			}); err != nil {
-				return err
-			}
-		}
-
-		if cluster.Properties.AvailableUpgradeVersions != nil {
-			availableUpgradeVersions := make([]interface{}, len(*cluster.Properties.AvailableUpgradeVersions), len(*cluster.Properties.AvailableUpgradeVersions))
-			for i, availableUpgradeVersion := range *cluster.Properties.AvailableUpgradeVersions {
-				availableUpgradeVersions[i] = availableUpgradeVersion
-			}
-			if err := d.Set("available_upgrade_versions", availableUpgradeVersions); err != nil {
 				return err
 			}
 		}

--- a/ionoscloud/resource_k8s_cluster_test.go
+++ b/ionoscloud/resource_k8s_cluster_test.go
@@ -137,7 +137,7 @@ resource ` + K8sClusterResource + ` ` + K8sClusterTestResource + ` {
   }
   api_subnet_allow_list = ["1.2.3.4/32"]
   s3_buckets { 
-     name = "sdktestv66"
+     name = "test_k8d"
   }
 }`
 

--- a/ionoscloud/resource_k8s_node_pool.go
+++ b/ionoscloud/resource_k8s_node_pool.go
@@ -155,14 +155,6 @@ func resourceK8sNodePool() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"available_upgrade_versions": {
-				Type:        schema.TypeList,
-				Description: "A list of kubernetes versions available for upgrade",
-				Computed:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 		},
 		Timeouts: &resourceDefaultTimeouts,
 	}
@@ -826,12 +818,6 @@ func setK8sNodePoolData(d *schema.ResourceData, nodePool *ionoscloud.KubernetesN
 			err := d.Set("lans", lans)
 			if err != nil {
 				return fmt.Errorf("error while setting lans property for k8sNodepool %s: %s", d.Id(), err)
-			}
-		}
-
-		if nodePool.Properties.AvailableUpgradeVersions != nil && len(*nodePool.Properties.AvailableUpgradeVersions) > 0 {
-			if err := d.Set("available_upgrade_versions", *nodePool.Properties.AvailableUpgradeVersions); err != nil {
-				return err
 			}
 		}
 

--- a/ionoscloud/resource_k8s_node_pool_test.go
+++ b/ionoscloud/resource_k8s_node_pool_test.go
@@ -1,3 +1,4 @@
+//go:build k8s
 // +build k8s
 
 package ionoscloud

--- a/ionoscloud/resource_loadbalancer_test.go
+++ b/ionoscloud/resource_loadbalancer_test.go
@@ -1,3 +1,4 @@
+//go:build waiting_for_vdc
 // +build waiting_for_vdc
 
 package ionoscloud


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
 fixed diff on availableUpgradeVersions for k8s cluster and nodepool by removing this field from resource and import

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
