### PR TITLE
fix: allow_replace field to allow update of immutable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 6.2.1(upcoming release)
 
-### Fixes 
-- adds `allow_replace` to node pool resource, which allows update of immutable node_pool fields by
+### Enhancement 
+- add `allow_replace` to node pool resource, which allows the update of immutable node_pool fields by
 destroying and re-creating the resource. This field should be used with care, understanding the risks.
 
 ## 6.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.2.1(upcoming release)
+
+### Fixes 
+- adds `allow_replace` to node pool resource, which allows update of immutable node_pool fields by
+destroying and re-creating the resource. This field should be used with care, understanding the risks.
+
 ## 6.2.0
 
 ### Enhancement

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please see the [Documentation](docs/index.md#migrating-from-the-profitbricks-pro
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.x
 - [Go](https://golang.org/doc/install) 1.13 (to build the provider plugin)
 
-**NOTE:** In order to use a speciffic version of this provider, please include the following block at the beginning of your terraform config files [details](https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version):
+**NOTE:** In order to use a specific version of this provider, please include the following block at the beginning of your terraform config files [details](https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version):
 
 ```terraform
 provider "ionoscloud" {

--- a/docs/resources/k8s_node_pool.md
+++ b/docs/resources/k8s_node_pool.md
@@ -92,6 +92,11 @@ The following arguments are supported:
 - `labels` - (Optional)[map] A key/value map of labels
 - `annotations` - (Optional)[map] A key/value map of annotations
 - `gateway_ip` - (Optional)[string] Public IP address for the gateway performing source NAT for the node pool's nodes belonging to a private cluster. Required only if the node pool belongs to a private cluster.
+- `allow_replace` - (Optional)[bool] When set to true, allows the update of immutable fields by destroying and re-creating the node pool.
+
+⚠️ **_Warning: `allow_replace` - will let you update immutable fields, but it will destroy and re-create the node pool in order to do it. Set the field to true only if you know what you are doing._**
+
+Immutable fields list: name, cpu_family, availability_zone, cores_count, ram_size, storage_size, storage_type, gateway_ip. 
 
 ## Import
 
@@ -103,4 +108,4 @@ terraform import ionoscloud_k8s_node_pool.demo {k8s_cluster_uuid}/{k8s_nodepool_
 
 This can be helpful when you want to import kubernetes node pools which you have already created manually or using other means, outside of terraform, towards the goal of managing them via Terraform
 
-> :warning: **If you are upgrading from v5.x.x to v6.x.x**: You have to modify you plan for lans to match the new structure, by putting the ids from the old slice in lans.id fields. This is not backwards compatible.
+⚠️ **_Warning: **If you are upgrading from v5.x.x to v6.x.x**: You have to modify you plan for lans to match the new structure, by putting the ids from the old slice in lans.id fields. This is not backwards compatible._**


### PR DESCRIPTION
## What does this fix or implement?

Adds optional field 'allow_replace'(default - false) to nodepool resource to allow the update of immutable fields by deleting and re-creating the resource.
fixes #218

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [X] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
