### PR TITLE
doc: use https instead of ssh for cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ by doing the following:
 
 Set env variable IONOS_PINNED_CERT=<insert_sha256_public_fingerprint_here>
 
-You can get the sha256 fingerprint most easily form the browser by inspecting the certificate.
+You can get the sha256 fingerprint most easily from the browser by inspecting the certificate.


### PR DESCRIPTION
HTTPS allows read access to the repository without the need to authenticate

## What does this fix or implement?

Cloning via SSH requires users to set up their public ssh key on Github, which might be time consuming if they haven't set up a SSH key yet. If they simply want to use Terraform, they can just clone using HTTPS which doesn't ask for any credentials for cloning/pulling (i.e. "read" operations)

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Documentation updated
