### PR TITLE
fix: add links to documentation for `cube` and `enterprise` server fi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ is `not found`(404)
 - Fix cube server creation. Some attributes were not populated - name, boot_cdrom, availability_zone
 - Crash on update of k8s version when we have a value without `.`
 
+### Documentation
+- add links to documentation for `cube` and `enterprise` fields
+
 ## 6.3.1
 
 ### Feature

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -46,11 +46,11 @@ The following attributes are returned by the datasource:
 * `template_uuid` - The UUID of the template for creating a CUBE server; the available templates for CUBE servers can be found on the templates resource
 * `id` - The id of that resource
 * `name` - The name of that resource
-* `type` - Server usages: ENTERPRISE or CUBE
+* `type` - Server usages: [ENTERPRISE](https://docs.ionos.com/cloud/compute-engine/virtual-servers/virtual-servers) or [CUBE](https://docs.ionos.com/cloud/compute-engine/virtual-servers/cloud-cubes)
 * `vm_state`- Status of the virtual Machine
 * `datacenter_id` - The id of the datacenter
 * `cores` - The total number of cores for the server
-* `cpu_family` - CPU architecture on which server gets provisione
+* `cpu_family` - CPU architecture on which server gets provisioned; not all CPU architectures are available in all datacenter regions; available CPU architectures can be retrieved from the datacenter resource.
 * `ram` - The amount of memory for the server in MB
 * `availability_zone` - The availability zone in which the server should exist
 * `vm_state` - Status of the virtual Machine

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -131,9 +131,9 @@ resource "ionoscloud_server" "example" {
 - `cores` - (Optional)[integer] Number of server CPU cores.
 - `ram` - (Optional)[integer] The amount of memory for the server in MB.
 - `image_name` - (Optional)[string] The name, ID or alias of the image. May also be a snapshot ID. It is required if `licence_type` is not provided. Attribute is immutable.
-- `availability_zone` - (Optional)[string] The availability zone in which the server should exist. This property is immutable.
+- `availability_zone` - (Optional)[string] The availability zone in which the server should exist. E.g: `AUTO`, `ZONE_1`, `ZONE_2`. This property is immutable.
 - `licence_type` - (Optional)[string] Sets the OS type of the server.
-- `cpu_family` - (Optional)[string] Sets the CPU type. "AMD_OPTERON", "INTEL_XEON" or "INTEL_SKYLAKE".
+- `cpu_family` - (Optional)[string] CPU architecture on which server gets provisioned; not all CPU architectures are available in all datacenter regions; available CPU architectures can be retrieved from the datacenter resource. E.g.: "AMD_OPTERON", "INTEL_XEON" or "INTEL_SKYLAKE".
 - `volume` - (Required) See the [Volume](volume.md) section.
 - `nic` - (Required) See the [Nic](nic.md) section.
 - `boot_volume` - (Computed) The associated boot volume.
@@ -144,7 +144,7 @@ resource "ionoscloud_server" "example" {
 - `firewallrule_id` - (Computed) The associated firewall rule.
 - `ssh_key_path` - (Optional)[list] List of paths to files containing a public SSH key that will be injected into IonosCloud provided Linux images.  Also accepts ssh keys directly. Required for IonosCloud Linux images. Required if `image_password` is not provided.
 - `image_password` - (Optional)[string] Required if `ssh_key_path` is not provided.
-- `type` - (Optional)[string] server usages: ENTERPRISE or CUBE. This property is immutable.
+- `type` - (Optional)[string] Server usages: [ENTERPRISE](https://docs.ionos.com/cloud/compute-engine/virtual-servers/virtual-servers) or [CUBE](https://docs.ionos.com/cloud/compute-engine/virtual-servers/cloud-cubes). This property is immutable.
 
 > **⚠ WARNING** 
 > 

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -68,11 +68,12 @@ func resourceServer() *schema.Resource {
 				Computed: true,
 			},
 			"type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				Description:      "server usages: ENTERPRISE or CUBE",
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"CUBE", "ENTERPRISE"}, true)),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "server usages: ENTERPRISE or CUBE",
+				//to do: add in next release
+				//ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"CUBE", "ENTERPRISE"}, true)),
 				DiffSuppressFunc: utils.DiffToLower,
 			},
 			"boot_image": {

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -68,13 +68,13 @@ func resourceServer() *schema.Resource {
 				Computed: true,
 			},
 			"type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "server usages: ENTERPRISE or CUBE",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				Description:      "server usages: ENTERPRISE or CUBE",
+				DiffSuppressFunc: utils.DiffToLower,
 				//to do: add in next release
 				//ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"CUBE", "ENTERPRISE"}, true)),
-				DiffSuppressFunc: utils.DiffToLower,
 			},
 			"boot_image": {
 				Type:     schema.TypeString,

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -71,6 +71,8 @@ func resourceServer() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
+				Description:      "server usages: ENTERPRISE or CUBE",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"CUBE", "ENTERPRISE"}, true)),
 				DiffSuppressFunc: utils.DiffToLower,
 			},
 			"boot_image": {


### PR DESCRIPTION
…elds

## What does this fix or implement?

Add documentation links for `cube` and `enterprise` fields.

fixes #320 

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [X] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
