### PR TITLE
fix: crash in volume resource when using image_alias with no image_password or ssh_key_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - do not allow empty string AvailabilityZone. Only allow "AUTO", "ZONE_1", "ZONE_2", "ZONE_3"
+- solve #266 crash on resource_volume when using image_alias with no image_password, or ssh_key_path
 
 ## 6.2.2
 

--- a/ionoscloud/resource_volume.go
+++ b/ionoscloud/resource_volume.go
@@ -783,7 +783,7 @@ func checkImage(ctx context.Context, client *ionoscloud.APIClient, imageInput, i
 				return image, imageAlias, isSnapshot, diags
 			}
 
-			if imagePassword == "" && len(sshKeyPath) == 0 && isSnapshot == false && img.Properties.Public != nil && *img.Properties.Public {
+			if imagePassword == "" && len(sshKeyPath) == 0 && isSnapshot == false && (img != nil && img.Properties != nil && img.Properties.Public != nil && *img.Properties.Public || imageAlias != "") {
 				diags := diag.FromErr(fmt.Errorf("either 'image_password' or 'ssh_key_path' must be provided"))
 				return image, imageAlias, isSnapshot, diags
 			}

--- a/ionoscloud/resource_volume_test.go
+++ b/ionoscloud/resource_volume_test.go
@@ -24,6 +24,11 @@ func TestAccVolumeBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckVolumeDestroyCheck,
 		Steps: []resource.TestStep{
 			{
+				//added to test - #266. crash when using image_alias on volume
+				Config:      testAccCheckVolumeConfigBasicErrorNoPassOrSSHPath,
+				ExpectError: regexp.MustCompile(`either 'image_password' or 'ssh_key_path' must be provided`),
+			},
+			{
 				Config: testAccCheckVolumeConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(VolumeResource+"."+VolumeTestResource, &volume),
@@ -248,6 +253,41 @@ resource ` + VolumeResource + ` ` + VolumeTestResource + ` {
 	user_data = "foo"
 }`
 
+const testAccCheckVolumeConfigBasicErrorNoPassOrSSHPath = testAccCheckLanConfigBasic + `
+resource ` + ServerResource + ` ` + ServerTestResource + `{
+  name = "` + ServerTestResource + `"
+  datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  cores = 1
+  ram = 1024
+  availability_zone = "ZONE_1"
+  cpu_family = "AMD_OPTERON"
+  image_name = "ubuntu:latest"
+  image_password = "K3tTj8G14a3EgKyNeeiY"
+  volume {
+    name = "system"
+    size = 5
+    disk_type = "HDD"
+  }
+  nic {
+    lan = ` + LanResource + `.` + LanTestResource + `.id
+    dhcp = true
+    firewall_active = true
+  }
+}
+resource ` + VolumeResource + ` ` + VolumeTestResource + ` {
+	datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+	server_id = ` + ServerResource + `.` + ServerTestResource + `.id
+	availability_zone = "ZONE_1"
+	name = "` + VolumeTestResource + `"
+	size = 5
+	disk_type = "SSD Standard"
+	bus = "VIRTIO"
+	image_name ="ubuntu:latest"
+	user_data = "foo"
+
+}`
+
+//ubuntu-21.10-server-cloudimg-amd64-20220201
 const testAccCheckVolumeConfigUpdate = testAccCheckLanConfigBasic + `
 resource ` + ServerResource + ` ` + ServerTestResource + `updated {
   name = "` + ServerTestResource + `"


### PR DESCRIPTION


## What does this fix or implement?

Fixes crash on resource volume when using image_alias, without image_password and ssh_key_path.
Shows ssh_key_path or image_password error also for image_alias.
## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
