### PR TITLE
fix: node_count update crash and creation without maintenance_window on node_pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - improved tests duration by moving steps from data_source test files in the corresponding resource test files 
 - added workflow to run tests from GitHub actions 
 - split tests with build tags
-- update http client with better values
+- improve http client performance and timeouts
 
 ### Documentations: 
 - a more accurate example on how can the cidr be set automatically on a DBaaS Cluster
@@ -13,6 +13,8 @@
 ### Fixes: 
 - fix on creating a DBaaS Cluster without specifying the maintenance window
 - solve #204 - targets in nlb forwarding rule(switched to Set instead of List), lb_private_ips(set to computed), features in datacenter resources(switched to Set instead of List)
+- fix of plugin crash when updating k8s_node_pool node_count
+- fix of diff when creating a k8s_node_pool without maintenance_window
 
 ## 6.1.3
 

--- a/ionoscloud/resource_k8s_node_pool_test.go
+++ b/ionoscloud/resource_k8s_node_pool_test.go
@@ -209,6 +209,49 @@ func TestAccK8sNodePoolGatewayIP(t *testing.T) {
 	})
 }
 
+func TestAccK8sNodePoolNoOptional(t *testing.T) {
+	var k8sNodepool ionoscloud.KubernetesNodePool
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckK8sNodePoolDestroyCheck,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckK8sNodePoolConfigNoOptionalFields,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8sNodePoolExists(ResourceNameK8sNodePool, &k8sNodepool),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "name", K8sNodePoolTestResource),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.21.4"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "cpu_family", "INTEL_XEON"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "availability_zone", "AUTO"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "storage_type", "SSD"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "node_count", "2"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "cores_count", "1"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "ram_size", "2048"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "storage_size", "40"),
+				),
+			},
+			{
+				Config: testAccCheckK8sNodePoolConfigNoOptionalFieldsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8sNodePoolExists(ResourceNameK8sNodePool, &k8sNodepool),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "name", K8sNodePoolTestResource),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.21.4"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "cpu_family", "INTEL_XEON"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "availability_zone", "AUTO"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "storage_type", "SSD"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "node_count", "1"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "cores_count", "1"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "ram_size", "2048"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "storage_size", "40")),
+			},
+		},
+	})
+}
+
 func testAccCheckK8sNodePoolDestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(SdkBundle).CloudApiClient
 
@@ -552,3 +595,69 @@ data ` + K8sNodePoolResource + ` ` + K8sNodePoolDataSourceByName + ` {
 	name			= ` + K8sNodePoolResource + `.` + K8sNodePoolTestResource + `.name
 }
 `
+
+const testAccCheckK8sNodePoolConfigNoOptionalFields = `
+resource ` + DatacenterResource + ` "terraform_acctest" {
+  name        = "terraform_acctest"
+  location    = "us/las"
+  description = "Datacenter created through terraform"
+}
+
+resource ` + K8sClusterResource + ` "terraform_acctest" {
+  name        = "terraform_acctest"
+  k8s_version = "1.21.4"
+  maintenance_window {
+    day_of_the_week = "Monday"
+    time            = "09:00:00Z"
+  }
+}
+resource ` + K8sNodePoolResource + ` ` + K8sNodePoolTestResource + ` {
+  datacenter_id     = ` + DatacenterResource + `.terraform_acctest.id
+  k8s_cluster_id    = ` + K8sClusterResource + `.terraform_acctest.id
+  k8s_version = ` + K8sClusterResource + `.terraform_acctest.k8s_version
+  name        = "` + K8sNodePoolTestResource + `"
+  auto_scaling {
+    min_node_count = 1
+    max_node_count = 3
+  }
+  cpu_family        = "INTEL_XEON"
+  availability_zone = "AUTO"
+  storage_type      = "SSD"
+  node_count        = 2
+  cores_count       = 1
+  ram_size          = 2048
+  storage_size      = 40
+}`
+
+const testAccCheckK8sNodePoolConfigNoOptionalFieldsUpdate = `
+resource ` + DatacenterResource + ` "terraform_acctest" {
+  name        = "terraform_acctest"
+  location    = "us/las"
+  description = "Datacenter created through terraform"
+}
+
+resource ` + K8sClusterResource + ` "terraform_acctest" {
+  name        = "terraform_acctest"
+  k8s_version = "1.21.4"
+  maintenance_window {
+    day_of_the_week = "Monday"
+    time            = "09:00:00Z"
+  }
+}
+resource ` + K8sNodePoolResource + ` ` + K8sNodePoolTestResource + ` {
+  datacenter_id     = ` + DatacenterResource + `.terraform_acctest.id
+  k8s_cluster_id    = ` + K8sClusterResource + `.terraform_acctest.id
+  name        = "` + K8sNodePoolTestResource + `"
+  k8s_version = ` + K8sClusterResource + `.terraform_acctest.k8s_version
+  auto_scaling {
+    min_node_count = 1
+    max_node_count = 3
+  }
+  cpu_family        = "INTEL_XEON"
+  availability_zone = "AUTO"
+  storage_type      = "SSD"
+  node_count        = 1
+  cores_count       = 1
+  ram_size          = 2048
+  storage_size      = 40
+}`


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
- fix of plugin crash when updating k8s_node_pool node_count
- fix of diff when creating a k8s_node_pool without maintenance_window
- added http client improvements on dbaas client

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
