### PR TITLE
doc: remove dbaas badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![Release](https://img.shields.io/github/v/release/ionos-cloud/terraform-provider-ionoscloud.svg)](https://github.com/ionos-cloud/terraform-provider-ionoscloud/releases/latest)
 [![Release Date](https://img.shields.io/github/release-date/ionos-cloud/terraform-provider-ionoscloud.svg)](https://github.com/ionos-cloud/terraform-provider-ionoscloud/releases/latest)
 [![Compute-engine test run](https://github.com/ionos-cloud/terraform-provider-ionoscloud/actions/workflows/compute-test-run.yml/badge.svg)](https://github.com/ionos-cloud/terraform-provider-ionoscloud/actions/workflows/compute-test-run.yml)
-[![DBaaS test run](https://github.com/ionos-cloud/terraform-provider-ionoscloud/actions/workflows/dbaas-test-run.yml/badge.svg)](https://github.com/ionos-cloud/terraform-provider-ionoscloud/actions/workflows/dbaas-test-run.yml)
 [![Go](https://img.shields.io/github/go-mod/go-version/ionos-cloud/terraform-provider-ionoscloud.svg)](https://github.com/ionos-cloud/terraform-provider-ionoscloud)
 
 ![Alt text](.github/IONOS.CLOUD.BLU.svg?raw=true "Title")


### PR DESCRIPTION
## What does this fix or implement?

Remove DBaaS badge from readme.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
