### PR TITLE
doc: update doc for k8s node pool with a note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Dependency update
 - Update `go` to version 1.19
 - Update `sdk-go-dbaas-postgres` to [v1.0.6](https://github.com/ionos-cloud/sdk-go-dbaas-postgres/releases/tag/v1.0.6)
+### Documentation
+- Update documentation for K8s node pools
 
 ## 6.3.5
 ### Feature:

--- a/docs/resources/k8s_node_pool.md
+++ b/docs/resources/k8s_node_pool.md
@@ -128,6 +128,20 @@ This will cause a downtime for all pods on that nodepool. Consider adding multip
 
 Immutable fields list: name, cpu_family, availability_zone, cores_count, ram_size, storage_size, storage_type. 
 
+⚠️ **Note**:
+
+Be careful when using `auto_scaling` since the number of nodes can change. Because of that, when running
+`terraform plan`, Terraform will think that an update is required (since `node_count` from the `tf` plan will be different
+from the number of nodes set by the scheduler). To avoid that, you can use:
+```hcl
+lifecycle {
+    ignore_changes = [
+      node_count
+    ]
+  }
+```
+This will also ignore the manual changes for `node_count` made in the `tf` plan.
+You can read more details about the `ignore_changes` attribute [here](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle).
 ## Import
 
 A Kubernetes Node Pool resource can be imported using its Kubernetes cluster's uuid as well as its own UUID, both of which you can retrieve from the cloud API: `resource id`, e.g.:


### PR DESCRIPTION
## What does this fix or implement?

Update the k8s node pool documentation with a note related to the `node_count` usage. We did that because we had a discussion with a client and we thought that we can add a little bit of clarity to the documentation.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
