### PR TITLE
fix: mongo and psql tests

### DIFF
--- a/ionoscloud/resource_dbaas_mongo_user_test.go
+++ b/ionoscloud/resource_dbaas_mongo_user_test.go
@@ -119,7 +119,7 @@ func testAccCheckMongoUserExists(n string, user *mongo.User) resource.TestCheckF
 var testAccCheckMongoUserConfigBasic = `
 resource ` + DatacenterResource + ` "datacenter_example" {
   name        = "datacenter_example"
-  location    = "de/txl"
+  location    = "de/fra"
   description = "Datacenter for testing dbaas cluster"
 }
 

--- a/ionoscloud/resource_dbaas_mongodb_cluster.go
+++ b/ionoscloud/resource_dbaas_mongodb_cluster.go
@@ -9,6 +9,7 @@ import (
 	dbaasService "github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/dbaas"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -285,7 +286,7 @@ func dbaasMongoClusterReady(ctx context.Context, client *dbaasService.MongoClien
 	if err != nil {
 		return true, fmt.Errorf("error checking dbaas mongo cluster status: %w", err)
 	}
-	return *subjectCluster.Metadata.State == "AVAILABLE", nil
+	return strings.EqualFold(string(*subjectCluster.Metadata.State), utils.Available), nil
 }
 
 func dbaasMongoClusterDeleted(ctx context.Context, client *dbaasService.MongoClient, d *schema.ResourceData) (bool, error) {

--- a/ionoscloud/resource_dbaas_pgsql_cluster_test.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster_test.go
@@ -145,7 +145,7 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(PsqlClusterResource+"."+DBaaSClusterTestResource, "ram", "3072"),
 					resource.TestCheckResourceAttr(PsqlClusterResource+"."+DBaaSClusterTestResource, "storage_size", "3072"),
 					resource.TestCheckResourceAttr(PsqlClusterResource+"."+DBaaSClusterTestResource, "storage_type", "HDD"),
-					resource.TestCheckNoResourceAttr(PsqlClusterResource+"."+DBaaSClusterTestResource, "connections"),
+					resource.TestCheckNoResourceAttr(PsqlClusterResource+"."+DBaaSClusterTestResource, "connections.%"),
 					resource.TestCheckResourceAttrPair(PsqlClusterResource+"."+DBaaSClusterTestResource, "location", DatacenterResource+".datacenter_example_update", "location"),
 					resource.TestCheckResourceAttr(PsqlClusterResource+"."+DBaaSClusterTestResource, "backup_location", "de"),
 					resource.TestCheckResourceAttr(PsqlClusterResource+"."+DBaaSClusterTestResource, "display_name", UpdatedResources),
@@ -168,7 +168,7 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 
 func TestAccDBaaSPgSqlClusterAdditionalParameters(t *testing.T) {
 	var dbaasCluster psql.ClusterResponse
-	t.Skip()
+	//t.Skip()
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/ionoscloud/resource_dbaas_pgsql_cluster_test.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster_test.go
@@ -168,7 +168,7 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 
 func TestAccDBaaSPgSqlClusterAdditionalParameters(t *testing.T) {
 	var dbaasCluster psql.ClusterResponse
-	//t.Skip()
+	t.Skip()
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)


### PR DESCRIPTION
## What does this fix or implement?

de/txl mongo clusters remain busy forever. Using de/fra.
check list does not exist for psql.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [X] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
