### PR TITLE
doc: Update k8s cluster resource version

### DIFF
--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -16,7 +16,7 @@ Manages a Managed Kubernetes cluster on IonosCloud.
 ```hcl
 resource "ionoscloud_k8s_cluster" "example" {
   name        = "example"
-  k8s_version = "1.18.5"
+  k8s_version = "1.22.6"
   maintenance_window {
     day_of_the_week = "Monday"
     time            = "09:30:00Z"


### PR DESCRIPTION
Tried to use the resource verbatim, got this:

```
│ Error: error creating k8s cluster: 422 Unprocessable Entity {
│   "httpStatus" : 422,
│   "messages" : [ {
│     "errorCode" : "200",
│     "message" : "[VDC-14-1829] Operation cannot be executed because the K8s version 1.18.5 is not viable for cluster. Available versions are [1.20.10, 1.21.4, 1.21.9, 1.22.6]"
│   } ]
│ }
```

So lets update the version in the k8s docs

## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
