### PR TITLE
fix: make maintenance window field computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Feature
 - When no argument is provided for user data source, try to get the email from the client configuration
 - Update Ionos Cloud GO SDK v6.1.2. Release notes here [v6.1.2](https://github.com/ionos-cloud/sdk-go/releases/tag/v6.1.2)
+- Refactor server and volume creation code
+- Make maintenance_window computed
 
 ## 6.3.0
 

--- a/docs/resources/k8s_node_pool.md
+++ b/docs/resources/k8s_node_pool.md
@@ -25,6 +25,9 @@ resource "ionoscloud_lan" "example" {
   datacenter_id         = ionoscloud_datacenter.example.id
   public                = false
   name                  = "Lan Example"
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "ionoscloud_ipblock" "example" {
@@ -86,6 +89,7 @@ resource "ionoscloud_k8s_node_pool" "example" {
 }
 
 ```
+**Note:** Set `create_before_destroy` on the lan resource if you want to remove it from the nodepool during an update. This is to ensure that the nodepool is updated before the lan is destroyed.
 
 ## Argument Reference
 

--- a/ionoscloud/resource_k8s_cluster.go
+++ b/ionoscloud/resource_k8s_cluster.go
@@ -41,6 +41,7 @@ func resourcek8sCluster() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "A maintenance window comprise of a day of the week and a time for maintenance to be allowed",
 				Optional:    true,
+				Computed:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## What does this fix or implement?

`Maintenance_window` is now computed.
Updated documentation on how to configure lan when part of a nodepool. Add lifecycle `create_before_destroy` to make sure the order of deletion is first update nodepool and only after delete lan.


## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [X] Documentation updated
- [X] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
