### PR TITLE
fix: allow k8s_version patch upgrades, but ignore downgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Update `sdk-go-dbaas-mongo` to [v1.0.6](https://github.com/ionos-cloud/sdk-go-dbaas-mongo/releases/tag/v1.2.2)
 ## Fixes
 - Update code to work with new mongo version
+- Ignore downgrades of `k8s_version` patch level.
+- Allow upgrades of `k8s_version` patch level.
 
 ## 6.3.6
 ### Feature

--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -51,5 +51,5 @@ terraform import ionoscloud_k8s_cluster.demo {k8s_cluster uuid}
 
 This can be helpful when you want to import kubernetes clusters which you have already created manually or using other means, outside of terraform.
 
-⚠️ **_Warning: **During a maintenance window, k8s can update you k8s_version if the old one reaches end of life. This upgrade will not be shown in the plan, as we prevent
+⚠️ **_Warning: **During a maintenance window, k8s can update your `k8s_version` if the old one reaches end of life. This upgrade will not be shown in the plan, as we prevent
 terraform from doing a downgrade, as downgrading `k8s_version` is not supported._**

--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -33,7 +33,7 @@ resource "ionoscloud_k8s_cluster" "example" {
 The following arguments are supported:
 
 - `name` - (Required)[string] The name of the Kubernetes Cluster.
-- `k8s_version` - (Optional)[string] The desired Kubernetes Version. For supported values, please check the API documentation. The provider will ignore changes of patch level.
+- `k8s_version` - (Optional)[string] The desired Kubernetes Version. For supported values, please check the API documentation. Downgrades are not supported. The provider will ignore downgrades of patch level.
 - `maintenance_window` - (Optional) A maintenance window comprise of a day of the week and a time for maintenance to be allowed
   - `time` - (Required)[string] A clock time in the day when maintenance is allowed
   - `day_of_the_week` - (Required)[string] Day of the week when maintenance is allowed
@@ -50,3 +50,6 @@ terraform import ionoscloud_k8s_cluster.demo {k8s_cluster uuid}
 ```
 
 This can be helpful when you want to import kubernetes clusters which you have already created manually or using other means, outside of terraform.
+
+⚠️ **_Warning: **During a maintenance window, k8s can update you k8s_version if the old one reaches end of life. This upgrade will not be shown in the plan, as we prevent
+terraform from doing a downgrade, as downgrading `k8s_version` is not supported._**

--- a/docs/resources/k8s_node_pool.md
+++ b/docs/resources/k8s_node_pool.md
@@ -152,7 +152,7 @@ terraform import ionoscloud_k8s_node_pool.demo {k8s_cluster_uuid}/{k8s_nodepool_
 
 This can be helpful when you want to import kubernetes node pools which you have already created manually or using other means, outside of terraform, towards the goal of managing them via Terraform
 
-⚠️ **_Warning: **During a maintenance window, k8s can update you k8s_version if the old one reaches end of life. This upgrade will not be shown in the plan, as we prevent
-terraform from doing a downgrade, as downgrading k8s_version is not supported._**
+⚠️ **_Warning: **During a maintenance window, k8s can update your `k8s_version` if the old one reaches end of life. This upgrade will not be shown in the plan, as we prevent 
+terraform from doing a downgrade, as downgrading `k8s_version` is not supported._**
 
 ⚠️ **_Warning: **If you are upgrading from v5.x.x to v6.x.x**: You have to modify you plan for lans to match the new structure, by putting the ids from the old slice in lans.id fields. This is not backwards compatible._**

--- a/docs/resources/k8s_node_pool.md
+++ b/docs/resources/k8s_node_pool.md
@@ -96,7 +96,7 @@ resource "ionoscloud_k8s_node_pool" "example" {
 The following arguments are supported:
 
 - `name` - (Required)[string] The name of the Kubernetes Cluster. *This attribute is immutable*.
-- `k8s_version` - (Optional)[string] The desired Kubernetes Version. for supported values, please check the API documentation. The provider will ignore changes of patch level.
+- `k8s_version` - (Optional)[string] The desired Kubernetes Version. For supported values, please check the API documentation. Downgrades are not supported. The provider will ignore downgrades of patch level.
 - `auto_scaling` - (Optional)[string] Wether the Node Pool should autoscale. For more details, please check the API documentation
   - `min_node_count` - (Optional)[int] The minimum number of worker nodes the node pool can scale down to. Should be less than max_node_count
   - `max_node_count` - (Optional)[int] The maximum number of worker nodes that the node pool can scale to. Should be greater than min_node_count
@@ -151,5 +151,8 @@ terraform import ionoscloud_k8s_node_pool.demo {k8s_cluster_uuid}/{k8s_nodepool_
 ```
 
 This can be helpful when you want to import kubernetes node pools which you have already created manually or using other means, outside of terraform, towards the goal of managing them via Terraform
+
+⚠️ **_Warning: **During a maintenance window, k8s can update you k8s_version if the old one reaches end of life. This upgrade will not be shown in the plan, as we prevent
+terraform from doing a downgrade, as downgrading k8s_version is not supported._**
 
 ⚠️ **_Warning: **If you are upgrading from v5.x.x to v6.x.x**: You have to modify you plan for lans to match the new structure, by putting the ids from the old slice in lans.id fields. This is not backwards compatible._**

--- a/ionoscloud/resource_k8s_cluster.go
+++ b/ionoscloud/resource_k8s_cluster.go
@@ -33,7 +33,7 @@ func resourcek8sCluster() *schema.Resource {
 			},
 			"k8s_version": {
 				Type:             schema.TypeString,
-				Description:      "The desired Kubernetes Version. For supported values, please check the API documentation. Downgrades are not supported. Downgrades are not supported. The provider will ignore downgrades of patch level.",
+				Description:      "The desired Kubernetes Version. For supported values, please check the API documentation. Downgrades are not supported. The provider will ignore downgrades of patch level.",
 				Optional:         true,
 				Computed:         true,
 				DiffSuppressFunc: DiffBasedOnVersion,

--- a/ionoscloud/resource_k8s_cluster.go
+++ b/ionoscloud/resource_k8s_cluster.go
@@ -33,7 +33,7 @@ func resourcek8sCluster() *schema.Resource {
 			},
 			"k8s_version": {
 				Type:             schema.TypeString,
-				Description:      "The desired kubernetes version",
+				Description:      "The desired Kubernetes Version. For supported values, please check the API documentation. Downgrades are not supported. Downgrades are not supported. The provider will ignore downgrades of patch level.",
 				Optional:         true,
 				Computed:         true,
 				DiffSuppressFunc: DiffBasedOnVersion,

--- a/ionoscloud/resource_k8s_node_pool.go
+++ b/ionoscloud/resource_k8s_node_pool.go
@@ -36,7 +36,7 @@ func resourceK8sNodePool() *schema.Resource {
 			},
 			"k8s_version": {
 				Type:             schema.TypeString,
-				Description:      "The desired kubernetes version",
+				Description:      "The desired Kubernetes Version. For supported values, please check the API documentation. Downgrades are not supported. The provider will ignore downgrades of patch level.",
 				Required:         true,
 				DiffSuppressFunc: DiffBasedOnVersion,
 			},


### PR DESCRIPTION
## What does this fix or implement?

Ignore downgrades of `k8s_version` patch level.
Allow upgrades of `k8s_version` patch level.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
