### PR TITLE
doc: Update k8s node pool resource version

### DIFF
--- a/docs/resources/k8s_node_pool.md
+++ b/docs/resources/k8s_node_pool.md
@@ -16,7 +16,7 @@ Manages a Kubernetes Node Pool, part of a managed Kubernetes cluster on IonosClo
 ```hcl
 resource "ionoscloud_k8s_node_pool" "demo" {
   name        = demo
-  k8s_version = "1.18.5"
+  k8s_version = "1.21.9"
   auto_scaling {
     min_node_count = 1
     max_node_count = 3


### PR DESCRIPTION
Just tried to use the node pool verbatim from the docs, got:

```
Error: error creating k8s node pool: 422 Unprocessable Entity {
│   "httpStatus" : 422,
│   "messages" : [ {
│     "errorCode" : "200",
│     "message" : "[VDC-14-1830] Operation cannot be executed because the K8s version 1.18.5 is not viable for nodepools in cluster. Available versions are [1.20.10, 1.21.4, 1.21.9]"
│   } ]
│ }
```

So lets update the version

## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
