### PR TITLE
fix: fixed crash when trying to disable autoscaling on k8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 ### Enhancement
 - update sdk-go dependency to v6.0.3. 
   * enable certificate pinning, by setting IONOS_PINNED_CERT env variable
-  * temporarily remove `gateway_ip` and `public` fields for k8s
+- temporarily removed `gateway_ip` and `public` fields for k8s
+- introduced error when trying to set `max_node_count` equal to `min_node_count` in `k8s_node_pool`
+
+### Fixes 
+- fixed crash when trying to disable `autoscaling` on `k8s_node_pool`
 
 ## 6.2.4
 ### Fixes

--- a/ionoscloud/resource_k8s_node_pool.go
+++ b/ionoscloud/resource_k8s_node_pool.go
@@ -390,6 +390,32 @@ func getLanResourceData(lansList *schema.Set) []ionoscloud.KubernetesNodePoolLan
 	}
 	return lans
 }
+
+func getAutoscalingData(d *schema.ResourceData) (*ionoscloud.KubernetesAutoScaling, error) {
+	var autoscaling ionoscloud.KubernetesAutoScaling
+
+	asmnVal, asmnOk := d.GetOk("auto_scaling.0.min_node_count")
+	asmxnVal, asmxnOk := d.GetOk("auto_scaling.0.max_node_count")
+
+	if asmnOk && asmxnOk {
+		asmnVal := int32(asmnVal.(int))
+		asmxnVal := int32(asmxnVal.(int))
+		if asmnVal == asmxnVal {
+			return &autoscaling, fmt.Errorf("error creating k8s node pool: max_node_count cannot be equal to min_node_count")
+		}
+
+		if asmxnVal < asmnVal {
+			return &autoscaling, fmt.Errorf("error creating k8s node pool: max_node_count cannot be lower than min_node_count")
+		}
+
+		log.Printf("[INFO] Setting Autoscaling minimum node count to : %d", asmnVal)
+		autoscaling.MinNodeCount = &asmnVal
+		log.Printf("[INFO] Setting Autoscaling maximum node count to : %d", asmxnVal)
+		autoscaling.MaxNodeCount = &asmxnVal
+	}
+
+	return &autoscaling, nil
+}
 func resourcek8sNodePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(SdkBundle).CloudApiClient
 
@@ -419,40 +445,6 @@ func resourcek8sNodePoolCreate(ctx context.Context, d *schema.ResourceData, meta
 		},
 	}
 
-	if _, asOk := d.GetOk("auto_scaling.0"); asOk {
-		k8sNodepool.Properties.AutoScaling = &ionoscloud.KubernetesAutoScaling{}
-	}
-
-	if asmnVal, asmnOk := d.GetOk("auto_scaling.0.min_node_count"); asmnOk {
-		log.Printf("[INFO] Setting Autoscaling minimum node count to : %d", uint32(asmnVal.(int)))
-		asmnVal := int32(asmnVal.(int))
-		k8sNodepool.Properties.AutoScaling.MinNodeCount = &asmnVal
-	}
-
-	if asmxnVal, asmxnOk := d.GetOk("auto_scaling.0.max_node_count"); asmxnOk {
-		log.Printf("[INFO] Setting Autoscaling maximum node count to : %d", uint32(asmxnVal.(int)))
-		asmxnVal := int32(asmxnVal.(int))
-		k8sNodepool.Properties.AutoScaling.MaxNodeCount = &asmxnVal
-	}
-
-	if k8sNodepool.Properties.AutoScaling != nil && k8sNodepool.Properties.AutoScaling.MinNodeCount != nil &&
-		k8sNodepool.Properties.AutoScaling.MaxNodeCount != nil && *k8sNodepool.Properties.AutoScaling.MinNodeCount != 0 &&
-		*k8sNodepool.Properties.AutoScaling.MaxNodeCount != 0 && *k8sNodepool.Properties.AutoScaling.MinNodeCount != *k8sNodepool.Properties.AutoScaling.MaxNodeCount {
-		log.Printf("[INFO] Autoscaling is on, doing some extra checks for k8s node pool")
-
-		if *k8sNodepool.Properties.NodeCount < *k8sNodepool.Properties.AutoScaling.MinNodeCount {
-			d.SetId("")
-			diags := diag.FromErr(fmt.Errorf("error creating k8s node pool: node_count cannot be lower than min_node_count"))
-			return diags
-		}
-
-		if *k8sNodepool.Properties.AutoScaling.MaxNodeCount < *k8sNodepool.Properties.AutoScaling.MinNodeCount {
-			d.SetId("")
-			diags := diag.FromErr(fmt.Errorf("error creating k8s node pool: max_node_count cannot be lower than min_node_count"))
-			return diags
-		}
-	}
-
 	if _, mwOk := d.GetOk("maintenance_window.0"); mwOk {
 		k8sNodepool.Properties.MaintenanceWindow = &ionoscloud.KubernetesMaintenanceWindow{}
 	}
@@ -466,6 +458,18 @@ func resourcek8sNodePoolCreate(ctx context.Context, d *schema.ResourceData, meta
 	if mdVal, mdOk := d.GetOk("maintenance_window.0.day_of_the_week"); mdOk {
 		mdVal := mdVal.(string)
 		k8sNodepool.Properties.MaintenanceWindow.DayOfTheWeek = &mdVal
+	}
+
+	if autoscaling, err := getAutoscalingData(d); err != nil {
+		return diag.FromErr(err)
+	} else {
+		k8sNodepool.Properties.AutoScaling = autoscaling
+	}
+
+	if k8sNodepool.Properties.AutoScaling != nil && k8sNodepool.Properties.AutoScaling.MinNodeCount != nil && *k8sNodepool.Properties.NodeCount < *k8sNodepool.Properties.AutoScaling.MinNodeCount {
+		d.SetId("")
+		diags := diag.FromErr(fmt.Errorf("error creating k8s node pool: node_count cannot be lower than min_node_count"))
+		return diags
 	}
 
 	if lansVal, lansOK := d.GetOk("lans"); lansOK {
@@ -605,47 +609,26 @@ func resourcek8sNodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 		log.Printf("[INFO] k8s pool k8s version changed from %+v to %+v", oldk8sVersion, newk8sVersion)
 	}
 
-	if _, autoScalingOk := d.GetOk("auto_scaling.0"); autoScalingOk {
-		_, newAs := d.GetChange("auto_scaling.0")
-		if newAs.(map[string]interface{}) != nil {
-			minNodeCount := int32(d.Get("auto_scaling.0.min_node_count").(int))
-			maxNodeCount := int32(d.Get("auto_scaling.0.max_node_count").(int))
+	if autoscaling, err := getAutoscalingData(d); err != nil {
+		return diag.FromErr(err)
+	} else {
+		request.Properties.AutoScaling = autoscaling
+	}
 
-			if minNodeCount > maxNodeCount {
-				d.SetId("")
-				diags := diag.FromErr(fmt.Errorf("error updating k8s node pool: max_node_count cannot be lower than min_node_count"))
-				return diags
-			}
+	if request.Properties.AutoScaling != nil && request.Properties.AutoScaling.MinNodeCount != nil && *request.Properties.NodeCount < *request.Properties.AutoScaling.MinNodeCount {
+		d.SetId("")
+		diags := diag.FromErr(fmt.Errorf("error creating k8s node pool: node_count cannot be lower than min_node_count"))
+		return diags
+	}
 
-			if nodeCount < minNodeCount {
-				d.SetId("")
-				diags := diag.FromErr(fmt.Errorf("error updating k8s node pool: node_count cannot be lower than min_node_count"))
-				return diags
-			}
+	if d.HasChange("auto_scaling.0.min_node_count") {
+		oldMinNodes, newMinNodes := d.GetChange("auto_scaling.0.min_node_count")
+		log.Printf("[INFO] k8s node pool autoscaling min # of nodes changed from %+v to %+v", oldMinNodes, newMinNodes)
+	}
 
-			if nodeCount > maxNodeCount {
-				d.SetId("")
-				diags := diag.FromErr(fmt.Errorf("error updating k8s node pool: node_count cannot be greater than max_node_count"))
-				return diags
-			}
-
-			autoScaling := &ionoscloud.KubernetesAutoScaling{
-				MinNodeCount: &minNodeCount,
-				MaxNodeCount: &maxNodeCount,
-			}
-
-			if d.HasChange("auto_scaling.0.min_node_count") {
-				oldMinNodes, newMinNodes := d.GetChange("auto_scaling.0.min_node_count")
-				log.Printf("[INFO] k8s node pool autoscaling min # of nodes changed from %+v to %+v", oldMinNodes, newMinNodes)
-			}
-
-			if d.HasChange("auto_scaling.0.max_node_count") {
-				oldMaxNodes, newMaxNodes := d.GetChange("auto_scaling.0.max_node_count")
-				log.Printf("[INFO] k8s node pool autoscaling max # of nodes changed from %+v to %+v", oldMaxNodes, newMaxNodes)
-			}
-
-			request.Properties.AutoScaling = autoScaling
-		}
+	if d.HasChange("auto_scaling.0.max_node_count") {
+		oldMaxNodes, newMaxNodes := d.GetChange("auto_scaling.0.max_node_count")
+		log.Printf("[INFO] k8s node pool autoscaling max # of nodes changed from %+v to %+v", oldMaxNodes, newMaxNodes)
 	}
 
 	if d.HasChange("lans") {

--- a/ionoscloud/resource_k8s_node_pool_test.go
+++ b/ionoscloud/resource_k8s_node_pool_test.go
@@ -33,8 +33,7 @@ func TestAccK8sNodePoolBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.20.10"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.day_of_the_week", "Monday"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.time", "09:00:00Z"),
-					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "auto_scaling.0.min_node_count", "1"),
-					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "auto_scaling.0.max_node_count", "1"),
+					resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "auto_scaling"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "cpu_family", "INTEL_XEON"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "availability_zone", "AUTO"),
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "storage_type", "SSD"),
@@ -59,8 +58,6 @@ func TestAccK8sNodePoolBasic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolId, "k8s_version", ResourceNameK8sNodePool, "k8s_version"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolId, "maintenance_window.0.day_of_the_week", ResourceNameK8sNodePool, "maintenance_window.0.day_of_the_week"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolId, "maintenance_window.0.time", ResourceNameK8sNodePool, "maintenance_window.0.time"),
-					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolId, "auto_scaling.0.min_node_count", ResourceNameK8sNodePool, "auto_scaling.0.min_node_count"),
-					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolId, "auto_scaling.0.max_node_count", ResourceNameK8sNodePool, "auto_scaling.0.max_node_count"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolId, "cpu_family", ResourceNameK8sNodePool, "cpu_family"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolId, "availability_zone", ResourceNameK8sNodePool, "availability_zone"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolId, "storage_type", ResourceNameK8sNodePool, "storage_type"),
@@ -82,8 +79,6 @@ func TestAccK8sNodePoolBasic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolName, "k8s_version", ResourceNameK8sNodePool, "k8s_version"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolName, "maintenance_window.0.day_of_the_week", ResourceNameK8sNodePool, "maintenance_window.0.day_of_the_week"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolName, "maintenance_window.0.time", ResourceNameK8sNodePool, "maintenance_window.0.time"),
-					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolName, "auto_scaling.0.min_node_count", ResourceNameK8sNodePool, "auto_scaling.0.min_node_count"),
-					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolName, "auto_scaling.0.max_node_count", ResourceNameK8sNodePool, "auto_scaling.0.max_node_count"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolName, "cpu_family", ResourceNameK8sNodePool, "cpu_family"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolName, "availability_zone", ResourceNameK8sNodePool, "availability_zone"),
 					resource.TestCheckResourceAttrPair(DataSourceK8sNodePoolName, "storage_type", ResourceNameK8sNodePool, "storage_type"),
@@ -349,10 +344,6 @@ resource ` + K8sNodePoolResource + ` ` + K8sNodePoolTestResource + ` {
   maintenance_window {
     day_of_the_week = "Monday"
     time            = "09:00:00Z"
-  } 
-  auto_scaling {
-    min_node_count = 1
-    max_node_count = 1
   }
   cpu_family        = "INTEL_XEON"
   availability_zone = "AUTO"

--- a/ionoscloud/resource_k8s_node_pool_test.go
+++ b/ionoscloud/resource_k8s_node_pool_test.go
@@ -139,28 +139,28 @@ func TestAccK8sNodePoolBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "annotations.ann3", "newValue"),
 				),
 			},
-			//{
-			//	Config: testAccCheckK8sNodePoolConfigUpdateAgain,
-			//	Check: resource.ComposeTestCheckFunc(
-			//		testAccCheckK8sNodePoolExists(ResourceNameK8sNodePool, &k8sNodepool),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "name", K8sNodePoolTestResource),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.21.9"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.day_of_the_week", "Tuesday"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.time", "10:00:00Z"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "auto_scaling.0.min_node_count", "1"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "auto_scaling.0.max_node_count", "2"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "cpu_family", "INTEL_XEON"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "availability_zone", "AUTO"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "storage_type", "SSD"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "node_count", "2"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "cores_count", "2"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "ram_size", "2048"),
-			//		resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "storage_size", "40"),
-			//		resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "public_ips"),
-			//		resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "lans"),
-			//		resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "labels"),
-			//		resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "annotations")),
-			//},
+			{
+				Config: testAccCheckK8sNodePoolConfigUpdateAgain,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8sNodePoolExists(ResourceNameK8sNodePool, &k8sNodepool),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "name", K8sNodePoolTestResource),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "k8s_version", "1.21.9"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.day_of_the_week", "Tuesday"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "maintenance_window.0.time", "10:00:00Z"),
+					resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "auto_scaling"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "cpu_family", "INTEL_XEON"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "availability_zone", "AUTO"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "storage_type", "SSD"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "node_count", "2"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "cores_count", "2"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "ram_size", "2048"),
+					resource.TestCheckResourceAttr(ResourceNameK8sNodePool, "storage_size", "40"),
+					//resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "public_ips"),
+					resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "lans"),
+					//resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "labels"),
+					//resource.TestCheckNoResourceAttr(ResourceNameK8sNodePool, "annotations")
+				),
+			},
 		},
 	})
 }
@@ -495,10 +495,6 @@ resource ` + K8sNodePoolResource + ` ` + K8sNodePoolTestResource + ` {
   	k8s_cluster_id    = ` + K8sClusterResource + `.terraform_acctest.id
   	name        = "` + K8sNodePoolTestResource + `"
  	 k8s_version = ` + K8sClusterResource + `.terraform_acctest.k8s_version
- 	 auto_scaling {
- 	 	min_node_count = 1
-		max_node_count = 2
-  }
   maintenance_window {
     day_of_the_week = "Tuesday"
     time            = "10:00:00Z"
@@ -510,9 +506,17 @@ resource ` + K8sNodePoolResource + ` ` + K8sNodePoolTestResource + ` {
   cores_count       = 2
   ram_size          = 2048
   storage_size      = 40
-  public_ips        = []
-  labels = {}
-  annotations = {}
+  public_ips        = [ ionoscloud_ipblock.terraform_acctest.ips[0], ionoscloud_ipblock.terraform_acctest.ips[1], ionoscloud_ipblock.terraform_acctest.ips[2]]
+  labels = {
+    foo = "baz"
+    color = "red"
+    third = "thirdValue"
+  }
+  annotations = {
+    ann1 = "value1Changed"
+    ann2 = "value2Changed"
+    ann3 = "newValue"
+  }
 }`
 const testAccCheckK8sNodePoolConfigGatewayIP = `
 resource ` + DatacenterResource + ` "terraform_acctest" {


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
- introduced error when trying to set `max_node_count` equal to `min_node_count` in `k8s_node_pool`
- fixed crash when trying to disable `autoscaling` on `k8s_node_pool`

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [x] Jira task updated
