### PR TITLE
fix: change the way in which we set the NIC data

### DIFF
--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -1351,9 +1351,12 @@ func setResourceServerData(ctx context.Context, client *ionoscloud.APIClient, d 
 	if primaryNicOk {
 		nicId = d.Get("primary_nic").(string)
 	} else if server.Entities.Nics != nil && server.Entities.Nics.Items != nil && len(*server.Entities.Nics.Items) > 0 && (*server.Entities.Nics.Items)[0].Id != nil {
-		// this might be a terraformer import, so primary_nic might not be set
-		// if no nics found until now, get the first one from entities
-		nicId = *(*server.Entities.Nics.Items)[0].Id
+		lastNicIndex := len(*server.Entities.Nics.Items) - 1
+		if (*server.Entities.Nics.Items)[lastNicIndex].Id != nil {
+			// this might be a terraformer import, so primary_nic might not be set
+			// if no nics found until now, get the last one from the list of nics.
+			nicId = *(*server.Entities.Nics.Items)[lastNicIndex].Id
+		}
 	}
 
 	nic, apiResponse, err := client.NetworkInterfacesApi.DatacentersServersNicsFindById(ctx, datacenterId, d.Id(), nicId).Depth(1).Execute()


### PR DESCRIPTION
## What does this fix or implement?

When setting the `NIC` for a specific server, if no `primary_nic` is found, select the last `NIC` from the list of `NICs` instead of the first one.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
