### PR TITLE
fix: fixed data sources for exact match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 6.1.6
+
+### Fixes
+- fixed data sources to provide an exact match (roll-back to 6.1.3 + errors in case of multiple results)
+
 ## 6.1.5
 
 ### Fixes
 - Limit max concurrent connections to the same host to 3.
 - Set max retries in case of rate-limit(429) to 999.
 - Set backoff time to 4s.
-
 
 ### Documentation:
 - updated gitbook documentation with `legal` subheading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Fixes
 - fixed data sources to provide an exact match (roll-back to 6.1.3 + errors in case of multiple results)
 
+### Documentation
+- updated k8s cluster and node pool version from examples
+
 ## 6.1.5
 
 ### Fixes

--- a/ionoscloud/data_source_backup_unit.go
+++ b/ionoscloud/data_source_backup_unit.go
@@ -78,12 +78,12 @@ func dataSourceBackupUnitRead(ctx context.Context, d *schema.ResourceData, meta 
 		var results []ionoscloud.BackupUnit
 		if backupUnits.Items != nil {
 			for _, bu := range *backupUnits.Items {
-				tmpBackupUnit, apiResponse, err := client.BackupUnitsApi.BackupunitsFindById(ctx, *bu.Id).Execute()
-				logApiRequestTime(apiResponse)
-				if err != nil {
-					return diag.FromErr(fmt.Errorf("an error occurred while fetching backup unit with ID %s: %s", *bu.Id, err.Error()))
-				}
-				if tmpBackupUnit.Properties.Name != nil && *tmpBackupUnit.Properties.Name == name.(string) {
+				if bu.Properties.Name != nil && *bu.Properties.Name == name.(string) {
+					tmpBackupUnit, apiResponse, err := client.BackupUnitsApi.BackupunitsFindById(ctx, *bu.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching backup unit with ID %s: %s", *bu.Id, err.Error()))
+					}
 					results = append(results, tmpBackupUnit)
 				}
 

--- a/ionoscloud/data_source_backup_unit.go
+++ b/ionoscloud/data_source_backup_unit.go
@@ -78,7 +78,7 @@ func dataSourceBackupUnitRead(ctx context.Context, d *schema.ResourceData, meta 
 		var results []ionoscloud.BackupUnit
 		if backupUnits.Items != nil {
 			for _, bu := range *backupUnits.Items {
-				if bu.Properties.Name != nil && *bu.Properties.Name == name.(string) {
+				if bu.Properties != nil && bu.Properties.Name != nil && *bu.Properties.Name == name.(string) {
 					tmpBackupUnit, apiResponse, err := client.BackupUnitsApi.BackupunitsFindById(ctx, *bu.Id).Execute()
 					logApiRequestTime(apiResponse)
 					if err != nil {

--- a/ionoscloud/data_source_datacenter.go
+++ b/ionoscloud/data_source_datacenter.go
@@ -125,11 +125,11 @@ func dataSourceDataCenterRead(ctx context.Context, d *schema.ResourceData, meta 
 
 		request := client.DataCentersApi.DatacentersGet(ctx).Depth(1)
 		if nameOk {
-			request = request.Filter("name", name)
+			request = request.Filter("name", name).OrderBy("name")
 		}
 
 		if locationOk {
-			request = request.Filter("location", location)
+			request = request.Filter("location", location).OrderBy("location")
 		}
 
 		results, apiResponse, err = request.Execute()

--- a/ionoscloud/data_source_datacenter.go
+++ b/ionoscloud/data_source_datacenter.go
@@ -140,9 +140,31 @@ func dataSourceDataCenterRead(ctx context.Context, d *schema.ResourceData, meta 
 		}
 
 		if results.Items != nil && len(*results.Items) > 0 {
-			datacenter = (*results.Items)[len(*results.Items)-1]
-			log.Printf("[WARN] %v datacenters found matching the search criteria. Getting the latest datacenter from the list %v", len(*results.Items), *datacenter.Id)
-		} else {
+			var match bool
+			for _, result := range *results.Items {
+				match = true
+
+				if nameOk && result.Properties != nil && result.Properties.Name != nil {
+					if *result.Properties.Name != name {
+						match = false
+					}
+				}
+
+				if locationOk && result.Properties != nil && result.Properties.Location != nil {
+					if *result.Properties.Location != location {
+						match = false
+					}
+				}
+
+				if match {
+					datacenter = result
+					break
+				}
+			}
+
+		}
+
+		if datacenter.Properties == nil {
 			return diag.FromErr(fmt.Errorf("no datacenter found with the specified criteria: name %s, location %s", name, location))
 		}
 

--- a/ionoscloud/data_source_dbaas_pgsql_cluster.go
+++ b/ionoscloud/data_source_dbaas_pgsql_cluster.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	dbaas "github.com/ionos-cloud/sdk-go-dbaas-postgres"
 	dbaasService "github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/dbaas"
-	"log"
 )
 
 func dataSourceDbaasPgSqlCluster() *schema.Resource {
@@ -185,10 +184,16 @@ func dataSourceDbaasPgSqlReadCluster(ctx context.Context, d *schema.ResourceData
 		}
 
 		if clusters.Items != nil && len(*clusters.Items) > 0 {
-			cluster = (*clusters.Items)[len(*clusters.Items)-1]
-			log.Printf("[WARN] %v clusters found matching the search criteria. Getting the latest datacenter from the list %v", len(*clusters.Items), *cluster.Id)
-		} else {
-			return diag.FromErr(errors.New("dbaas cluster not found"))
+			for _, clusterItem := range *clusters.Items {
+				if clusterItem.Properties != nil && clusterItem.Properties.DisplayName != nil && *clusterItem.Properties.DisplayName == name.(string) {
+					cluster = clusterItem
+					break
+				}
+			}
+		}
+
+		if cluster.Properties == nil {
+			return diag.FromErr(fmt.Errorf("no DBaaS cluster found with the specified name %s", name.(string)))
 		}
 	}
 

--- a/ionoscloud/data_source_firewall.go
+++ b/ionoscloud/data_source_firewall.go
@@ -119,15 +119,14 @@ func dataSourceFirewallRead(ctx context.Context, d *schema.ResourceData, meta in
 
 		if firewalls.Items != nil {
 			for _, fr := range *firewalls.Items {
-				tmpFirewall, apiResponse, err := client.FirewallRulesApi.DatacentersServersNicsFirewallrulesFindById(ctx, datacenterId, serverId, nicId, *fr.Id).Execute()
-				logApiRequestTime(apiResponse)
-				if err != nil {
-					return diag.FromErr(fmt.Errorf("an error occurred while fetching firewall rule with ID %s: %s", *fr.Id, err.Error()))
+				if fr.Properties != nil && fr.Properties.Name != nil && *fr.Properties.Name == name.(string) {
+					tmpFirewall, apiResponse, err := client.FirewallRulesApi.DatacentersServersNicsFirewallrulesFindById(ctx, datacenterId, serverId, nicId, *fr.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching firewall rule with ID %s: %s", *fr.Id, err.Error()))
+					}
+					results = append(results, tmpFirewall)
 				}
-				if tmpFirewall.Properties != nil && tmpFirewall.Properties.Name != nil && *tmpFirewall.Properties.Name == name.(string) {
-					results = append(results, fr)
-				}
-
 			}
 		}
 

--- a/ionoscloud/data_source_firewall.go
+++ b/ionoscloud/data_source_firewall.go
@@ -106,7 +106,7 @@ func dataSourceFirewallRead(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	} else {
 		/* search by name */
-		firewalls, apiResponse, err := client.FirewallRulesApi.DatacentersServersNicsFirewallrulesGet(ctx, datacenterId, serverId, nicId).Depth(1).Filter("name", name.(string)).Execute()
+		firewalls, apiResponse, err := client.FirewallRulesApi.DatacentersServersNicsFirewallrulesGet(ctx, datacenterId, serverId, nicId).Depth(1).Filter("name", name.(string)).OrderBy("name").Execute()
 		logApiRequestTime(apiResponse)
 
 		if err != nil {

--- a/ionoscloud/data_source_group.go
+++ b/ionoscloud/data_source_group.go
@@ -122,7 +122,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	} else {
 		/* search by name */
-		groups, apiResponse, err := client.UserManagementApi.UmGroupsGet(ctx).Depth(1).Filter("name", name.(string)).Execute()
+		groups, apiResponse, err := client.UserManagementApi.UmGroupsGet(ctx).Depth(1).Filter("name", name.(string)).OrderBy("name").Execute()
 		logApiRequestTime(apiResponse)
 		if err != nil {
 			diags := diag.FromErr(fmt.Errorf("an error occurred while fetching groups: %w", err))

--- a/ionoscloud/data_source_group.go
+++ b/ionoscloud/data_source_group.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
-	"log"
 )
 
 func dataSourceGroup() *schema.Resource {
@@ -131,12 +130,17 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if groups.Items != nil && len(*groups.Items) > 0 {
-			group = (*groups.Items)[len(*groups.Items)-1]
-			log.Printf("[WARN] %v groups found matching the search criteria. Getting the latest group from the list %v", len(*groups.Items), *group.Id)
-		} else {
-			return diag.FromErr(fmt.Errorf("no group found with the specified name %s", name.(string)))
+			for _, groupItem := range *groups.Items {
+				if groupItem.Properties != nil && groupItem.Properties.Name != nil && *groupItem.Properties.Name == name.(string) {
+					group = groupItem
+					break
+				}
+			}
 		}
 
+		if group.Properties == nil {
+			return diag.FromErr(fmt.Errorf("no group found with the specified name %s", name.(string)))
+		}
 	}
 
 	if err = setGroupData(ctx, client, d, &group); err != nil {

--- a/ionoscloud/data_source_image.go
+++ b/ionoscloud/data_source_image.go
@@ -137,7 +137,7 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 	} else if nameOk {
 		if images.Items != nil {
 			for _, img := range *images.Items {
-				if img.Properties.Name != nil && strings.ToLower(*img.Properties.Name) == strings.ToLower(name.(string)) {
+				if img.Properties != nil && img.Properties.Name != nil && strings.ToLower(*img.Properties.Name) == strings.ToLower(name.(string)) {
 					results = append(results, img)
 					break
 				}
@@ -151,7 +151,7 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if imageTypeOk {
 		var imageTypeResults []ionoscloud.Image
 		for _, img := range results {
-			if img.Properties.ImageType != nil && *img.Properties.ImageType == imageType.(string) {
+			if img.Properties != nil && img.Properties.ImageType != nil && *img.Properties.ImageType == imageType.(string) {
 				imageTypeResults = append(imageTypeResults, img)
 			}
 
@@ -162,7 +162,7 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if locationOk {
 		var locationResults []ionoscloud.Image
 		for _, img := range results {
-			if img.Properties.Location != nil && *img.Properties.Location == location.(string) {
+			if img.Properties != nil && img.Properties.Location != nil && *img.Properties.Location == location.(string) {
 				locationResults = append(locationResults, img)
 			}
 		}
@@ -172,7 +172,7 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if cloudInitOk {
 		var cloudInitResults []ionoscloud.Image
 		for _, img := range results {
-			if img.Properties.CloudInit != nil && *img.Properties.CloudInit == cloudInit.(string) {
+			if img.Properties != nil && img.Properties.CloudInit != nil && *img.Properties.CloudInit == cloudInit.(string) {
 				cloudInitResults = append(cloudInitResults, img)
 			}
 		}

--- a/ionoscloud/data_source_image.go
+++ b/ionoscloud/data_source_image.go
@@ -119,21 +119,21 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 	// otherwise search by name or part of the name
 	if versionOk {
 		nameVer := fmt.Sprintf("%s-%s", name.(string), version.(string))
-		request = request.Filter("name", nameVer)
+		request = request.Filter("name", nameVer).OrderBy("name")
 	} else {
-		request = request.Filter("name", name.(string))
+		request = request.Filter("name", name.(string)).OrderBy("name")
 	}
 
 	if imageTypeOk {
-		request = request.Filter("imageType", imageType.(string))
+		request = request.Filter("imageType", imageType.(string)).OrderBy("imageType")
 	}
 
 	if locationOk {
-		request = request.Filter("location", location.(string))
+		request = request.Filter("location", location.(string)).OrderBy("location")
 	}
 
 	if cloudInitOk {
-		request = request.Filter("cloudInit", cloudInit.(string))
+		request = request.Filter("cloudInit", cloudInit.(string)).OrderBy("cloudInit")
 	}
 
 	results, apiResponse, err := request.Execute()

--- a/ionoscloud/data_source_image_test.go
+++ b/ionoscloud/data_source_image_test.go
@@ -28,7 +28,7 @@ func TestAccDataSourceImageBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceImageWrongName,
+				Config:      testAccDataSourceImageWrongNameError,
 				ExpectError: regexp.MustCompile("no image found with the specified criteria"),
 			},
 			{
@@ -62,7 +62,7 @@ const testAccDataSourceImageBasic = `
 	}
 `
 
-const testAccDataSourceImageWrongName = `
+const testAccDataSourceImageWrongNameError = `
 	data ` + ImageResource + ` ` + ImageTestResource + ` {
 	  name = "wrong_name"
 	  type = "CDROM"

--- a/ionoscloud/data_source_ipblock.go
+++ b/ionoscloud/data_source_ipblock.go
@@ -132,31 +132,54 @@ func datasourceIpBlockRead(ctx context.Context, data *schema.ResourceData, meta 
 		log.Printf("[INFO] Got ip block [Name=%s, Location=%s]", *ipBlock.Properties.Name, *ipBlock.Properties.Location)
 	} else {
 
-		var results ionoscloud.IpBlocks
-
-		request := client.IPBlocksApi.IpblocksGet(ctx).Depth(1)
-
-		if nameOk {
-			request = request.Filter("name", name)
-		}
-
-		if locationOk {
-			request = request.Filter("location", location)
-		}
-
-		results, apiResponse, err := request.Execute()
+		ipBlocks, apiResponse, err := client.IPBlocksApi.IpblocksGet(ctx).Depth(1).Execute()
 		logApiRequestTime(apiResponse)
 
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("an error occurred while fetching ip blocks: %s", err.Error()))
+			return diag.FromErr(fmt.Errorf("an error occured while fetching ipBlocks: %s ", err))
 		}
 
-		if results.Items != nil && len(*results.Items) > 0 {
-			ipBlock = (*results.Items)[len(*results.Items)-1]
-			log.Printf("[WARN] %v ip blocks found matching the search criteria. Getting the latest ip block from the list %v", len(*results.Items), *ipBlock.Id)
-		} else {
-			return diag.FromErr(fmt.Errorf("no ip block found with the specified criteria: name %s, location %s", name, location))
+		var results []ionoscloud.IpBlock
+
+		if nameOk && ipBlocks.Items != nil {
+			for _, block := range *ipBlocks.Items {
+				if block.Properties != nil && block.Properties.Name != nil && *block.Properties.Name == name {
+					results = append(results, block)
+				}
+			}
+
+			if results == nil {
+				return diag.FromErr(fmt.Errorf("no ip block found with the specified criteria name %s", name))
+			}
 		}
+
+		if locationOk {
+			if results != nil {
+				var locationResults []ionoscloud.IpBlock
+				for _, block := range results {
+					if block.Properties.Location != nil && *block.Properties.Location == location {
+						locationResults = append(locationResults, block)
+					}
+				}
+				results = locationResults
+			} else if ipBlocks.Items != nil {
+				/* find the first ipblock matching the location */
+				for _, block := range *ipBlocks.Items {
+					if block.Properties.Location != nil && *block.Properties.Location == location {
+						results = append(results, block)
+					}
+				}
+			}
+		}
+
+		if results == nil || len(results) == 0 {
+			return diag.FromErr(fmt.Errorf("no ip block found with the specified criteria name = %s, location = %s", name, location))
+		} else if len(results) > 1 {
+			return diag.FromErr(fmt.Errorf("more than one ip block found with the specified criteria name = %s, location = %s", name, location))
+		} else {
+			ipBlock = results[0]
+		}
+
 	}
 
 	if err := IpBlockSetData(data, &ipBlock); err != nil {

--- a/ionoscloud/data_source_ipblock.go
+++ b/ionoscloud/data_source_ipblock.go
@@ -118,13 +118,13 @@ func datasourceIpBlockRead(ctx context.Context, data *schema.ResourceData, meta 
 			return diag.FromErr(fmt.Errorf("error getting ip block with id %s %s", id.(string), err))
 		}
 		if nameOk {
-			if *ipBlock.Properties.Name != name {
+			if ipBlock.Properties != nil && *ipBlock.Properties.Name != name {
 				return diag.FromErr(fmt.Errorf("name of ip block (UUID=%s, name=%s) does not match expected name: %s",
 					*ipBlock.Id, *ipBlock.Properties.Name, name))
 			}
 		}
 		if locationOk {
-			if *ipBlock.Properties.Location != location {
+			if ipBlock.Properties != nil && *ipBlock.Properties.Location != location {
 				return diag.FromErr(fmt.Errorf("location of ip block (UUID=%s, location=%s) does not match expected location: %s",
 					*ipBlock.Id, *ipBlock.Properties.Location, location))
 			}
@@ -157,7 +157,7 @@ func datasourceIpBlockRead(ctx context.Context, data *schema.ResourceData, meta 
 			if results != nil {
 				var locationResults []ionoscloud.IpBlock
 				for _, block := range results {
-					if block.Properties.Location != nil && *block.Properties.Location == location {
+					if block.Properties != nil && block.Properties.Location != nil && *block.Properties.Location == location {
 						locationResults = append(locationResults, block)
 					}
 				}
@@ -165,7 +165,7 @@ func datasourceIpBlockRead(ctx context.Context, data *schema.ResourceData, meta 
 			} else if ipBlocks.Items != nil {
 				/* find the first ipblock matching the location */
 				for _, block := range *ipBlocks.Items {
-					if block.Properties.Location != nil && *block.Properties.Location == location {
+					if block.Properties != nil && block.Properties.Location != nil && *block.Properties.Location == location {
 						results = append(results, block)
 					}
 				}

--- a/ionoscloud/data_source_k8s_cluster.go
+++ b/ionoscloud/data_source_k8s_cluster.go
@@ -280,12 +280,12 @@ func dataSourceK8sReadCluster(ctx context.Context, d *schema.ResourceData, meta 
 			var results []ionoscloud.KubernetesCluster
 
 			for _, c := range *clusters.Items {
-				tmpCluster, apiResponse, err := client.KubernetesApi.K8sFindByClusterId(ctx, *c.Id).Execute()
-				logApiRequestTime(apiResponse)
-				if err != nil {
-					return diag.FromErr(fmt.Errorf("an error occurred while fetching k8s cluster with ID %s: %s", *c.Id, err.Error()))
-				}
-				if tmpCluster.Properties != nil && tmpCluster.Properties.Name != nil && *tmpCluster.Properties.Name == name.(string) {
+				if c.Properties != nil && c.Properties.Name != nil && *c.Properties.Name == name.(string) {
+					tmpCluster, apiResponse, err := client.KubernetesApi.K8sFindByClusterId(ctx, *c.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching k8s cluster with ID %s: %s", *c.Id, err.Error()))
+					}
 					results = append(results, tmpCluster)
 					break
 				}

--- a/ionoscloud/data_source_k8s_cluster.go
+++ b/ionoscloud/data_source_k8s_cluster.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	"gopkg.in/yaml.v3"
-	"log"
 )
 
 type KubeConfig struct {
@@ -269,18 +268,36 @@ func dataSourceK8sReadCluster(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	} else {
 		/* search by name */
-		clusters, apiResponse, err := client.KubernetesApi.K8sGet(ctx).Depth(1).Filter("name", name.(string)).Execute()
+		var clusters ionoscloud.KubernetesClusters
+
+		clusters, apiResponse, err := client.KubernetesApi.K8sGet(ctx).Execute()
 		logApiRequestTime(apiResponse)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("an error occurred while fetching k8s clusters: %s", err.Error()))
 		}
 
-		if clusters.Items != nil && len(*clusters.Items) > 0 {
-			cluster = (*clusters.Items)[len(*clusters.Items)-1]
-			log.Printf("[WARN] %v clusters found matching the search criteria. Getting the latest  cluster from the list %v", len(*clusters.Items), *cluster.Id)
+		if clusters.Items != nil {
+			var results []ionoscloud.KubernetesCluster
 
-		} else {
-			return diag.FromErr(fmt.Errorf("no cluster found with the specified name %s", name.(string)))
+			for _, c := range *clusters.Items {
+				tmpCluster, apiResponse, err := client.KubernetesApi.K8sFindByClusterId(ctx, *c.Id).Execute()
+				logApiRequestTime(apiResponse)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf("an error occurred while fetching k8s cluster with ID %s: %s", *c.Id, err.Error()))
+				}
+				if tmpCluster.Properties != nil && tmpCluster.Properties.Name != nil && *tmpCluster.Properties.Name == name.(string) {
+					results = append(results, tmpCluster)
+					break
+				}
+			}
+
+			if results == nil || len(results) == 0 {
+				return diag.FromErr(fmt.Errorf("no cluster found with the specified name %s", name.(string)))
+			} else if len(results) > 1 {
+				return diag.FromErr(fmt.Errorf("more than one cluster found with the specified name %s", name.(string)))
+			} else {
+				cluster = results[0]
+			}
 		}
 
 	}

--- a/ionoscloud/data_source_k8s_node_pool.go
+++ b/ionoscloud/data_source_k8s_node_pool.go
@@ -227,12 +227,12 @@ func dataSourceK8sReadNodePool(ctx context.Context, d *schema.ResourceData, meta
 			var results []ionoscloud.KubernetesNodePool
 
 			for _, c := range *nodePools.Items {
-				tmpNodePool, apiResponse, err := client.KubernetesApi.K8sNodepoolsFindById(ctx, clusterId.(string), *c.Id).Execute()
-				logApiRequestTime(apiResponse)
-				if err != nil {
-					return diag.FromErr(fmt.Errorf("an error occurred while fetching k8s nodePool with ID %s: %w", *c.Id, err))
-				}
-				if tmpNodePool.Properties != nil && tmpNodePool.Properties.Name != nil && *tmpNodePool.Properties.Name == name.(string) {
+				if c.Properties != nil && c.Properties.Name != nil && *c.Properties.Name == name.(string) {
+					tmpNodePool, apiResponse, err := client.KubernetesApi.K8sNodepoolsFindById(ctx, clusterId.(string), *c.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching k8s nodePool with ID %s: %w", *c.Id, err))
+					}
 					/* lan found */
 					results = append(results, tmpNodePool)
 					break

--- a/ionoscloud/data_source_location_test.go
+++ b/ionoscloud/data_source_location_test.go
@@ -26,7 +26,7 @@ func TestAccDataSourceLocationBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceLocationWrongName,
+				Config:      testAccDataSourceLocationWrongNameError,
 				ExpectError: regexp.MustCompile("no location found with the specified criteria"),
 			},
 			{
@@ -44,7 +44,7 @@ data ` + LocationResource + ` ` + LocationTestResource + ` {
 	  feature = "SSD"
 }
 `
-const testAccDataSourceLocationWrongName = `
+const testAccDataSourceLocationWrongNameError = `
 data ` + LocationResource + ` ` + LocationTestResource + ` {
 	  name = "wrong_name"
 	  feature = "SSD"

--- a/ionoscloud/data_source_natgateway.go
+++ b/ionoscloud/data_source_natgateway.go
@@ -102,16 +102,14 @@ func dataSourceNatGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 
 		var results []ionoscloud.NatGateway
 		if natGateways.Items != nil {
-			for _, c := range *natGateways.Items {
-				if c.Properties.Name != nil {
-					if *c.Properties.Name == name.(string) {
-						tmpNatGateway, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysFindByNatGatewayId(ctx, datacenterId.(string), *c.Id).Execute()
-						logApiRequestTime(apiResponse)
-						if err != nil {
-							return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway with ID %s: %s", *c.Id, err.Error()))
-						}
-						results = append(results, tmpNatGateway)
+			for _, ng := range *natGateways.Items {
+				if ng.Properties != nil && ng.Properties.Name != nil && *ng.Properties.Name == name.(string) {
+					tmpNatGateway, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysFindByNatGatewayId(ctx, datacenterId.(string), *ng.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway with ID %s: %s", *ng.Id, err.Error()))
 					}
+					results = append(results, tmpNatGateway)
 				}
 
 			}

--- a/ionoscloud/data_source_natgateway.go
+++ b/ionoscloud/data_source_natgateway.go
@@ -102,14 +102,15 @@ func dataSourceNatGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 
 		var results []ionoscloud.NatGateway
 		if natGateways.Items != nil {
-			for _, ng := range *natGateways.Items {
-				if ng.Properties != nil && ng.Properties.Name != nil && *ng.Properties.Name == name.(string) {
-					tmpNatGateway, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysFindByNatGatewayId(ctx, datacenterId.(string), *ng.Id).Execute()
-					logApiRequestTime(apiResponse)
-					if err != nil {
-						return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway with ID %s: %s", *ng.Id, err.Error()))
-					}
-					results = append(results, tmpNatGateway)
+			for _, c := range *natGateways.Items {
+				tmpNatGateway, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysFindByNatGatewayId(ctx, datacenterId.(string), *c.Id).Execute()
+				logApiRequestTime(apiResponse)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway with ID %s: %s", *c.Id, err.Error()))
+				}
+				if tmpNatGateway.Properties != nil && tmpNatGateway.Properties.Name != nil && *tmpNatGateway.Properties.Name == name.(string) {
+					natGateway = tmpNatGateway
+					results = append(results, natGateway)
 				}
 
 			}

--- a/ionoscloud/data_source_natgateway.go
+++ b/ionoscloud/data_source_natgateway.go
@@ -104,12 +104,12 @@ func dataSourceNatGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 		var results []ionoscloud.NatGateway
 		if natGateways.Items != nil {
 			for _, c := range *natGateways.Items {
-				tmpNatGateway, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysFindByNatGatewayId(ctx, datacenterId.(string), *c.Id).Execute()
-				logApiRequestTime(apiResponse)
-				if err != nil {
-					return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway with ID %s: %s", *c.Id, err.Error()))
-				}
-				if tmpNatGateway.Properties.Name != nil {
+				if c.Properties.Name != nil {
+					tmpNatGateway, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysFindByNatGatewayId(ctx, datacenterId.(string), *c.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway with ID %s: %s", *c.Id, err.Error()))
+					}
 					if strings.Contains(*tmpNatGateway.Properties.Name, name.(string)) {
 						natGateway = tmpNatGateway
 						results = append(results, natGateway)

--- a/ionoscloud/data_source_natgateway.go
+++ b/ionoscloud/data_source_natgateway.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
-	"strings"
 )
 
 func dataSourceNatGateway() *schema.Resource {
@@ -105,14 +104,13 @@ func dataSourceNatGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 		if natGateways.Items != nil {
 			for _, c := range *natGateways.Items {
 				if c.Properties.Name != nil {
-					tmpNatGateway, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysFindByNatGatewayId(ctx, datacenterId.(string), *c.Id).Execute()
-					logApiRequestTime(apiResponse)
-					if err != nil {
-						return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway with ID %s: %s", *c.Id, err.Error()))
-					}
-					if strings.Contains(*tmpNatGateway.Properties.Name, name.(string)) {
-						natGateway = tmpNatGateway
-						results = append(results, natGateway)
+					if *c.Properties.Name == name.(string) {
+						tmpNatGateway, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysFindByNatGatewayId(ctx, datacenterId.(string), *c.Id).Execute()
+						logApiRequestTime(apiResponse)
+						if err != nil {
+							return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway with ID %s: %s", *c.Id, err.Error()))
+						}
+						results = append(results, tmpNatGateway)
 					}
 				}
 

--- a/ionoscloud/data_source_natgateway_rule.go
+++ b/ionoscloud/data_source_natgateway_rule.go
@@ -134,12 +134,12 @@ func dataSourceNatGatewayRuleRead(ctx context.Context, d *schema.ResourceData, m
 
 		var results []ionoscloud.NatGatewayRule
 		if natGatewayRules.Items != nil {
-			for _, c := range *natGatewayRules.Items {
-				if c.Properties.Name != nil && *c.Properties.Name == name.(string) {
-					tmpNatGatewayRule, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysRulesFindByNatGatewayRuleId(ctx, datacenterId.(string), natgatewayId.(string), *c.Id).Execute()
+			for _, ngr := range *natGatewayRules.Items {
+				if ngr.Properties != nil && ngr.Properties.Name != nil && *ngr.Properties.Name == name.(string) {
+					tmpNatGatewayRule, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysRulesFindByNatGatewayRuleId(ctx, datacenterId.(string), natgatewayId.(string), *ngr.Id).Execute()
 					logApiRequestTime(apiResponse)
 					if err != nil {
-						return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway rule with ID %s: %s", *c.Id, err.Error()))
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway rule with ID %s: %s", *ngr.Id, err.Error()))
 					}
 					results = append(results, tmpNatGatewayRule)
 				}

--- a/ionoscloud/data_source_natgateway_rule.go
+++ b/ionoscloud/data_source_natgateway_rule.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
-	"log"
 )
 
 func dataSourceNatGatewayRule() *schema.Resource {
@@ -116,12 +115,6 @@ func dataSourceNatGatewayRuleRead(ctx context.Context, d *schema.ResourceData, m
 	var err error
 	var apiResponse *ionoscloud.APIResponse
 
-	ctx, cancel := context.WithTimeout(context.Background(), *resourceDefaultTimeouts.Default)
-
-	if cancel != nil {
-		defer cancel()
-	}
-
 	if idOk {
 		/* search by ID */
 		natGatewayRule, apiResponse, err = client.NATGatewaysApi.DatacentersNatgatewaysRulesFindByNatGatewayRuleId(ctx, datacenterId.(string), natgatewayId.(string), id.(string)).Execute()
@@ -131,18 +124,37 @@ func dataSourceNatGatewayRuleRead(ctx context.Context, d *schema.ResourceData, m
 		}
 	} else {
 		/* search by name */
-		natGatewayRules, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysRulesGet(ctx, datacenterId.(string), natgatewayId.(string)).Depth(1).Filter("name", name.(string)).Execute()
+		var natGatewayRules ionoscloud.NatGatewayRules
+
+		natGatewayRules, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysRulesGet(ctx, datacenterId.(string), natgatewayId.(string)).Execute()
 		logApiRequestTime(apiResponse)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway rules: %s", err.Error()))
 		}
 
-		if natGatewayRules.Items != nil && len(*natGatewayRules.Items) > 0 {
-			natGatewayRule = (*natGatewayRules.Items)[len(*natGatewayRules.Items)-1]
-			log.Printf("[WARN] %v nat gateway rules found matching the search criteria. Getting the latest nat gateway rule from the list %v", len(*natGatewayRules.Items), *natGatewayRule.Id)
-		} else {
-			return diag.FromErr(fmt.Errorf("no nat gateway rule found with the specified name %s", name.(string)))
+		var results []ionoscloud.NatGatewayRule
+		if natGatewayRules.Items != nil {
+			for _, c := range *natGatewayRules.Items {
+				tmpNatGatewayRule, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysRulesFindByNatGatewayRuleId(ctx, datacenterId.(string), natgatewayId.(string), *c.Id).Execute()
+				logApiRequestTime(apiResponse)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway rule with ID %s: %s", *c.Id, err.Error()))
+				}
+				if tmpNatGatewayRule.Properties.Name != nil && *tmpNatGatewayRule.Properties.Name == name.(string) {
+					results = append(results, tmpNatGatewayRule)
+				}
+
+			}
 		}
+
+		if results == nil || len(results) == 0 {
+			return diag.FromErr(fmt.Errorf("no nat gateway rule found with the specified criteria: name = %s", name.(string)))
+		} else if len(results) > 1 {
+			return diag.FromErr(fmt.Errorf("more than one nat gateway rule found with the specified criteria: name = %s", name.(string)))
+		} else {
+			natGatewayRule = results[0]
+		}
+
 	}
 
 	if err = setNatGatewayRuleData(d, &natGatewayRule); err != nil {

--- a/ionoscloud/data_source_natgateway_rule.go
+++ b/ionoscloud/data_source_natgateway_rule.go
@@ -134,13 +134,13 @@ func dataSourceNatGatewayRuleRead(ctx context.Context, d *schema.ResourceData, m
 
 		var results []ionoscloud.NatGatewayRule
 		if natGatewayRules.Items != nil {
-			for _, ngr := range *natGatewayRules.Items {
-				if ngr.Properties != nil && ngr.Properties.Name != nil && *ngr.Properties.Name == name.(string) {
-					tmpNatGatewayRule, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysRulesFindByNatGatewayRuleId(ctx, datacenterId.(string), natgatewayId.(string), *ngr.Id).Execute()
-					logApiRequestTime(apiResponse)
-					if err != nil {
-						return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway rule with ID %s: %s", *ngr.Id, err.Error()))
-					}
+			for _, c := range *natGatewayRules.Items {
+				tmpNatGatewayRule, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysRulesFindByNatGatewayRuleId(ctx, datacenterId.(string), natgatewayId.(string), *c.Id).Execute()
+				logApiRequestTime(apiResponse)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway rule with ID %s: %s", *c.Id, err.Error()))
+				}
+				if tmpNatGatewayRule.Properties != nil && tmpNatGatewayRule.Properties.Name != nil && *tmpNatGatewayRule.Properties.Name == name.(string) {
 					results = append(results, tmpNatGatewayRule)
 				}
 

--- a/ionoscloud/data_source_natgateway_rule.go
+++ b/ionoscloud/data_source_natgateway_rule.go
@@ -135,12 +135,12 @@ func dataSourceNatGatewayRuleRead(ctx context.Context, d *schema.ResourceData, m
 		var results []ionoscloud.NatGatewayRule
 		if natGatewayRules.Items != nil {
 			for _, c := range *natGatewayRules.Items {
-				tmpNatGatewayRule, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysRulesFindByNatGatewayRuleId(ctx, datacenterId.(string), natgatewayId.(string), *c.Id).Execute()
-				logApiRequestTime(apiResponse)
-				if err != nil {
-					return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway rule with ID %s: %s", *c.Id, err.Error()))
-				}
-				if tmpNatGatewayRule.Properties.Name != nil && *tmpNatGatewayRule.Properties.Name == name.(string) {
+				if c.Properties.Name != nil && *c.Properties.Name == name.(string) {
+					tmpNatGatewayRule, apiResponse, err := client.NATGatewaysApi.DatacentersNatgatewaysRulesFindByNatGatewayRuleId(ctx, datacenterId.(string), natgatewayId.(string), *c.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching nat gateway rule with ID %s: %s", *c.Id, err.Error()))
+					}
 					results = append(results, tmpNatGatewayRule)
 				}
 

--- a/ionoscloud/data_source_networkloadbalancer.go
+++ b/ionoscloud/data_source_networkloadbalancer.go
@@ -101,12 +101,12 @@ func dataSourceNetworkLoadBalancerRead(ctx context.Context, d *schema.ResourceDa
 
 		var results []ionoscloud.NetworkLoadBalancer
 		if networkLoadBalancers.Items != nil {
-			for _, c := range *networkLoadBalancers.Items {
-				if c.Properties.Name != nil && *c.Properties.Name == name.(string) {
-					tmpNetworkLoadBalancer, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersFindByNetworkLoadBalancerId(ctx, datacenterId.(string), *c.Id).Execute()
+			for _, nlb := range *networkLoadBalancers.Items {
+				if nlb.Properties != nil && nlb.Properties.Name != nil && *nlb.Properties.Name == name.(string) {
+					tmpNetworkLoadBalancer, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersFindByNetworkLoadBalancerId(ctx, datacenterId.(string), *nlb.Id).Execute()
 					logApiRequestTime(apiResponse)
 					if err != nil {
-						return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer with ID %s: %s", *c.Id, err.Error()))
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer with ID %s: %s", *nlb.Id, err.Error()))
 					}
 					results = append(results, tmpNetworkLoadBalancer)
 				}

--- a/ionoscloud/data_source_networkloadbalancer.go
+++ b/ionoscloud/data_source_networkloadbalancer.go
@@ -101,13 +101,13 @@ func dataSourceNetworkLoadBalancerRead(ctx context.Context, d *schema.ResourceDa
 
 		var results []ionoscloud.NetworkLoadBalancer
 		if networkLoadBalancers.Items != nil {
-			for _, nlb := range *networkLoadBalancers.Items {
-				if nlb.Properties != nil && nlb.Properties.Name != nil && *nlb.Properties.Name == name.(string) {
-					tmpNetworkLoadBalancer, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersFindByNetworkLoadBalancerId(ctx, datacenterId.(string), *nlb.Id).Execute()
-					logApiRequestTime(apiResponse)
-					if err != nil {
-						return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer with ID %s: %s", *nlb.Id, err.Error()))
-					}
+			for _, c := range *networkLoadBalancers.Items {
+				tmpNetworkLoadBalancer, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersFindByNetworkLoadBalancerId(ctx, datacenterId.(string), *c.Id).Execute()
+				logApiRequestTime(apiResponse)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer with ID %s: %s", *c.Id, err.Error()))
+				}
+				if tmpNetworkLoadBalancer.Properties != nil && tmpNetworkLoadBalancer.Properties.Name != nil && *tmpNetworkLoadBalancer.Properties.Name == name.(string) {
 					results = append(results, tmpNetworkLoadBalancer)
 				}
 			}

--- a/ionoscloud/data_source_networkloadbalancer.go
+++ b/ionoscloud/data_source_networkloadbalancer.go
@@ -102,12 +102,12 @@ func dataSourceNetworkLoadBalancerRead(ctx context.Context, d *schema.ResourceDa
 		var results []ionoscloud.NetworkLoadBalancer
 		if networkLoadBalancers.Items != nil {
 			for _, c := range *networkLoadBalancers.Items {
-				tmpNetworkLoadBalancer, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersFindByNetworkLoadBalancerId(ctx, datacenterId.(string), *c.Id).Execute()
-				logApiRequestTime(apiResponse)
-				if err != nil {
-					return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer with ID %s: %s", *c.Id, err.Error()))
-				}
-				if tmpNetworkLoadBalancer.Properties.Name != nil && *tmpNetworkLoadBalancer.Properties.Name == name.(string) {
+				if c.Properties.Name != nil && *c.Properties.Name == name.(string) {
+					tmpNetworkLoadBalancer, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersFindByNetworkLoadBalancerId(ctx, datacenterId.(string), *c.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer with ID %s: %s", *c.Id, err.Error()))
+					}
 					results = append(results, tmpNetworkLoadBalancer)
 				}
 			}

--- a/ionoscloud/data_source_networkloadbalancer_forwardingrule.go
+++ b/ionoscloud/data_source_networkloadbalancer_forwardingrule.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
-	"log"
 )
 
 func dataSourceNetworkLoadBalancerForwardingRule() *schema.Resource {
@@ -178,28 +177,34 @@ func dataSourceNetworkLoadBalancerForwardingRuleRead(ctx context.Context, d *sch
 		}
 	} else {
 		/* search by name */
-		networkLoadBalancerForwardingRules, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersForwardingrulesGet(ctx, datacenterId.(string), networkloadbalancerId.(string)).Depth(1).Filter("name", name.(string)).Execute()
+		var networkLoadBalancerForwardingRules ionoscloud.NetworkLoadBalancerForwardingRules
+
+		networkLoadBalancerForwardingRules, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersForwardingrulesGet(ctx, datacenterId.(string), networkloadbalancerId.(string)).Execute()
 		logApiRequestTime(apiResponse)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancers forwarding rules: %s", err.Error()))
 		}
 
-		if networkLoadBalancerForwardingRules.Items != nil && len(*networkLoadBalancerForwardingRules.Items) > 0 {
-			networkLoadBalancerForwardingRule = (*networkLoadBalancerForwardingRules.Items)[len(*networkLoadBalancerForwardingRules.Items)-1]
-			log.Printf("[INFO] %v network load balancers forwarding rules found matching the search criteria. Getting the latest network load balancer forwarding rule from the list %v", len(*networkLoadBalancerForwardingRules.Items), *networkLoadBalancerForwardingRule.Id)
-		} else {
-			return diag.FromErr(fmt.Errorf("no network load balancer forwarding rule found with the specified name %s", name.(string)))
+		var results []ionoscloud.NetworkLoadBalancerForwardingRule
+		if networkLoadBalancerForwardingRules.Items != nil {
+			for _, c := range *networkLoadBalancerForwardingRules.Items {
+				tmpNetworkLoadBalancerForwardingRule, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersForwardingrulesFindByForwardingRuleId(ctx, datacenterId.(string), networkloadbalancerId.(string), *c.Id).Execute()
+				logApiRequestTime(apiResponse)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer forwarding rule with ID %s: %s", *c.Id, err.Error()))
+				}
+				if tmpNetworkLoadBalancerForwardingRule.Properties.Name != nil && *tmpNetworkLoadBalancerForwardingRule.Properties.Name == name.(string) {
+					results = append(results, tmpNetworkLoadBalancerForwardingRule)
+				}
+			}
 		}
 
-	}
-
-	if &networkLoadBalancerForwardingRule == nil {
-		return diag.FromErr(errors.New("network loadbalancer not found"))
-	}
-
-	if networkLoadBalancerForwardingRule.Id != nil {
-		if err := d.Set("id", *networkLoadBalancerForwardingRule.Id); err != nil {
-			return diag.FromErr(err)
+		if results == nil || len(results) == 0 {
+			return diag.FromErr(fmt.Errorf("no network load balancer forwarding rule found with the specified criteria: name = %s", name.(string)))
+		} else if len(results) > 1 {
+			return diag.FromErr(fmt.Errorf("more than one network load balancer forwarding rule found with the specified criteria: name = %s", name.(string)))
+		} else {
+			networkLoadBalancerForwardingRule = results[0]
 		}
 	}
 

--- a/ionoscloud/data_source_networkloadbalancer_forwardingrule.go
+++ b/ionoscloud/data_source_networkloadbalancer_forwardingrule.go
@@ -187,12 +187,12 @@ func dataSourceNetworkLoadBalancerForwardingRuleRead(ctx context.Context, d *sch
 
 		var results []ionoscloud.NetworkLoadBalancerForwardingRule
 		if networkLoadBalancerForwardingRules.Items != nil {
-			for _, c := range *networkLoadBalancerForwardingRules.Items {
-				if c.Properties.Name != nil && *c.Properties.Name == name.(string) {
-					tmpNetworkLoadBalancerForwardingRule, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersForwardingrulesFindByForwardingRuleId(ctx, datacenterId.(string), networkloadbalancerId.(string), *c.Id).Execute()
+			for _, nlbr := range *networkLoadBalancerForwardingRules.Items {
+				if nlbr.Properties != nil && nlbr.Properties.Name != nil && *nlbr.Properties.Name == name.(string) {
+					tmpNetworkLoadBalancerForwardingRule, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersForwardingrulesFindByForwardingRuleId(ctx, datacenterId.(string), networkloadbalancerId.(string), *nlbr.Id).Execute()
 					logApiRequestTime(apiResponse)
 					if err != nil {
-						return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer forwarding rule with ID %s: %s", *c.Id, err.Error()))
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer forwarding rule with ID %s: %s", *nlbr.Id, err.Error()))
 					}
 					results = append(results, tmpNetworkLoadBalancerForwardingRule)
 				}

--- a/ionoscloud/data_source_networkloadbalancer_forwardingrule.go
+++ b/ionoscloud/data_source_networkloadbalancer_forwardingrule.go
@@ -187,13 +187,13 @@ func dataSourceNetworkLoadBalancerForwardingRuleRead(ctx context.Context, d *sch
 
 		var results []ionoscloud.NetworkLoadBalancerForwardingRule
 		if networkLoadBalancerForwardingRules.Items != nil {
-			for _, nlbr := range *networkLoadBalancerForwardingRules.Items {
-				if nlbr.Properties != nil && nlbr.Properties.Name != nil && *nlbr.Properties.Name == name.(string) {
-					tmpNetworkLoadBalancerForwardingRule, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersForwardingrulesFindByForwardingRuleId(ctx, datacenterId.(string), networkloadbalancerId.(string), *nlbr.Id).Execute()
-					logApiRequestTime(apiResponse)
-					if err != nil {
-						return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer forwarding rule with ID %s: %s", *nlbr.Id, err.Error()))
-					}
+			for _, c := range *networkLoadBalancerForwardingRules.Items {
+				tmpNetworkLoadBalancerForwardingRule, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersForwardingrulesFindByForwardingRuleId(ctx, datacenterId.(string), networkloadbalancerId.(string), *c.Id).Execute()
+				logApiRequestTime(apiResponse)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer forwarding rule with ID %s: %s", *c.Id, err.Error()))
+				}
+				if tmpNetworkLoadBalancerForwardingRule.Properties != nil && tmpNetworkLoadBalancerForwardingRule.Properties.Name != nil && *tmpNetworkLoadBalancerForwardingRule.Properties.Name == name.(string) {
 					results = append(results, tmpNetworkLoadBalancerForwardingRule)
 				}
 			}

--- a/ionoscloud/data_source_networkloadbalancer_forwardingrule.go
+++ b/ionoscloud/data_source_networkloadbalancer_forwardingrule.go
@@ -188,12 +188,12 @@ func dataSourceNetworkLoadBalancerForwardingRuleRead(ctx context.Context, d *sch
 		var results []ionoscloud.NetworkLoadBalancerForwardingRule
 		if networkLoadBalancerForwardingRules.Items != nil {
 			for _, c := range *networkLoadBalancerForwardingRules.Items {
-				tmpNetworkLoadBalancerForwardingRule, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersForwardingrulesFindByForwardingRuleId(ctx, datacenterId.(string), networkloadbalancerId.(string), *c.Id).Execute()
-				logApiRequestTime(apiResponse)
-				if err != nil {
-					return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer forwarding rule with ID %s: %s", *c.Id, err.Error()))
-				}
-				if tmpNetworkLoadBalancerForwardingRule.Properties.Name != nil && *tmpNetworkLoadBalancerForwardingRule.Properties.Name == name.(string) {
+				if c.Properties.Name != nil && *c.Properties.Name == name.(string) {
+					tmpNetworkLoadBalancerForwardingRule, apiResponse, err := client.NetworkLoadBalancersApi.DatacentersNetworkloadbalancersForwardingrulesFindByForwardingRuleId(ctx, datacenterId.(string), networkloadbalancerId.(string), *c.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						return diag.FromErr(fmt.Errorf("an error occurred while fetching network loadbalancer forwarding rule with ID %s: %s", *c.Id, err.Error()))
+					}
 					results = append(results, tmpNetworkLoadBalancerForwardingRule)
 				}
 			}

--- a/ionoscloud/data_source_resource.go
+++ b/ionoscloud/data_source_resource.go
@@ -3,6 +3,7 @@ package ionoscloud
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -10,7 +11,7 @@ import (
 
 func dataSourceResource() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceResourceRead,
+		ReadContext: dataSourceResourceRead,
 		Schema: map[string]*schema.Schema{
 			"resource_type": {
 				Type:     schema.TypeString,
@@ -25,7 +26,7 @@ func dataSourceResource() *schema.Resource {
 	}
 }
 
-func dataSourceResourceRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(SdkBundle).CloudApiClient
 
 	var results []ionoscloud.Resource
@@ -42,43 +43,43 @@ func dataSourceResourceRead(d *schema.ResourceData, meta interface{}) error {
 		result, apiResponse, err := client.UserManagementApi.UmResourcesFindByTypeAndId(ctx, resourceType, resourceId).Execute()
 		logApiRequestTime(apiResponse)
 		if err != nil {
-			return fmt.Errorf("an error occured while fetching resource by type %s", err)
+			return diag.FromErr(fmt.Errorf("an error occured while fetching resource by type %s", err))
 		}
 		results = append(results, result)
 
 		err = d.Set("resource_type", result.Type)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		err = d.Set("resource_id", result.Id)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	} else if resourceType != "" {
 		//items, err := client.ListResourcesByType(resource_type)
 		items, apiResponse, err := client.UserManagementApi.UmResourcesFindByType(ctx, resourceType).Execute()
 		logApiRequestTime(apiResponse)
 		if err != nil {
-			return fmt.Errorf("an error occured while fetching resources by type %s", err)
+			return diag.FromErr(fmt.Errorf("an error occured while fetching resources by type %s", err))
 		}
 
 		results = *items.Items
 		err = d.Set("resource_type", results[0].Type)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	} else {
 		//items, err := client.ListResources()
 		items, apiResponse, err := client.UserManagementApi.UmResourcesGet(ctx).Depth(1).Execute()
 		logApiRequestTime(apiResponse)
 		if err != nil {
-			return fmt.Errorf("an error occured while fetching resources %s", err)
+			return diag.FromErr(fmt.Errorf("an error occured while fetching resources %s", err))
 		}
 		results = *items.Items
 	}
 
 	if len(results) == 0 {
-		return fmt.Errorf("there are no resources that match the search criteria")
+		return diag.FromErr(fmt.Errorf("there are no resources that match the search criteria"))
 	}
 
 	d.SetId(*results[0].Id)

--- a/ionoscloud/data_source_snapshot.go
+++ b/ionoscloud/data_source_snapshot.go
@@ -152,7 +152,7 @@ func dataSourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta in
 		if sizeOk {
 			var sizeResults []ionoscloud.Snapshot
 			for _, snp := range results {
-				if *snp.Properties.Size == float32(size.(int)) {
+				if snp.Properties != nil && snp.Properties.Size != nil && *snp.Properties.Size == float32(size.(int)) {
 					sizeResults = append(sizeResults, snp)
 				}
 

--- a/ionoscloud/data_source_template.go
+++ b/ionoscloud/data_source_template.go
@@ -101,7 +101,7 @@ func dataSourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta in
 		if results != nil {
 			var storageSizeResults []ionoscloud.Template
 			for _, tmp := range results {
-				if tmp.Properties.StorageSize != nil && *tmp.Properties.StorageSize == storageSize {
+				if tmp.Properties != nil && tmp.Properties.StorageSize != nil && *tmp.Properties.StorageSize == storageSize {
 					storageSizeResults = append(storageSizeResults, tmp)
 				}
 			}

--- a/ionoscloud/data_source_template_test.go
+++ b/ionoscloud/data_source_template_test.go
@@ -82,7 +82,6 @@ data ` + TemplateResource + ` ` + TemplateTestResource + ` {
 const testAccDataSourceTemplateCores = `
 data ` + TemplateResource + ` ` + TemplateTestResource + ` {
 	cores = 6
-	name = "CUBES XL"
 }`
 
 const testAccDataSourceTemplateRam = `
@@ -93,7 +92,6 @@ data ` + TemplateResource + ` ` + TemplateTestResource + ` {
 const testAccDataSourceTemplateStorageSize = `
 data ` + TemplateResource + ` ` + TemplateTestResource + ` {
 	storage_size = 80
-	cores = 2
 }`
 
 const testAccDataSourceTemplateStorageWrongNameError = `

--- a/ionoscloud/data_source_template_test.go
+++ b/ionoscloud/data_source_template_test.go
@@ -54,7 +54,7 @@ func TestAccDataSourceTemplate(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceTemplateStorageWrongName,
+				Config:      testAccDataSourceTemplateStorageWrongNameError,
 				ExpectError: regexp.MustCompile(`no template found with the specified criteria`),
 			},
 			{
@@ -96,7 +96,7 @@ data ` + TemplateResource + ` ` + TemplateTestResource + ` {
 	cores = 2
 }`
 
-const testAccDataSourceTemplateStorageWrongName = `
+const testAccDataSourceTemplateStorageWrongNameError = `
 data ` + TemplateResource + ` ` + TemplateTestResource + ` {
 	name		 = "CUBES S"
 	cores		 = 6

--- a/ionoscloud/data_source_volume.go
+++ b/ionoscloud/data_source_volume.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
-	"log"
 )
 
 func dataSourceVolume() *schema.Resource {
@@ -142,7 +141,9 @@ func dataSourceVolumeRead(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	} else {
 		/* search by name */
-		volumes, apiResponse, err := client.VolumesApi.DatacentersVolumesGet(ctx, datacenterId.(string)).Depth(1).Filter("name", name.(string)).Execute()
+		var volumes ionoscloud.Volumes
+
+		volumes, apiResponse, err = client.VolumesApi.DatacentersVolumesGet(ctx, datacenterId.(string)).Depth(1).Execute()
 		logApiRequestTime(apiResponse)
 
 		if err != nil {
@@ -150,11 +151,28 @@ func dataSourceVolumeRead(ctx context.Context, d *schema.ResourceData, meta inte
 			return diags
 		}
 
-		if volumes.Items != nil && len(*volumes.Items) > 0 {
-			volume = (*volumes.Items)[len(*volumes.Items)-1]
-			log.Printf("[INFO] %v volumes found matching the search criteria. Getting the latest volume from the list %v", len(*volumes.Items), *volume.Id)
+		var results []ionoscloud.Volume
+		if volumes.Items != nil {
+			for _, v := range *volumes.Items {
+				if v.Properties != nil && v.Properties.Name != nil && *v.Properties.Name == name.(string) {
+					/* volume found */
+					volume, apiResponse, err = client.VolumesApi.DatacentersVolumesFindById(ctx, datacenterId.(string), *v.Id).Execute()
+					logApiRequestTime(apiResponse)
+					if err != nil {
+						diags := diag.FromErr(fmt.Errorf("an error occurred while fetching volume %s: %w", *v.Id, err))
+						return diags
+					}
+					results = append(results, volume)
+				}
+			}
+		}
+
+		if results == nil || len(results) == 0 {
+			return diag.FromErr(fmt.Errorf("no volume found with the specified criteria: name = %s", name.(string)))
+		} else if len(results) > 1 {
+			return diag.FromErr(fmt.Errorf("more than one volume found with the specified criteria: name = %s", name.(string)))
 		} else {
-			return diag.FromErr(fmt.Errorf("no volume found with the specified name %s", name.(string)))
+			volume = results[0]
 		}
 	}
 

--- a/ionoscloud/import_backup_unit_test.go
+++ b/ionoscloud/import_backup_unit_test.go
@@ -1,4 +1,4 @@
-//go:build compute || all || backup_unit
+//go:build all || backup_unit
 
 package ionoscloud
 

--- a/ionoscloud/resource_backup_unit_test.go
+++ b/ionoscloud/resource_backup_unit_test.go
@@ -49,7 +49,7 @@ func TestAccBackupUnitBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceBackupUnitMatchWrongName,
+				Config:      testAccDataSourceBackupUnitMatchWrongNameError,
 				ExpectError: regexp.MustCompile("no backup unit found with the specified name"),
 			},
 			{
@@ -173,7 +173,7 @@ data ` + BackupUnitResource + ` ` + BackupUnitDataSourceByName + ` {
 }
 `
 
-const testAccDataSourceBackupUnitMatchWrongName = testAccCheckBackupUnitConfigBasic + `
+const testAccDataSourceBackupUnitMatchWrongNameError = testAccCheckBackupUnitConfigBasic + `
 data ` + BackupUnitResource + ` ` + BackupUnitDataSourceByName + ` {
   name			= "wrong_name"
 }

--- a/ionoscloud/resource_backup_unit_test.go
+++ b/ionoscloud/resource_backup_unit_test.go
@@ -1,4 +1,4 @@
-//go:build compute || all || backup
+//go:build all || backup
 
 package ionoscloud
 

--- a/ionoscloud/resource_backup_unit_test.go
+++ b/ionoscloud/resource_backup_unit_test.go
@@ -162,6 +162,12 @@ data ` + BackupUnitResource + ` ` + BackupUnitDataSourceById + ` {
 `
 
 const testAccDataSourceBackupUnitMatchName = testAccCheckBackupUnitConfigBasic + `
+resource ` + BackupUnitResource + ` ` + BackupUnitTestResource + `similar {
+	name        = "similar` + BackupUnitTestResource + `"
+	password    = "DemoPassword1234$Updated"
+	email       = "example-updated@ionoscloud.com"
+}
+
 data ` + BackupUnitResource + ` ` + BackupUnitDataSourceByName + ` {
   name			= "` + BackupUnitTestResource + `"
 }

--- a/ionoscloud/resource_datacenter_test.go
+++ b/ionoscloud/resource_datacenter_test.go
@@ -67,15 +67,19 @@ func TestAccDataCenterBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceDatacenterWrongName,
+				Config:      testAccDataSourceDatacenterMultipleResultsError,
+				ExpectError: regexp.MustCompile("more than one datacenter found with the specified criteria"),
+			},
+			{
+				Config:      testAccDataSourceDatacenterWrongNameError,
 				ExpectError: regexp.MustCompile("no datacenter found with the specified criteria"),
 			},
 			{
-				Config:      testAccDataSourceDatacenterWrongLocation,
+				Config:      testAccDataSourceDatacenterWrongLocationError,
 				ExpectError: regexp.MustCompile("no datacenter found with the specified criteria"),
 			},
 			{
-				Config:      testAccDataSourceDatacenterWrongNameAndLocation,
+				Config:      testAccDataSourceDatacenterWrongNameAndLocationError,
 				ExpectError: regexp.MustCompile("no datacenter found with the specified criteria"),
 			},
 			{
@@ -170,13 +174,6 @@ data ` + DatacenterResource + ` ` + DatacenterDataSourceById + ` {
 }`
 
 const testAccDataSourceDatacenterMatchName = testAccCheckDatacenterConfigBasic + `
-resource ` + DatacenterResource + ` ` + DatacenterTestResource + `similar {
-	name       =  "similar` + UpdatedResources + `"
-	location = "us/las"
-	description = "Test Datacenter Description Updated"
-	sec_auth_protection = false
-}
-
 data ` + DatacenterResource + ` ` + DatacenterDataSourceByName + ` {
     name = ` + DatacenterResource + `.` + DatacenterTestResource + `.name
 }`
@@ -187,19 +184,32 @@ data ` + DatacenterResource + ` ` + DatacenterDataSourceMatching + ` {
     location = ` + DatacenterResource + `.` + DatacenterTestResource + `.location
 }`
 
-const testAccDataSourceDatacenterWrongName = testAccCheckDatacenterConfigBasic + `
+const testAccDataSourceDatacenterMultipleResultsError = testAccCheckDatacenterConfigBasic + `
+resource ` + DatacenterResource + ` ` + DatacenterTestResource + `_multiple_results {
+	name       = "` + DatacenterTestResource + `"
+	location = "us/las"
+	description = "Test Datacenter Description Updated"
+	sec_auth_protection = false
+}
+
+data ` + DatacenterResource + ` ` + DatacenterDataSourceMatching + ` {
+    name = ` + DatacenterResource + `.` + DatacenterTestResource + `.name
+    location = ` + DatacenterResource + `.` + DatacenterTestResource + `.location
+}`
+
+const testAccDataSourceDatacenterWrongNameError = testAccCheckDatacenterConfigBasic + `
 data ` + DatacenterResource + ` ` + DatacenterDataSourceMatching + ` {
     name = "wrong_name"
     location = ` + DatacenterResource + `.` + DatacenterTestResource + `.location
 }`
 
-const testAccDataSourceDatacenterWrongLocation = testAccCheckDatacenterConfigBasic + `
+const testAccDataSourceDatacenterWrongLocationError = testAccCheckDatacenterConfigBasic + `
 data ` + DatacenterResource + ` ` + DatacenterDataSourceMatching + ` {
     name = ` + DatacenterResource + `.` + DatacenterTestResource + `.name
     location =  "wrong_location"
 }`
 
-const testAccDataSourceDatacenterWrongNameAndLocation = testAccCheckDatacenterConfigBasic + `
+const testAccDataSourceDatacenterWrongNameAndLocationError = testAccCheckDatacenterConfigBasic + `
 data ` + DatacenterResource + ` ` + DatacenterDataSourceMatching + ` {
     name =  "wrong_name"
     location =  "wrong_location"

--- a/ionoscloud/resource_datacenter_test.go
+++ b/ionoscloud/resource_datacenter_test.go
@@ -148,7 +148,7 @@ func testAccCheckDatacenterExists(n string, datacenter *ionoscloud.Datacenter) r
 			return fmt.Errorf("error occured while fetching DC: %s", rs.Primary.ID)
 		}
 		if *foundDC.Id != rs.Primary.ID {
-			return fmt.Errorf("Record not found")
+			return fmt.Errorf("record not found")
 		}
 		datacenter = &foundDC
 
@@ -170,6 +170,13 @@ data ` + DatacenterResource + ` ` + DatacenterDataSourceById + ` {
 }`
 
 const testAccDataSourceDatacenterMatchName = testAccCheckDatacenterConfigBasic + `
+resource ` + DatacenterResource + ` ` + DatacenterTestResource + `similar {
+	name       =  "similar` + UpdatedResources + `"
+	location = "us/las"
+	description = "Test Datacenter Description Updated"
+	sec_auth_protection = false
+}
+
 data ` + DatacenterResource + ` ` + DatacenterDataSourceByName + ` {
     name = ` + DatacenterResource + `.` + DatacenterTestResource + `.name
 }`

--- a/ionoscloud/resource_dbaas_pgsql_cluster_test.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster_test.go
@@ -86,7 +86,7 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceDBaaSPgSqlClusterWrongName,
+				Config:      testAccDataSourceDBaaSPgSqlClusterWrongNameError,
 				ExpectError: regexp.MustCompile("no DBaaS cluster found with the specified name"),
 			},
 			{
@@ -444,7 +444,7 @@ data ` + DBaaSClusterResource + ` ` + DBaaSClusterTestDataSourceByName + ` {
 }
 `
 
-const testAccDataSourceDBaaSPgSqlClusterWrongName = testAccCheckDbaasPgSqlClusterConfigBasic + `
+const testAccDataSourceDBaaSPgSqlClusterWrongNameError = testAccCheckDbaasPgSqlClusterConfigBasic + `
 data ` + DBaaSClusterResource + ` ` + DBaaSClusterTestDataSourceByName + ` {
   display_name	= "wrong_name"
 }

--- a/ionoscloud/resource_dbaas_pgsql_cluster_test.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	dbaas "github.com/ionos-cloud/sdk-go-dbaas-postgres"
+	"regexp"
 	"testing"
 )
 
@@ -83,6 +84,10 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(DataSource+"."+DBaaSClusterResource+"."+DBaaSClusterTestDataSourceByName, "credentials.username", DBaaSClusterResource+"."+DBaaSClusterTestResource, "credentials.username"),
 					resource.TestCheckResourceAttrPair(DataSource+"."+DBaaSClusterResource+"."+DBaaSClusterTestDataSourceByName, "credentials.password", DBaaSClusterResource+"."+DBaaSClusterTestResource, "credentials.password"),
 				),
+			},
+			{
+				Config:      testAccDataSourceDBaaSPgSqlClusterWrongName,
+				ExpectError: regexp.MustCompile("no DBaaS cluster found with the specified name"),
 			},
 			{
 				Config: testAccDataSourceDbaasPgSqlClusterBackups,
@@ -436,6 +441,12 @@ data ` + DBaaSClusterResource + ` ` + DBaaSClusterTestDataSourceById + ` {
 const testAccDataSourceDBaaSPgSqlClusterMatchName = testAccCheckDbaasPgSqlClusterConfigBasic + `
 data ` + DBaaSClusterResource + ` ` + DBaaSClusterTestDataSourceByName + ` {
   display_name	= "` + DBaaSClusterTestResource + `"
+}
+`
+
+const testAccDataSourceDBaaSPgSqlClusterWrongName = testAccCheckDbaasPgSqlClusterConfigBasic + `
+data ` + DBaaSClusterResource + ` ` + DBaaSClusterTestDataSourceByName + ` {
+  display_name	= "wrong_name"
 }
 `
 

--- a/ionoscloud/resource_firewall_test.go
+++ b/ionoscloud/resource_firewall_test.go
@@ -64,8 +64,12 @@ func TestAccFirewallBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceFirewallWrongName,
-				ExpectError: regexp.MustCompile("no firewall found with the specified name"),
+				Config:      testAccDataSourceFirewallMultipleResultsError,
+				ExpectError: regexp.MustCompile("more than one firewall rule found with the specified criteria name"),
+			},
+			{
+				Config:      testAccDataSourceFirewallWrongNameError,
+				ExpectError: regexp.MustCompile("no firewall rule found with the specified name"),
 			},
 			{
 				Config: testAccCheckFirewallConfigUpdate,
@@ -471,7 +475,30 @@ data ` + FirewallResource + ` ` + FirewallDataSourceByName + ` {
 }
 `
 
-const testAccDataSourceFirewallWrongName = testAccCheckFirewallConfigBasic + `
+const testAccDataSourceFirewallMultipleResultsError = testAccCheckFirewallConfigBasic + `
+resource ` + FirewallResource + ` ` + FirewallTestResource + `_multiple_results  {
+datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  server_id = ` + ServerResource + `.` + ServerTestResource + `.id
+  nic_id = "${ionoscloud_nic.database_nic.id}"
+  protocol = "ICMP"
+  name = "` + FirewallTestResource + `"
+  source_mac = "00:0a:95:9d:68:16"
+  source_ip = ionoscloud_ipblock.ipblock.ips[0]
+  target_ip = ionoscloud_ipblock.ipblock.ips[1]
+  icmp_type = 1
+  icmp_code = 8
+  type = "INGRESS"
+}
+
+data ` + FirewallResource + ` ` + FirewallDataSourceByName + ` {
+  datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  server_id = ` + ServerResource + `.` + ServerTestResource + `.id
+  nic_id = ionoscloud_nic.database_nic.id
+  name	= "` + FirewallTestResource + `"
+}
+`
+
+const testAccDataSourceFirewallWrongNameError = testAccCheckFirewallConfigBasic + `
 data ` + FirewallResource + ` ` + FirewallDataSourceByName + ` {
   datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
   server_id = ` + ServerResource + `.` + ServerTestResource + `.id

--- a/ionoscloud/resource_group_test.go
+++ b/ionoscloud/resource_group_test.go
@@ -208,6 +208,18 @@ data ` + GroupResource + ` ` + GroupDataSourceById + ` {
 `
 
 var testAccDataSourceGroupMatchName = testAccCheckGroupConfigBasic + `
+resource ` + GroupResource + ` ` + GroupTestResource + `similar {
+  name = "similar` + GroupTestResource + `"
+  create_datacenter = true
+  create_snapshot = true
+  reserve_ip = true
+  access_activity_log = true
+  create_pcc = true
+  s3_privilege = true
+  create_backup_unit = true
+  create_internet_access = true
+  create_k8s_cluster = true
+}
 data ` + GroupResource + ` ` + GroupDataSourceByName + ` {
   name			= "` + GroupTestResource + `"
 }

--- a/ionoscloud/resource_group_test.go
+++ b/ionoscloud/resource_group_test.go
@@ -88,7 +88,11 @@ func TestAccGroupBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceGroupWrongName,
+				Config:      testAccDataSourceGroupMultipleResultsError,
+				ExpectError: regexp.MustCompile("more than one group found with the specified criteria"),
+			},
+			{
+				Config:      testAccDataSourceGroupWrongNameError,
 				ExpectError: regexp.MustCompile("no group found with the specified name"),
 			},
 			{
@@ -225,7 +229,26 @@ data ` + GroupResource + ` ` + GroupDataSourceByName + ` {
 }
 `
 
-var testAccDataSourceGroupWrongName = testAccCheckGroupConfigBasic + `
+var testAccDataSourceGroupMultipleResultsError = testAccCheckGroupConfigBasic + `
+resource ` + GroupResource + ` ` + GroupTestResource + `_multiple_results {
+  name = "` + GroupTestResource + `"
+  create_datacenter = true
+  create_snapshot = true
+  reserve_ip = true
+  access_activity_log = true
+  create_pcc = true
+  s3_privilege = true
+  create_backup_unit = true
+  create_internet_access = true
+  create_k8s_cluster = true
+}
+
+data ` + GroupResource + ` ` + GroupDataSourceByName + ` {
+  name			= "` + GroupTestResource + `"
+}
+`
+
+var testAccDataSourceGroupWrongNameError = testAccCheckGroupConfigBasic + `
 data ` + GroupResource + ` ` + GroupDataSourceByName + ` {
   name			= "wrong_name"
 }

--- a/ionoscloud/resource_ipblock_test.go
+++ b/ionoscloud/resource_ipblock_test.go
@@ -70,6 +70,10 @@ func TestAccIPBlockBasic(t *testing.T) {
 				),
 			},
 			{
+				Config:      testAccDataSourceIpBlockMultipleResultsError,
+				ExpectError: regexp.MustCompile(`more than one ip block found with the specified criteria`),
+			},
+			{
 				Config:      testAccDataSourceIpBlockNameError,
 				ExpectError: regexp.MustCompile(`no ip block found with the specified criteria`),
 			},
@@ -199,6 +203,17 @@ data ` + IpBlockResource + ` ` + IpBlockDataSourceMatching + ` {
 }`
 
 const testAccDataSourceIpBlockMatchName = testAccCheckIPBlockConfigBasic + `
+data ` + IpBlockResource + ` ` + IpBlockDataSourceByName + ` { 
+	name = ` + fullIpBlockResourceName + `.name
+}`
+
+const testAccDataSourceIpBlockMultipleResultsError = testAccCheckIPBlockConfigBasic + `
+resource ` + IpBlockResource + ` ` + IpBlockTestResource + `_same_name{
+  location = "` + location + `"
+  size = 2
+  name = ` + fullIpBlockResourceName + `.name
+}
+
 data ` + IpBlockResource + ` ` + IpBlockDataSourceByName + ` { 
 	name = ` + fullIpBlockResourceName + `.name
 }`

--- a/ionoscloud/resource_k8s_node_pool_test.go
+++ b/ionoscloud/resource_k8s_node_pool_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -29,7 +30,7 @@ func TestAccK8sNodePoolBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckK8sNodePoolExists(ResourceNameK8sNodePool, &k8sNodepool),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "name", K8sNodePoolTestResource),
-					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.19.10"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.20.10"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.day_of_the_week", "Monday"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.time", "09:00:00Z"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "auto_scaling.0.min_node_count", "1"),
@@ -104,11 +105,15 @@ func TestAccK8sNodePoolBasic(t *testing.T) {
 				),
 			},
 			{
+				Config:      testAccDataSourceDatacenterWrongNameError,
+				ExpectError: regexp.MustCompile("no nodepool found with the specified name"),
+			},
+			{
 				Config: testAccCheckK8sNodePoolConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckK8sNodePoolExists(ResourceNameK8sNodePool, &k8sNodepool),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "name", K8sNodePoolTestResource),
-					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.19.10"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.20.10"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.day_of_the_week", "Tuesday"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.time", "10:00:00Z"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "auto_scaling.0.min_node_count", "1"),
@@ -146,7 +151,7 @@ func TestAccK8sNodePoolBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckK8sNodePoolExists(ResourceNameK8sNodePool, &k8sNodepool),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "name", K8sNodePoolTestResource),
-					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.20.10"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.21.9"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.day_of_the_week", "Tuesday"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.time", "10:00:00Z"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "auto_scaling.0.min_node_count", "1"),
@@ -182,7 +187,7 @@ func TestAccK8sNodePoolGatewayIP(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckK8sNodePoolExists(ResourceNameK8sNodePool, &k8sNodepool),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "name", K8sNodePoolTestResource),
-					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.19.10"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.20.10"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.day_of_the_week", "Monday"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.time", "09:00:00Z"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "auto_scaling.0.min_node_count", "1"),
@@ -337,7 +342,7 @@ resource ` + IpBlockResource + ` "terraform_acctest" {
 }
 resource ` + K8sClusterResource + ` "terraform_acctest" {
   name        = "terraform_acctest"
-  k8s_version = "1.19.10"
+  k8s_version = "1.20.10"
   maintenance_window {
     day_of_the_week = "Monday"
     time            = "09:00:00Z"
@@ -405,7 +410,7 @@ resource ` + IpBlockResource + ` "terraform_acctest" {
 }
 resource ` + K8sClusterResource + ` "terraform_acctest" {
 	name        = "terraform_acctest"
-	k8s_version = "1.19.14"
+	k8s_version = "1.20.14"
 	maintenance_window {
 		day_of_the_week = "Monday"
 		time            = "09:00:00Z"
@@ -487,7 +492,7 @@ resource ` + IpBlockResource + ` "terraform_acctest" {
 }
 resource ` + K8sClusterResource + ` "terraform_acctest" {
 	name        = "terraform_acctest"
-    k8s_version = "1.20.10"
+    k8s_version = "1.21.9"
 	maintenance_window {
 		day_of_the_week = "Monday"
 		time            = "09:00:00Z"
@@ -535,7 +540,7 @@ resource ` + IpBlockResource + ` "terraform_acctest" {
 }
 resource ` + K8sClusterResource + ` "terraform_acctest" {
   name        = "terraform_acctest"
-  k8s_version = "1.19.10"
+  k8s_version = "1.20.10"
   maintenance_window {
     day_of_the_week = "Monday"
     time            = "09:00:00Z"
@@ -593,6 +598,13 @@ const testAccDataSourceProfitBricksK8sNodePoolMatchName = testAccCheckK8sNodePoo
 data ` + K8sNodePoolResource + ` ` + K8sNodePoolDataSourceByName + ` {
 	k8s_cluster_id 	= ` + K8sClusterResource + `.terraform_acctest.id
 	name			= ` + K8sNodePoolResource + `.` + K8sNodePoolTestResource + `.name
+}
+`
+
+const testAccDataSourceProfitBricksK8sNodePoolWrongNameError = testAccCheckK8sNodePoolConfigBasic + `
+data ` + K8sNodePoolResource + ` ` + K8sNodePoolDataSourceByName + ` {
+	k8s_cluster_id 	= ` + K8sClusterResource + `.terraform_acctest.id
+	name			= "wrong_name"
 }
 `
 

--- a/ionoscloud/resource_lan_test.go
+++ b/ionoscloud/resource_lan_test.go
@@ -52,7 +52,11 @@ func TestAccLanBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceLanWrongName,
+				Config:      testAccDataSourceLanMultipleResultsError,
+				ExpectError: regexp.MustCompile(`more than one lan found with the specified criteria name`),
+			},
+			{
+				Config:      testAccDataSourceLanWrongNameError,
 				ExpectError: regexp.MustCompile(`no lan found with the specified name`),
 			},
 			{
@@ -152,7 +156,20 @@ data ` + LanResource + ` ` + LanDataSourceByName + ` {
 }
 `
 
-const testAccDataSourceLanWrongName = testAccCheckLanConfigBasic + `
+const testAccDataSourceLanMultipleResultsError = testAccCheckLanConfigBasic + `
+resource ` + LanResource + ` ` + LanTestResource + `_multiple_results {
+  datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  public = true
+  name = "` + LanTestResource + `"
+}
+
+data ` + LanResource + ` ` + LanDataSourceByName + ` {
+  datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  name			= "` + LanTestResource + `"
+}
+`
+
+const testAccDataSourceLanWrongNameError = testAccCheckLanConfigBasic + `
 data ` + LanResource + ` ` + LanDataSourceByName + ` {
   datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
   name			= "wrong_name"

--- a/ionoscloud/resource_natgateway_rule_test.go
+++ b/ionoscloud/resource_natgateway_rule_test.go
@@ -43,18 +43,6 @@ func TestAccNatGatewayRuleBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCheckNatGatewayRuleConfigUpdate, UpdatedResources),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "name", UpdatedResources),
-					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "type", "SNAT"),
-					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "protocol", "UDP"),
-					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "source_subnet", "10.3.1.0/24"),
-					resource.TestCheckResourceAttrPair(resourceNatGatewayRuleResource, "public_ip", IpBlockResource+".natgateway_rule_ips", "ips.0"),
-					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "target_subnet", "172.31.0.0/24"),
-					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "target_port_range.0.start", "200"),
-					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "target_port_range.0.end", "1111")),
-			},
-			{
 				Config: fmt.Sprintf(testAccDataSourceNatGatewayRuleMatchId, NatGatewayRuleTestResource),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceIdNatGatewayRuleResource, "name", resourceNatGatewayRuleResource, "name"),
@@ -82,7 +70,19 @@ func TestAccNatGatewayRuleBasic(t *testing.T) {
 			},
 			{
 				Config:      fmt.Sprintf(testAccDataSourceNatGatewayRuleWrongNameError, NatGatewayRuleTestResource),
-				ExpectError: regexp.MustCompile(`no nat gateway found with the specified criteria: name`),
+				ExpectError: regexp.MustCompile(`no nat gateway rule found with the specified criteria: name`),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckNatGatewayRuleConfigUpdate, UpdatedResources),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "name", UpdatedResources),
+					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "type", "SNAT"),
+					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "protocol", "UDP"),
+					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "source_subnet", "10.3.1.0/24"),
+					resource.TestCheckResourceAttrPair(resourceNatGatewayRuleResource, "public_ip", IpBlockResource+".natgateway_rule_ips", "ips.0"),
+					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "target_subnet", "172.31.0.0/24"),
+					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "target_port_range.0.start", "200"),
+					resource.TestCheckResourceAttr(resourceNatGatewayRuleResource, "target_port_range.0.end", "1111")),
 			},
 		},
 	})

--- a/ionoscloud/resource_natgateway_rule_test.go
+++ b/ionoscloud/resource_natgateway_rule_test.go
@@ -81,8 +81,8 @@ func TestAccNatGatewayRuleBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      fmt.Sprintf(testAccDataSourceNatGatewayRuleWrongName, NatGatewayRuleTestResource),
-				ExpectError: regexp.MustCompile(`no nat gateway rule found with the specified name`),
+				Config:      fmt.Sprintf(testAccDataSourceNatGatewayRuleWrongNameError, NatGatewayRuleTestResource),
+				ExpectError: regexp.MustCompile(`no nat gateway found with the specified criteria: name`),
 			},
 		},
 	})
@@ -257,7 +257,7 @@ data ` + NatGatewayRuleResource + ` ` + NatGatewayRuleDataSourceByName + ` {
 }
 `
 
-const testAccDataSourceNatGatewayRuleWrongName = testAccCheckNatGatewayRuleConfigBasic + `
+const testAccDataSourceNatGatewayRuleWrongNameError = testAccCheckNatGatewayRuleConfigBasic + `
 data ` + NatGatewayRuleResource + ` ` + NatGatewayRuleDataSourceByName + ` {
   datacenter_id = ` + DatacenterResource + `.natgateway_rule_datacenter.id
   natgateway_id = ` + NatGatewayResource + `.natgateway.id

--- a/ionoscloud/resource_natgateway_test.go
+++ b/ionoscloud/resource_natgateway_test.go
@@ -57,8 +57,8 @@ func TestAccNatGatewayBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceNatGatewayWrongName,
-				ExpectError: regexp.MustCompile(`no nat gateway found with the specified name`),
+				Config:      testAccDataSourceNatGatewayWrongNameError,
+				ExpectError: regexp.MustCompile(`no nat gateway found with the specified criteria`),
 			},
 			{
 				Config: fmt.Sprintf(testAccCheckNatGatewayConfigUpdate, UpdatedResources),
@@ -217,7 +217,7 @@ data ` + NatGatewayResource + ` ` + NatGatewayDataSourceByName + `  {
 }
 `
 
-const testAccDataSourceNatGatewayWrongName = testAccCheckNatGatewayConfigBasic + `
+const testAccDataSourceNatGatewayWrongNameError = testAccCheckNatGatewayConfigBasic + `
 data ` + NatGatewayResource + ` ` + NatGatewayDataSourceByName + `  {
   datacenter_id = ` + DatacenterResource + `.natgateway_datacenter.id
   name			= "wrong_name"

--- a/ionoscloud/resource_networkloadbalancer_forwardingrule_test.go
+++ b/ionoscloud/resource_networkloadbalancer_forwardingrule_test.go
@@ -97,7 +97,7 @@ func TestAccNetworkLoadBalancerForwardingRuleBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceNetworkLoadBalancerForwardingRuleWrongName,
+				Config:      testAccDataSourceNetworkLoadBalancerForwardingRuleWrongNameError,
 				ExpectError: regexp.MustCompile(`no network load balancer forwarding rule found with the specified name`),
 			},
 			{
@@ -304,7 +304,7 @@ data ` + NetworkLoadBalancerForwardingRuleResource + ` ` + NetworkLoadBalancerFo
 }
 `
 
-const testAccDataSourceNetworkLoadBalancerForwardingRuleWrongName = testAccCheckNetworkLoadBalancerForwardingRuleConfigBasic + `
+const testAccDataSourceNetworkLoadBalancerForwardingRuleWrongNameError = testAccCheckNetworkLoadBalancerForwardingRuleConfigBasic + `
 data ` + NetworkLoadBalancerForwardingRuleResource + ` ` + NetworkLoadBalancerForwardingRuleDataSourceByName + ` {
   datacenter_id = ` + networkLoadBalancerForwardingRuleResource + `.datacenter_id
   networkloadbalancer_id  = ` + networkLoadBalancerForwardingRuleResource + `.networkloadbalancer_id

--- a/ionoscloud/resource_networkloadbalancer_forwardingrule_test.go
+++ b/ionoscloud/resource_networkloadbalancer_forwardingrule_test.go
@@ -98,7 +98,7 @@ func TestAccNetworkLoadBalancerForwardingRuleBasic(t *testing.T) {
 			},
 			{
 				Config:      testAccDataSourceNetworkLoadBalancerForwardingRuleWrongNameError,
-				ExpectError: regexp.MustCompile(`no network load balancer forwarding rule found with the specified name`),
+				ExpectError: regexp.MustCompile(`no network load balancer forwarding rule found with the specified criteria: name`),
 			},
 			{
 				Config: testAccCheckNetworkLoadBalancerForwardingRuleConfigUpdate,

--- a/ionoscloud/resource_networkloadbalancer_test.go
+++ b/ionoscloud/resource_networkloadbalancer_test.go
@@ -73,7 +73,7 @@ func TestAccNetworkLoadBalancerBasic(t *testing.T) {
 			},
 			{
 				Config:      testAccDataSourceNetworkLoadBalancerWrongNameError,
-				ExpectError: regexp.MustCompile(`no network load balancer found with the specified name`),
+				ExpectError: regexp.MustCompile(`no network load balancer found with the specified criteria: name`),
 			},
 			{
 				Config: testAccCheckNetworkLoadBalancerConfigUpdate,

--- a/ionoscloud/resource_networkloadbalancer_test.go
+++ b/ionoscloud/resource_networkloadbalancer_test.go
@@ -72,7 +72,7 @@ func TestAccNetworkLoadBalancerBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceNetworkLoadBalancerWrongName,
+				Config:      testAccDataSourceNetworkLoadBalancerWrongNameError,
 				ExpectError: regexp.MustCompile(`no network load balancer found with the specified name`),
 			},
 			{
@@ -269,7 +269,7 @@ data ` + NetworkLoadBalancerResource + ` ` + NetworkLoadBalancerDataSourceByName
 }
 `
 
-const testAccDataSourceNetworkLoadBalancerWrongName = testAccCheckNetworkLoadBalancerConfigBasic + `
+const testAccDataSourceNetworkLoadBalancerWrongNameError = testAccCheckNetworkLoadBalancerConfigBasic + `
 data ` + NetworkLoadBalancerResource + ` ` + NetworkLoadBalancerDataSourceByName + ` {
   datacenter_id = ` + NetworkLoadBalancerResource + `.` + NetworkLoadBalancerTestResource + `.datacenter_id
   name			= "wrong_name"

--- a/ionoscloud/resource_private_crossconnect_test.go
+++ b/ionoscloud/resource_private_crossconnect_test.go
@@ -50,7 +50,7 @@ func TestAccPrivateCrossConnectBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourcePccWrongName,
+				Config:      testAccDataSourcePccWrongNameError,
 				ExpectError: regexp.MustCompile(`no pcc found with the specified name`),
 			},
 			{
@@ -144,7 +144,7 @@ data ` + PCCResource + ` ` + PCCDataSourceByName + ` {
 }
 `
 
-const testAccDataSourcePccWrongName = testAccCheckPrivateCrossConnectConfigBasic + `
+const testAccDataSourcePccWrongNameError = testAccCheckPrivateCrossConnectConfigBasic + `
 data ` + PCCResource + ` ` + PCCDataSourceByName + ` {
   name			= "wrong_name"
 }

--- a/ionoscloud/resource_private_crossconnect_test.go
+++ b/ionoscloud/resource_private_crossconnect_test.go
@@ -50,8 +50,12 @@ func TestAccPrivateCrossConnectBasic(t *testing.T) {
 				),
 			},
 			{
+				Config:      testAccDataSourcePccMultipleResultsError,
+				ExpectError: regexp.MustCompile(`more than one pcc found with the specified criteria: name`),
+			},
+			{
 				Config:      testAccDataSourcePccWrongNameError,
-				ExpectError: regexp.MustCompile(`no pcc found with the specified name`),
+				ExpectError: regexp.MustCompile(`no pcc found with the specified criteria: name`),
 			},
 			{
 				Config: testAccCheckPrivateCrossConnectConfigUpdate,
@@ -147,5 +151,16 @@ data ` + PCCResource + ` ` + PCCDataSourceByName + ` {
 const testAccDataSourcePccWrongNameError = testAccCheckPrivateCrossConnectConfigBasic + `
 data ` + PCCResource + ` ` + PCCDataSourceByName + ` {
   name			= "wrong_name"
+}
+`
+
+const testAccDataSourcePccMultipleResultsError = testAccCheckPrivateCrossConnectConfigBasic + `
+resource ` + PCCResource + ` ` + PCCTestResource + `_multiple_results {
+  name        = "` + PCCTestResource + `"
+  description = "` + PCCTestResource + `"
+}
+
+data ` + PCCResource + ` ` + PCCDataSourceByName + ` {
+  name			= "` + PCCTestResource + `"
 }
 `

--- a/ionoscloud/resource_server_test.go
+++ b/ionoscloud/resource_server_test.go
@@ -15,6 +15,8 @@ import (
 
 const bootCdromImageId = "83f21679-3321-11eb-a681-1e659523cb7b"
 
+//ToDo: add backup unit back in tests when stable
+
 func TestAccServerBasic(t *testing.T) {
 	var server ionoscloud.Server
 
@@ -40,7 +42,6 @@ func TestAccServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "volume.0.name", "system"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "volume.0.size", "5"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "volume.0.disk_type", "SSD Standard"),
-					resource.TestCheckResourceAttrPair(ServerResource+"."+ServerTestResource, "volume.0.backup_unit_id", BackupUnitResource+"."+BackupUnitTestResource, "id"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "volume.0.bus", "VIRTIO"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "volume.0.availability_zone", "ZONE_1"),
 					resource.TestCheckResourceAttrPair(ServerResource+"."+ServerTestResource, "volume.0.boot_server", ServerResource+"."+ServerTestResource, "id"),
@@ -144,7 +145,6 @@ func TestAccServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "type", "ENTERPRISE"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "volume.0.size", "6"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "volume.0.disk_type", "SSD Standard"),
-					resource.TestCheckResourceAttrPair(ServerResource+"."+ServerTestResource, "volume.0.backup_unit_id", BackupUnitResource+"."+BackupUnitTestResource, "id"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "volume.0.bus", "IDE"),
 					resource.TestCheckResourceAttr(ServerResource+"."+ServerTestResource, "volume.0.availability_zone", "ZONE_1"),
 					resource.TestCheckResourceAttrPair(ServerResource+"."+ServerTestResource, "nic.0.lan", LanResource+"."+LanTestResource, "id"),
@@ -428,7 +428,6 @@ resource ` + DatacenterResource + ` ` + DatacenterTestResource + ` {
 	name       = "server-test"
 	location = "us/las"
 }
-` + testAccCheckBackupUnitConfigBasic + `
 
 resource "ionoscloud_ipblock" "webserver_ipblock" {
   location = ` + DatacenterResource + `.` + DatacenterTestResource + `.location
@@ -460,7 +459,6 @@ resource ` + ServerResource + ` ` + ServerTestResource + ` {
     name = "` + UpdatedResources + `"
     size = 6
     disk_type = "SSD Standard"
-	backup_unit_id = ` + BackupUnitResource + `.` + BackupUnitTestResource + `.id
     user_data = "foo"
     bus = "IDE"
     availability_zone = "ZONE_1"

--- a/ionoscloud/resource_server_test.go
+++ b/ionoscloud/resource_server_test.go
@@ -127,7 +127,7 @@ func TestAccServerBasic(t *testing.T) {
 			},
 			{
 				Config:      testAccDataSourceServerWrongNameError,
-				ExpectError: regexp.MustCompile(`no server found with the specified name`),
+				ExpectError: regexp.MustCompile(`no server found with the specified criteria: name`),
 			},
 			{
 				Config: testAccCheckServerConfigUpdate,

--- a/ionoscloud/resource_server_test.go
+++ b/ionoscloud/resource_server_test.go
@@ -126,7 +126,7 @@ func TestAccServerBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceServerWrongName,
+				Config:      testAccDataSourceServerWrongNameError,
 				ExpectError: regexp.MustCompile(`no server found with the specified name`),
 			},
 			{
@@ -497,7 +497,7 @@ data ` + ServerResource + ` ` + ServerDataSourceByName + ` {
   name			= "` + ServerTestResource + `"
 }
 `
-const testAccDataSourceServerWrongName = testAccCheckServerConfigBasic + `
+const testAccDataSourceServerWrongNameError = testAccCheckServerConfigBasic + `
 data ` + ServerResource + ` ` + ServerDataSourceByName + ` {
   datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
   name			= "wrong_name"

--- a/ionoscloud/resource_snapshot_test.go
+++ b/ionoscloud/resource_snapshot_test.go
@@ -222,5 +222,5 @@ const testAccDataSourceSnapshotWrongSize = testAccCheckSnapshotConfigBasic + `
 data ` + SnapshotResource + ` ` + SnapshotDataSourceByName + ` {
     name = ` + SnapshotResource + `.` + SnapshotTestResource + `.name
     location = ` + SnapshotResource + `.` + SnapshotTestResource + `.location
-    size = 10
+    size = 1234
 }`

--- a/ionoscloud/resource_snapshot_test.go
+++ b/ionoscloud/resource_snapshot_test.go
@@ -94,7 +94,7 @@ func TestAccSnapshotBasic(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccDataSourceSnapshotWrongName,
+				Config:      testAccDataSourceSnapshotWrongNameError,
 				ExpectError: regexp.MustCompile(`no snapshot found with the specified criteria`),
 			},
 			{
@@ -204,7 +204,7 @@ data ` + SnapshotResource + ` ` + SnapshotDataSourceByName + ` {
     size = ` + SnapshotResource + `.` + SnapshotTestResource + `.size
 }`
 
-const testAccDataSourceSnapshotWrongName = testAccCheckSnapshotConfigBasic + `
+const testAccDataSourceSnapshotWrongNameError = testAccCheckSnapshotConfigBasic + `
 data ` + SnapshotResource + ` ` + SnapshotDataSourceByName + ` {
     name = "wrong_name"
     location = ` + SnapshotResource + `.` + SnapshotTestResource + `.location

--- a/ionoscloud/resource_user_test.go
+++ b/ionoscloud/resource_user_test.go
@@ -63,30 +63,30 @@ func TestAccUserBasic(t *testing.T) {
 			},
 			{
 				Config:      testAccDataSourceUserWrongEmail,
-				ExpectError: regexp.MustCompile(`no user found with the specified email`),
+				ExpectError: regexp.MustCompile(`no user found with the specified criteria: email`),
 			},
-			{
-				Config: testAccCheckUserConfigUpdateForceSec,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(UserResource+"."+UserTestResource, &user),
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "first_name", UserTestResource),
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "last_name", UserTestResource),
-					resource.TestCheckResourceAttrSet(UserResource+"."+UserTestResource, "email"),
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "administrator", "true"),
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "force_sec_auth", "false"),
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "active", "true"),
-				),
-			},
-			{
-				Config: testAccCheckUserConfigUpdate,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "first_name", UpdatedResources),
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "last_name", UpdatedResources),
-					resource.TestCheckResourceAttrSet(UserResource+"."+UserTestResource, "email"),
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "administrator", "false"),
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "force_sec_auth", "false"),
-					resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "active", "false")),
-			},
+			//{
+			//	Config: testAccCheckUserConfigUpdateForceSec,
+			//	Check: resource.ComposeTestCheckFunc(
+			//		testAccCheckUserExists(UserResource+"."+UserTestResource, &user),
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "first_name", UserTestResource),
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "last_name", UserTestResource),
+			//		resource.TestCheckResourceAttrSet(UserResource+"."+UserTestResource, "email"),
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "administrator", "true"),
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "force_sec_auth", "false"),
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "active", "true"),
+			//	),
+			//},
+			//{
+			//	Config: testAccCheckUserConfigUpdate,
+			//	Check: resource.ComposeTestCheckFunc(
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "first_name", UpdatedResources),
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "last_name", UpdatedResources),
+			//		resource.TestCheckResourceAttrSet(UserResource+"."+UserTestResource, "email"),
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "administrator", "false"),
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "force_sec_auth", "false"),
+			//		resource.TestCheckResourceAttr(UserResource+"."+UserTestResource, "active", "false")),
+			//},
 		},
 	})
 }
@@ -164,27 +164,27 @@ resource ` + UserResource + ` ` + UserTestResource + ` {
   active  = true
 }`
 
-var testAccCheckUserConfigUpdateForceSec = `
-resource ` + UserResource + ` ` + UserTestResource + ` {
-  first_name = "` + UserTestResource + `"
-  last_name = "` + UserTestResource + `"
-  email = "` + GenerateEmail() + `"
-  password = "abc123-321CBA"
-  administrator = true
-  force_sec_auth= false
-  active  = true
-}`
+//var testAccCheckUserConfigUpdateForceSec = `
+//resource ` + UserResource + ` ` + UserTestResource + ` {
+//  first_name = "` + UserTestResource + `"
+//  last_name = "` + UserTestResource + `"
+//  email = "` + GenerateEmail() + `"
+//  password = "abc123-321CBA"
+//  administrator = true
+//  force_sec_auth= false
+//  active  = true
+//}`
 
-var testAccCheckUserConfigUpdate = `
-resource ` + UserResource + ` ` + UserTestResource + ` {
-  first_name = "` + UpdatedResources + `"
-  last_name = "` + UpdatedResources + `"
-  email = "` + GenerateEmail() + `"
-  password = "abc123-321CBAupdated"
-  administrator = false
-  force_sec_auth= false
-  active  = false
-}`
+//var testAccCheckUserConfigUpdate = `
+//resource ` + UserResource + ` ` + UserTestResource + ` {
+//  first_name = "` + UpdatedResources + `"
+//  last_name = "` + UpdatedResources + `"
+//  email = "` + GenerateEmail() + `"
+//  password = "abc123-321CBAupdated"
+//  administrator = false
+//  force_sec_auth= false
+//  active  = false
+//}`
 
 var testAccDataSourceUserMatchId = testAccCheckUserConfigBasic + `
 data ` + UserResource + ` ` + UserDataSourceById + ` {

--- a/ionoscloud/resource_volume_test.go
+++ b/ionoscloud/resource_volume_test.go
@@ -76,7 +76,7 @@ func TestAccVolumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(DataSource+"."+VolumeResource+"."+VolumeDataSourceByName, "boot_server", ServerResource+"."+ServerTestResource, "id")),
 			},
 			{
-				Config:      testAccDataSourceVolumeWrongName,
+				Config:      testAccDataSourceVolumeWrongNameError,
 				ExpectError: regexp.MustCompile(`no volume found with the specified name`),
 			},
 			{
@@ -298,7 +298,7 @@ data ` + VolumeResource + ` ` + VolumeDataSourceByName + ` {
 }
 `
 
-var testAccDataSourceVolumeWrongName = testAccCheckVolumeConfigBasic + `
+var testAccDataSourceVolumeWrongNameError = testAccCheckVolumeConfigBasic + `
 data ` + VolumeResource + ` ` + VolumeDataSourceByName + ` {
   datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
   name			= "wrong_name"

--- a/ionoscloud/resource_volume_test.go
+++ b/ionoscloud/resource_volume_test.go
@@ -214,7 +214,7 @@ func testAccCheckVolumeExists(n string, volume *ionoscloud.Volume) resource.Test
 	}
 }
 
-const testAccCheckVolumeConfigBasic = testAccCheckLanConfigBasic + testAccCheckBackupUnitConfigBasic + `
+const testAccCheckVolumeConfigBasic = testAccCheckLanConfigBasic + `
 resource ` + ServerResource + ` ` + ServerTestResource + `{
   name = "` + ServerTestResource + `"
   datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
@@ -245,11 +245,10 @@ resource ` + VolumeResource + ` ` + VolumeTestResource + ` {
 	bus = "VIRTIO"
 	image_name ="Debian-10-cloud-init.qcow2"
 	image_password = "K3tTj8G14a3EgKyNeeiY"
-	backup_unit_id = ` + BackupUnitResource + `.` + BackupUnitTestResource + `.id
 	user_data = "foo"
 }`
 
-const testAccCheckVolumeConfigUpdate = testAccCheckBackupUnitConfigBasic + testAccCheckLanConfigBasic + `
+const testAccCheckVolumeConfigUpdate = testAccCheckLanConfigBasic + `
 resource ` + ServerResource + ` ` + ServerTestResource + `updated {
   name = "` + ServerTestResource + `"
   datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
@@ -280,7 +279,6 @@ resource ` + VolumeResource + ` ` + VolumeTestResource + ` {
 	bus = "VIRTIO"
 	image_name ="Debian-10-cloud-init.qcow2"
 	image_password = "K3tTj8G14a3EgKyNeeiYupdated"
-	backup_unit_id = ` + BackupUnitResource + `.` + BackupUnitTestResource + `.id
 	user_data = "foo"
 }`
 

--- a/ionoscloud/resource_volume_test.go
+++ b/ionoscloud/resource_volume_test.go
@@ -77,7 +77,7 @@ func TestAccVolumeBasic(t *testing.T) {
 			},
 			{
 				Config:      testAccDataSourceVolumeWrongNameError,
-				ExpectError: regexp.MustCompile(`no volume found with the specified name`),
+				ExpectError: regexp.MustCompile(`no volume found with the specified criteria: name`),
 			},
 			{
 				Config: testAccCheckVolumeConfigUpdate,

--- a/ionoscloud/test_constants.go
+++ b/ionoscloud/test_constants.go
@@ -47,8 +47,6 @@ resource ` + DatacenterResource + ` ` + DatacenterTestResource + ` {
 	name       = "server-test"
 	location = "us/las"
 }
-` + testAccCheckBackupUnitConfigBasic + `
-
 resource "ionoscloud_ipblock" "webserver_ipblock" {
   location = ` + DatacenterResource + `.` + DatacenterTestResource + `.location
   size = 4
@@ -73,7 +71,6 @@ resource ` + ServerResource + ` ` + ServerTestResource + ` {
     name = "system"
     size = 5
     disk_type = "SSD Standard"
-	backup_unit_id = ` + BackupUnitResource + `.` + BackupUnitTestResource + `.id
     user_data = "foo"
     bus = "VIRTIO"
     availability_zone = "ZONE_1"


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
- roll back to the 6.1.3 implementation of data sources - without filters 
- added check on the number of results found by the data sources, in order to send an error to the user if more than one resource is found 

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [x] Jira task updated
