### PR TITLE
fix: allow server import with nic and firewall ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  - defining a separate firewall rule for server should not set firewall_id inside server resource, as it moves the firewall resource inside the server on re-apply
  - Fixes creating share resource edit and share privileges mix up
  - `viable_node_pool_versions`  in k8s cluster is no longer optional, is only computed
+ - allow server import with nic and firewallId : `terraform import ionoscloud_server.myserver {datacenter uuid}/{server uuid}/{primary nic id}/{firewall rule id}`
 
 ## 6.3.3
 ### Feature

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -180,10 +180,14 @@ resource "random_password" "server_image_password" {
 
 ## Import
 
-Resource Server can be imported using the `resource id` and the `datacenter id`, e.g.
+Resource Server can be imported using the `resource id` and the `datacenter id`, e.g.. Passing only resource id and datacenter id means that the first nic found linked to the server will be attached to it.
 
 ```shell
 terraform import ionoscloud_server.myserver {datacenter uuid}/{server uuid}
+```
+Optionally, you can pass `primary_nic` and `firewallrule_id` so terraform will know to import aso the first nic and firewall rule(if it exists on the server):
+```shell
+terraform import ionoscloud_server.myserver {datacenter uuid}/{server uuid}/{primary nic id}/{firewall rule id}
 ```
 
 ## Notes

--- a/ionoscloud/import_server_test.go
+++ b/ionoscloud/import_server_test.go
@@ -23,7 +23,7 @@ func TestAccServerImportBasic(t *testing.T) {
 			},
 			{
 				ResourceName:            ServerResource + "." + ServerTestResource,
-				ImportStateIdFunc:       testAccServerImportStateId,
+				ImportStateIdFunc:       testAccServerImportStateIdWithNicAndFw,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"image_password", "ssh_key_path.#", "image_name", "volume.0.user_data", "volume.0.backup_unit_id", "firewallrule_id", "primary_nic"},
@@ -38,6 +38,7 @@ func TestAccServerWithLabelsImport(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		ExternalProviders: randomProviderVersion343(),
 		CheckDestroy:      testAccCheckServerDestroyCheck,
+
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckServerCreationWithLabels,
@@ -52,7 +53,6 @@ func TestAccServerWithLabelsImport(t *testing.T) {
 		},
 	})
 }
-
 func testAccServerImportStateId(s *terraform.State) (string, error) {
 	var importID = ""
 
@@ -62,7 +62,77 @@ func testAccServerImportStateId(s *terraform.State) (string, error) {
 		}
 
 		importID = fmt.Sprintf("%s/%s", rs.Primary.Attributes["datacenter_id"], rs.Primary.Attributes["id"])
+
 	}
 
 	return importID, nil
 }
+func testAccServerImportStateIdWithNicAndFw(s *terraform.State) (string, error) {
+	var importID = ""
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != ServerResource {
+			continue
+		}
+
+		importID = fmt.Sprintf("%s/%s", rs.Primary.Attributes["datacenter_id"], rs.Primary.Attributes["id"])
+		//we might get the primary nic id and the primary firewall id here as import optionals
+		if nicID, ok := rs.Primary.Attributes["primary_nic"]; ok {
+			importID += "/" + nicID
+			if primaryFwID, ok := rs.Primary.Attributes["firewallrule_id"]; ok {
+				importID += "/" + primaryFwID
+			}
+		}
+
+	}
+
+	return importID, nil
+}
+
+const testAccCheckServerImport = `
+resource ` + DatacenterResource + ` ` + DatacenterTestResource + ` {
+	name       = "server-test"
+	location = "us/las"
+}
+resource ` + LanResource + ` ` + LanTestResource + ` {
+  datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  public = true
+  name = "public"
+}
+resource "random_password" "image_password" {
+  length = 16
+  special = false
+}
+resource ` + ServerResource + ` ` + ServerTestResource + ` {
+  name = "` + ServerTestResource + `"
+  datacenter_id = ` + DatacenterResource + `.` + DatacenterTestResource + `.id
+  cores = 1
+  ram = 1024
+  availability_zone = "ZONE_1"
+  cpu_family = "AMD_OPTERON"
+  image_name = "ubuntu:latest"
+  image_password = random_password.image_password.result
+  type = "ENTERPRISE"
+  volume {
+    name = "system"
+    size = 5
+    disk_type = "SSD Standard"
+    user_data = "foo"
+    bus = "VIRTIO"
+    availability_zone = "ZONE_1"
+}
+  nic {
+    lan = ` + LanResource + `.` + LanTestResource + `.id
+    name = "system"
+    dhcp = true
+    firewall_active = false
+  }
+  label {
+    key = "labelkey0"
+    value = "labelvalue0"
+  }
+  label {
+    key = "labelkey1"
+    value = "labelvalue1"
+  }
+}`


### PR DESCRIPTION
## What does this fix or implement?

Server will allow passing primary nic and firewall rule for import so they are correctly populated. 


## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [X] Tests added or updated
- [X] Documentation updated
- [X] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
