### PR TITLE
refactor: add id to primary nic in server_resource 

### DIFF
--- a/docs/resources/nic.md
+++ b/docs/resources/nic.md
@@ -70,6 +70,7 @@ resource "ionoscloud_nic" "example" {
 - `ips` - (Optional)[list] Collection of IP addresses assigned to a nic. Explicitly assigned public IPs need to come from reserved IP blocks, Passing value null or empty array will assign an IP address automatically.
 - `firewall_active` - (Optional)[Boolean] If this resource is set to true and is nested under a server resource firewall, with open SSH port, resource must be nested under the NIC.
 - `firewall_type` - (Optional) [String] The type of firewall rules that will be allowed on the NIC. If it is not specified it will take the default value INGRESS
+- `id` - (Computed) The ID of the NIC.
 - `mac` - (Computed) The MAC address of the NIC.
 * `device_number`- (Computed) The Logical Unit Number (LUN) of the storage volume. Null if this NIC was created from CloudAPI and no DCD changes were done on the Datacenter.
 * `pci_slot`- (Computed) The PCI slot number of the Nic.

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -245,6 +245,10 @@ func resourceServer() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"mac": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -849,7 +853,7 @@ func resourceServerRead(ctx context.Context, d *schema.ResourceData, meta interf
 		if nic.Properties.Ips != nil && len(*nic.Properties.Ips) > 0 {
 			network["ips"] = *nic.Properties.Ips
 		}
-
+		network["id"] = nic.Id
 		if firewallId, ok := d.GetOk("firewallrule_id"); ok {
 			firewall, apiResponse, err := client.FirewallRulesApi.DatacentersServersNicsFirewallrulesFindById(ctx, dcId, serverId, primarynic.(string), firewallId.(string)).Execute()
 			logApiRequestTime(apiResponse)


### PR DESCRIPTION
## What does this fix or implement?

This pr will add the nic id to the server resource. 

I did not read the documentation properly and wasn't aware of the [primary_nic](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/latest/docs/resources/server#primary_nic) computed value in this resource. 

My suggestion was to access the primary_nic id as follows: 

```hcl
resource "ionoscloud_server" "example" {
  name              = "Server Example"
  datacenter_id     = ionoscloud_datacenter.example.id
  cores             = 1
  ram               = 1024
  availability_zone = "ZONE_1"
  cpu_family        = "AMD_OPTERON"
  image_name        = "Ubuntu-20.04"
  image_password    = "123451231241"
  volume {
    name      = "system"
    size      = 14
    disk_type = "SSD"
  }
  nic {
    name            = "default"
    lan             = "1"
    dhcp            = true
    firewall_active = true
  }
}

resource "ionoscloud_firewall" "example" {
  datacenter_id = ionoscloud_datacenter.example.id
  server_id     = ionoscloud_server.example.id
  nic_id        = ionoscloud_server.example.nic[0].id
  protocol      = "ICMP"
  name          = "Firewall Example"
  source_mac    = "00:0a:95:9d:68:16"
  source_ip     = "1.1.1.1"
  target_ip     = "8.8.8.8"
  icmp_type     = 1
  icmp_code     = 8
  type          = "INGRESS"
  depends_on    = [ionoscloud_server.example]
}
```

This is obviously not possible, because `ionoscloud_server.example.nic[0].id` was never set. 
The resource is probably meant to be used like this:

```hcl 
resource "ionoscloud_firewall" "example" {
  datacenter_id = ionoscloud_datacenter.example.id
  server_id     = ionoscloud_server.example.id
  nic_id        = ionoscloud_server.example.primary_nic
  protocol      = "ICMP"
  name          = "Firewall Example"
  source_mac    = "00:0a:95:9d:68:16"
  source_ip     = "1.1.1.1"
  target_ip     = "8.8.8.8"
  icmp_type     = 1
  icmp_code     = 8
  type          = "INGRESS"
  depends_on    = [ionoscloud_server.example]
}
```

This PR should enable both syntaxes and reduce confusion. 
If you possess another opinion or think this will lead to more confusion or issues, feel free to close this PR 

The only example, using the `primary_nic` I've found is [in the failover documentation](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/latest/docs/resources/ipfailover)


## Checklist
Terraform version: `v1.1.6`
Provider version: `v6.2.1`
<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
