### PR TITLE
fix: retry for 5 minutes on nic not found after creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Increase go version to 1.18
 - Update dependencies to latest versions
 
+### Fixes
+- Reproduces rarely: sometimes the `nic` resource is not found after creation. As a fix we added a retry for 5 minutes to be able to get the NIC. The retry will keep trying if the response 
+is `not found`(404)
+
 ## 6.3.1
 
 ### Feature


### PR DESCRIPTION
## What does this fix or implement?

Reproduced once: after a nic creation, the nic was not found in the api even though we wait until 'Available' state. 
Added a retry that will try for 5 minutes to find the nic and then use that nic to populate the fields.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
