### PR TITLE
feat: add new fields for PostgreSQL cluster backup data source

### DIFF
--- a/docs/data-sources/dbaas_pgsql_backups.md
+++ b/docs/data-sources/dbaas_pgsql_backups.md
@@ -35,11 +35,11 @@ The following attributes are returned by the datasource:
 * `cluster_backups` - List of backups.
     * `id` - The unique ID of the resource.
     * `cluster_id` - The unique ID of the cluster
-    * `display_name` - The friendly name of your cluster.
     * `size` - The size of all base backups including the wal size in MB.
     * `location` - The S3 location where the backups will be stored.
     * `version` - The PostgreSQL version this backup was created from.
     * `is_active` - Whether a cluster currently backs up data to this backup.
+    * `earliest_recovery_target_time` - The oldest available timestamp to which you can restore.
     * `type`
     * `metadata` - Metadata of the resource.
         * `created_date` - The ISO 8601 creation timestamp.

--- a/docs/data-sources/dbaas_pgsql_backups.md
+++ b/docs/data-sources/dbaas_pgsql_backups.md
@@ -36,6 +36,10 @@ The following attributes are returned by the datasource:
     * `id` - The unique ID of the resource.
     * `cluster_id` - The unique ID of the cluster
     * `display_name` - The friendly name of your cluster.
+    * `size` - The size of all base backups including the wal size in MB.
+    * `location` - The S3 location where the backups will be stored.
+    * `version` - The PostgreSQL version this backup was created from.
+    * `is_active` - Whether a cluster currently backs up data to this backup.
     * `type`
     * `metadata` - Metadata of the resource.
         * `created_date` - The ISO 8601 creation timestamp.

--- a/docs/data-sources/dbaas_pgsql_backups.md
+++ b/docs/data-sources/dbaas_pgsql_backups.md
@@ -48,3 +48,5 @@ The following attributes are returned by the datasource:
         * `last_modified_date` - The ISO 8601 modified timestamp.
         * `last_modified_by`
         * `last_modified_by_user_id`
+
+**NOTE:** If the `earliestRecoveryTargetTime` is missing in your backup, the cluster from where you want to restore wasn't able to do a base backup. This can happen, when you e.g. quickly delete a newly created cluster, since the base backup will be triggered up to a minute after the cluster is available.

--- a/ionoscloud/data_source_dbaas_pgsql_backups.go
+++ b/ionoscloud/data_source_dbaas_pgsql_backups.go
@@ -56,6 +56,11 @@ func dataSourceDbaasPgSqlBackups() *schema.Resource {
 							Description: "Whether a cluster currently backs up data to this backup.",
 							Computed:    true,
 						},
+						"earliest_recovery_target_time": {
+							Type:        schema.TypeString,
+							Description: "The oldest available timestamp to which you can restore.",
+							Computed:    true,
+						},
 						"metadata": {
 							Type:        schema.TypeList,
 							Description: "Metadata of the resource",

--- a/ionoscloud/data_source_dbaas_pgsql_backups.go
+++ b/ionoscloud/data_source_dbaas_pgsql_backups.go
@@ -36,6 +36,26 @@ func dataSourceDbaasPgSqlBackups() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"size": {
+							Type:        schema.TypeInt,
+							Description: "Size of all base backups including the wal size in MB.",
+							Computed:    true,
+						},
+						"location": {
+							Type:        schema.TypeString,
+							Description: "The S3 location where the backups will be stored.",
+							Computed:    true,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Description: "The PostgreSQL version this backup was created from.",
+							Computed:    true,
+						},
+						"is_active": {
+							Type:        schema.TypeBool,
+							Description: "Whether a cluster currently backs up data to this backup.",
+							Computed:    true,
+						},
 						"metadata": {
 							Type:        schema.TypeList,
 							Description: "Metadata of the resource",

--- a/ionoscloud/resource_dbaas_pgsql_cluster_test.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster_test.go
@@ -97,6 +97,11 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 				Config: testAccDataSourceDbaasPgSqlClusterBackups,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.cluster_id", DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_id"),
+					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.size"),
+					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.location"),
+					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.version"),
+					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.is_active"),
+					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.earliest_recovery_target_time"),
 					utils.TestNotEmptySlice(PsqlBackupsResource, "cluster_backups.#"),
 				),
 			},

--- a/ionoscloud/resource_dbaas_pgsql_cluster_test.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster_test.go
@@ -101,7 +101,6 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.location"),
 					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.version"),
 					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.is_active"),
-					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.earliest_recovery_target_time"),
 					utils.TestNotEmptySlice(PsqlBackupsResource, "cluster_backups.#"),
 				),
 			},

--- a/services/dbaas/backups.go
+++ b/services/dbaas/backups.go
@@ -45,6 +45,10 @@ func SetPgSqlClusterBackupData(d *schema.ResourceData, clusterBackups *dbaas.Clu
 				backupEntry["id"] = *backup.Id
 			}
 
+			if backup.Properties == nil {
+				return diag.FromErr(fmt.Errorf("backup properties do not exist."))
+			}
+
 			if backup.Properties.ClusterId != nil {
 				backupEntry["cluster_id"] = *backup.Properties.ClusterId
 			}

--- a/services/dbaas/backups.go
+++ b/services/dbaas/backups.go
@@ -65,6 +65,10 @@ func SetPgSqlClusterBackupData(d *schema.ResourceData, clusterBackups *dbaas.Clu
 				backupEntry["is_active"] = *backup.Properties.IsActive
 			}
 
+			if backup.Properties.EarliestRecoveryTargetTime != nil {
+				backupEntry["earliest_recovery_target_time"] = (*backup.Properties.EarliestRecoveryTargetTime).String()
+			}
+
 			if backup.Type != nil {
 				backupEntry["type"] = *backup.Type
 			}

--- a/services/dbaas/backups.go
+++ b/services/dbaas/backups.go
@@ -49,6 +49,22 @@ func SetPgSqlClusterBackupData(d *schema.ResourceData, clusterBackups *dbaas.Clu
 				backupEntry["cluster_id"] = *backup.Properties.ClusterId
 			}
 
+			if backup.Properties.Size != nil {
+				backupEntry["size"] = *backup.Properties.Size
+			}
+
+			if backup.Properties.Location != nil {
+				backupEntry["location"] = *backup.Properties.Location
+			}
+
+			if backup.Properties.Version != nil {
+				backupEntry["version"] = *backup.Properties.Version
+			}
+
+			if backup.Properties.IsActive != nil {
+				backupEntry["is_active"] = *backup.Properties.IsActive
+			}
+
 			if backup.Type != nil {
 				backupEntry["type"] = *backup.Type
 			}


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Add `size` and `location` fields from v1.0.4 DBaaS PSQL release, but also other fields that were missing.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [x] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [x] Jira task updated
