### PR TITLE
fix: crash on update of k8s version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please contact your sales representative or support for more information.
 - Reproduces rarely: sometimes the `nic` resource is not found after creation. As a fix we added a retry for 5 minutes to be able to get the NIC. The retry will keep trying if the response 
 is `not found`(404)
 - Fix cube server creation. Some attributes were not populated - name, boot_cdrom, availability_zone
+- Crash on update of k8s version when we have a value without `.`
 
 ## 6.3.1
 

--- a/ionoscloud/resource_k8s_node_pool.go
+++ b/ionoscloud/resource_k8s_node_pool.go
@@ -35,26 +35,10 @@ func resourceK8sNodePool() *schema.Resource {
 				ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
 			},
 			"k8s_version": {
-				Type:        schema.TypeString,
-				Description: "The desired kubernetes version",
-				Required:    true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					var oldMajor, oldMinor string
-					if old != "" {
-						oldSplit := strings.Split(old, ".")
-						oldMajor = oldSplit[0]
-						oldMinor = oldSplit[1]
-
-						newSplit := strings.Split(new, ".")
-						newMajor := newSplit[0]
-						newMinor := newSplit[1]
-
-						if oldMajor == newMajor && oldMinor == newMinor {
-							return true
-						}
-					}
-					return false
-				},
+				Type:             schema.TypeString,
+				Description:      "The desired kubernetes version",
+				Required:         true,
+				DiffSuppressFunc: DiffBasedOnVersion,
 			},
 			"auto_scaling": {
 				Type:        schema.TypeList,

--- a/ionoscloud/utils.go
+++ b/ionoscloud/utils.go
@@ -30,14 +30,19 @@ func responseBody(resp *ionoscloud.APIResponse) string {
 // DiffBasedOnVersion used for k8 node pool and cluster
 func DiffBasedOnVersion(_, old, new string, _ *schema.ResourceData) bool {
 	var oldMajor, oldMinor string
+	var newMajor, newMinor string
 	if old != "" {
 		oldSplit := strings.Split(old, ".")
-		oldMajor = oldSplit[0]
-		oldMinor = oldSplit[1]
+		if len(oldSplit) > 1 {
+			oldMajor = oldSplit[0]
+			oldMinor = oldSplit[1]
+		}
 
 		newSplit := strings.Split(new, ".")
-		newMajor := newSplit[0]
-		newMinor := newSplit[1]
+		if len(newSplit) > 1 {
+			newMajor = newSplit[0]
+			newMinor = newSplit[1]
+		}
 
 		if oldMajor == newMajor && oldMinor == newMinor {
 			return true


### PR DESCRIPTION
## What does this fix or implement?

Fix crash on update of k8s_version with invalid value - without `.` 

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [X] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
