### PR TITLE
fix: snapshot size, location and name should be computed in data source

### DIFF
--- a/ionoscloud/data_source_snapshot.go
+++ b/ionoscloud/data_source_snapshot.go
@@ -20,16 +20,19 @@ func dataSourceSnapshot() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "A name of that resource",
 			},
 			"location": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Location of that image/snapshot",
 			},
 			"size": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "The size of the image in GB",
 			},
 			"description": {


### PR DESCRIPTION
## What does this fix or implement?

You can now use snapshot data source size to reference when creating a server. Before it was not computed, so terraform did could not use it before the resource was created.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
