### PR TITLE
Fix/client should limit concurrent connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 6.1.5 (upcoming release)
+## 6.1.5
+
+### Fixes
+- Limit max concurrent connections to the same host to 3.
+- Set max retries in case of rate-limit(429) to 999.
+- Set backoff time to 4s.
+
 
 ### Documentation:
 - updated gitbook documentation with `legal` subheading

--- a/ionoscloud/provider.go
+++ b/ionoscloud/provider.go
@@ -169,7 +169,8 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 	if os.Getenv("IONOS_DEBUG") != "" {
 		newConfig.Debug = true
 	}
-
+	newConfig.MaxRetries = 6
+	newConfig.WaitTime = 4 * time.Second
 	newConfig.HTTPClient = &http.Client{Transport: createTransport()}
 
 	newClient := ionoscloud.NewAPIClient(newConfig)
@@ -196,12 +197,11 @@ func createTransport() *http.Transport {
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           dialer.DialContext,
 		DisableKeepAlives:     true,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
 		TLSHandshakeTimeout:   15 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+		MaxIdleConnsPerHost:   3,
+		MaxConnsPerHost:       3,
 	}
 }
 

--- a/ionoscloud/provider.go
+++ b/ionoscloud/provider.go
@@ -169,7 +169,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 	if os.Getenv("IONOS_DEBUG") != "" {
 		newConfig.Debug = true
 	}
-	newConfig.MaxRetries = 6
+	newConfig.MaxRetries = 999
 	newConfig.WaitTime = 4 * time.Second
 	newConfig.HTTPClient = &http.Client{Transport: createTransport()}
 

--- a/services/dbaas/client.go
+++ b/services/dbaas/client.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"runtime"
 	"time"
 )
 
@@ -35,6 +34,8 @@ func NewClientService(username, password, token, url string) ClientService {
 	if os.Getenv("IONOS_DEBUG") != "" {
 		newConfigDbaas.Debug = true
 	}
+	newConfigDbaas.MaxRetries = 6
+	newConfigDbaas.MaxWaitTime = 2 * time.Second
 
 	newConfigDbaas.HTTPClient = &http.Client{Transport: createTransport()}
 
@@ -64,11 +65,10 @@ func createTransport() *http.Transport {
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           dialer.DialContext,
 		DisableKeepAlives:     true,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
 		TLSHandshakeTimeout:   15 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+		MaxIdleConnsPerHost:   3,
+		MaxConnsPerHost:       3,
 	}
 }

--- a/services/dbaas/client.go
+++ b/services/dbaas/client.go
@@ -34,7 +34,7 @@ func NewClientService(username, password, token, url string) ClientService {
 	if os.Getenv("IONOS_DEBUG") != "" {
 		newConfigDbaas.Debug = true
 	}
-	newConfigDbaas.MaxRetries = 6
+	newConfigDbaas.MaxRetries = 999
 	newConfigDbaas.MaxWaitTime = 2 * time.Second
 
 	newConfigDbaas.HTTPClient = &http.Client{Transport: createTransport()}


### PR DESCRIPTION
## What does this fix or implement?

Limits max concurrent connections to the same host to 3.
Sets max retries in case of rate-limit(429) to 999.
Sets backoff time to 4s.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
