### PR TITLE
fix: make viable_node_pool_versions only computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Fixes
  - Fix mongo user tests to check for cluster state instead of user state which was removed
  - Fixes creating share resource edit and share privileges mix up
+ - `viable_node_pool_versions`  in k8s cluster is no longer optional, is only computed
 
 ## 6.3.3
 ### Feature

--- a/ionoscloud/resource_dbaas_pgsql_cluster.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster.go
@@ -25,16 +25,16 @@ func resourceDbaasPgSqlCluster() *schema.Resource {
 		CustomizeDiff: checkDBaaSClusterImmutableFields,
 		Schema: map[string]*schema.Schema{
 			"postgres_version": {
-				Type:         schema.TypeString,
-				Description:  "The PostgreSQL version of your cluster.",
-				Required:     true,
-				ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+				Type:             schema.TypeString,
+				Description:      "The PostgreSQL version of your cluster.",
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 			},
 			"instances": {
-				Type:         schema.TypeInt,
-				Description:  "The total number of instances in the cluster (one master and n-1 standbys)",
-				Required:     true,
-				ValidateFunc: validation.All(validation.IntBetween(1, 5)),
+				Type:             schema.TypeInt,
+				Description:      "The total number of instances in the cluster (one master and n-1 standbys)",
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 5)),
 			},
 			"cores": {
 				Type:        schema.TypeInt,
@@ -42,22 +42,22 @@ func resourceDbaasPgSqlCluster() *schema.Resource {
 				Required:    true,
 			},
 			"ram": {
-				Type:         schema.TypeInt,
-				Description:  "The amount of memory per instance in megabytes. Has to be a multiple of 1024.",
-				Required:     true,
-				ValidateFunc: validation.All(validation.IntAtLeast(2048), validation.IntDivisibleBy(1024)),
+				Type:             schema.TypeInt,
+				Description:      "The amount of memory per instance in megabytes. Has to be a multiple of 1024.",
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.IntAtLeast(2048), validation.IntDivisibleBy(1024))),
 			},
 			"storage_size": {
-				Type:         schema.TypeInt,
-				Description:  "The amount of storage per instance in megabytes. Has to be a multiple of 2048.",
-				Required:     true,
-				ValidateFunc: validation.All(validation.IntAtLeast(2048)),
+				Type:             schema.TypeInt,
+				Description:      "The amount of storage per instance in megabytes. Has to be a multiple of 2048.",
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(2048)),
 			},
 			"storage_type": {
-				Type:         schema.TypeString,
-				Description:  "The storage type used in your cluster.",
-				Required:     true,
-				ValidateFunc: validation.All(validation.StringInSlice([]string{"HDD", "SSD", "SSD Premium", "SSD Standard"}, true)),
+				Type:             schema.TypeString,
+				Description:      "The storage type used in your cluster.",
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"HDD", "SSD", "SSD Premium", "SSD Standard"}, true)),
 			},
 			"connections": {
 				Type:        schema.TypeList,
@@ -67,16 +67,16 @@ func resourceDbaasPgSqlCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"datacenter_id": {
-							Type:         schema.TypeString,
-							Description:  "The datacenter to connect your cluster to.",
-							Required:     true,
-							ValidateFunc: validation.All(validation.IsUUID),
+							Type:             schema.TypeString,
+							Description:      "The datacenter to connect your cluster to.",
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IsUUID),
 						},
 						"lan_id": {
-							Type:         schema.TypeString,
-							Description:  "The LAN to connect your cluster to.",
-							Required:     true,
-							ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+							Type:             schema.TypeString,
+							Description:      "The LAN to connect your cluster to.",
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 						},
 						"cidr": {
 							Type:         schema.TypeString,
@@ -88,17 +88,17 @@ func resourceDbaasPgSqlCluster() *schema.Resource {
 				},
 			},
 			"location": {
-				Type:         schema.TypeString,
-				Description:  "The physical location where the cluster will be created. This will be where all of your instances live. Property cannot be modified after datacenter creation (disallowed in update requests)",
-				Required:     true,
-				ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+				Type:             schema.TypeString,
+				Description:      "The physical location where the cluster will be created. This will be where all of your instances live. Property cannot be modified after datacenter creation (disallowed in update requests)",
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 			},
 			"backup_location": {
-				Type:         schema.TypeString,
-				Description:  "The S3 location where the backups will be stored.",
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.All(validation.StringInSlice([]string{"de", "eu-south-2", "eu-central-2"}, true)),
+				Type:             schema.TypeString,
+				Description:      "The S3 location where the backups will be stored.",
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"de", "eu-south-2", "eu-central-2"}, true)),
 			},
 			"display_name": {
 				Type:        schema.TypeString,
@@ -114,14 +114,14 @@ func resourceDbaasPgSqlCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"time": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 						},
 						"day_of_the_week": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.All(validation.IsDayOfTheWeek(true)),
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IsDayOfTheWeek(true)),
 						},
 					},
 				},
@@ -134,25 +134,25 @@ func resourceDbaasPgSqlCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"username": {
-							Type:         schema.TypeString,
-							Description:  "the username for the initial postgres user. some system usernames are restricted (e.g. \"postgres\", \"admin\", \"standby\")",
-							Required:     true,
-							ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+							Type:             schema.TypeString,
+							Description:      "the username for the initial postgres user. some system usernames are restricted (e.g. \"postgres\", \"admin\", \"standby\")",
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 						},
 						"password": {
-							Type:         schema.TypeString,
-							Required:     true,
-							Sensitive:    true,
-							ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+							Type:             schema.TypeString,
+							Required:         true,
+							Sensitive:        true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 						},
 					},
 				},
 			},
 			"synchronization_mode": {
-				Type:         schema.TypeString,
-				Description:  "Represents different modes of replication.",
-				Required:     true,
-				ValidateFunc: validation.All(validation.StringInSlice([]string{"ASYNCHRONOUS", "SYNCHRONOUS", "STRICTLY_SYNCHRONOUS"}, false)),
+				Type:             schema.TypeString,
+				Description:      "Represents different modes of replication.",
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"ASYNCHRONOUS", "SYNCHRONOUS", "STRICTLY_SYNCHRONOUS"}, false)),
 			},
 			"from_backup": {
 				Type:        schema.TypeList,
@@ -162,10 +162,10 @@ func resourceDbaasPgSqlCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"backup_id": {
-							Type:         schema.TypeString,
-							Description:  "The unique ID of the backup you want to restore.",
-							Required:     true,
-							ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+							Type:             schema.TypeString,
+							Description:      "The unique ID of the backup you want to restore.",
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 						},
 						"recovery_target_time": {
 							Type:        schema.TypeString,

--- a/ionoscloud/resource_k8s_cluster.go
+++ b/ionoscloud/resource_k8s_cluster.go
@@ -26,10 +26,10 @@ func resourcek8sCluster() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				Description:  "The desired name for the cluster",
-				Required:     true,
-				ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+				Type:             schema.TypeString,
+				Description:      "The desired name for the cluster",
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 			},
 			"k8s_version": {
 				Type:             schema.TypeString,
@@ -47,16 +47,16 @@ func resourcek8sCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"time": {
-							Type:         schema.TypeString,
-							Description:  "A clock time in the day when maintenance is allowed",
-							Required:     true,
-							ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+							Type:             schema.TypeString,
+							Description:      "A clock time in the day when maintenance is allowed",
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 						},
 						"day_of_the_week": {
-							Type:         schema.TypeString,
-							Description:  "Day of the week when maintenance is allowed",
-							Required:     true,
-							ValidateFunc: validation.All(validation.StringIsNotWhiteSpace),
+							Type:             schema.TypeString,
+							Description:      "Day of the week when maintenance is allowed",
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 						},
 					},
 				},
@@ -64,7 +64,6 @@ func resourcek8sCluster() *schema.Resource {
 			"viable_node_pool_versions": {
 				Type:        schema.TypeList,
 				Description: "List of versions that may be used for node pools under this cluster",
-				Optional:    true,
 				Computed:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,


### PR DESCRIPTION
## What does this fix or implement?

`viable_node_pool_versions` is no longer optional, only computed.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [X] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
