### PR TITLE
fix: sql backups data source not finding backups

### DIFF
--- a/ionoscloud/resource_dbaas_pgsql_cluster_test.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster_test.go
@@ -97,7 +97,7 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 				ExpectError: regexp.MustCompile("no DBaaS cluster found with the specified name"),
 			},
 			{
-				PreConfig: SleepUntilBackupIsReady,
+				PreConfig: sleepUntilBackupIsReady,
 				Config:    testAccDataSourceDbaasPgSqlClusterBackups,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.cluster_id", DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_id"),
@@ -174,10 +174,11 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 	})
 }
 
-// SleepUntilBackupIsReady waits 30s until backup is ready
-func SleepUntilBackupIsReady() {
+// sleepUntilBackupIsReady waits 30s until backup is ready
+func sleepUntilBackupIsReady() {
 	time.Sleep(60 * time.Second)
 }
+
 func TestAccDBaaSPgSqlClusterAdditionalParameters(t *testing.T) {
 	var dbaasCluster psql.ClusterResponse
 	t.Skip()

--- a/ionoscloud/resource_dbaas_pgsql_cluster_test.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -96,7 +97,8 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 				ExpectError: regexp.MustCompile("no DBaaS cluster found with the specified name"),
 			},
 			{
-				Config: testAccDataSourceDbaasPgSqlClusterBackups,
+				PreConfig: SleepUntilBackupIsReady,
+				Config:    testAccDataSourceDbaasPgSqlClusterBackups,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.cluster_id", DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_id"),
 					resource.TestCheckResourceAttrSet(DataSource+"."+PsqlBackupsResource+"."+PsqlBackupsTest, "cluster_backups.0.size"),
@@ -172,6 +174,10 @@ func TestAccDBaaSPgSqlClusterBasic(t *testing.T) {
 	})
 }
 
+// SleepUntilBackupIsReady waits 30s until backup is ready
+func SleepUntilBackupIsReady() {
+	time.Sleep(60 * time.Second)
+}
 func TestAccDBaaSPgSqlClusterAdditionalParameters(t *testing.T) {
 	var dbaasCluster psql.ClusterResponse
 	t.Skip()


### PR DESCRIPTION
## What does this fix or implement?

Fix `TestAccDBaaSPgSqlClusterBasic` test failing because backups are crated later.
Wait 60 seconds before searching for backups.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [X] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
