### PR TITLE
fix: log levels shown correctly and filtered correctly when enabling …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Dependency update
 - Update `sdk-go-dbaas-mongo` to [v1.0.6](https://github.com/ionos-cloud/sdk-go-dbaas-mongo/releases/tag/v1.2.2)
 ## Fixes
+- Log levels need to be shown and filtered correctly when set with `TF_LOG`. Also change `WARNING` log levels to `WARN`.
 - Update code to work with new mongo version
 
 ## 6.3.6

--- a/ionoscloud/data_source_dbaas_mongo_template.go
+++ b/ionoscloud/data_source_dbaas_mongo_template.go
@@ -101,7 +101,7 @@ func dataSourceDbassMongoTemplateRead(ctx context.Context, d *schema.ResourceDat
 // matchesName checks if a template has a specific name. allows for partial matching if partialMatch is true
 func matchesName(template mongo.TemplateResponse, name string, partialMatch bool) bool {
 	if template.Properties == nil || template.Properties.Name == nil {
-		log.Printf("[WARNING] template %s missing properties, or name", *template.Id)
+		log.Printf("[WARN] template %s missing properties, or name", *template.Id)
 		return false
 	}
 

--- a/ionoscloud/labels_service.go
+++ b/ionoscloud/labels_service.go
@@ -88,7 +88,7 @@ func (ls *LabelsService) datacentersServersLabelsDelete(datacenterId, serverId s
 				apiResponse.LogInfo()
 				if err != nil {
 					if httpNotFound(apiResponse) {
-						log.Printf("[WARNING] label with key %s has been already removed from server %s\n", labelKey, serverId)
+						log.Printf("[WARN] label with key %s has been already removed from server %s\n", labelKey, serverId)
 					} else {
 						return fmt.Errorf("[label update] an error occured while deleting label with key: %s, server ID: %s, error: %w", labelKey, serverId, err)
 					}

--- a/ionoscloud/resource_loadbalancer.go
+++ b/ionoscloud/resource_loadbalancer.go
@@ -189,7 +189,7 @@ func resourceLoadbalancerUpdate(ctx context.Context, d *schema.ResourceData, met
 				if httpNotFound(apiResponse) {
 					/* 404 - nic was not found - in case the nic is removed, VDC removes the nic from load balancers
 					that contain it, behind the scenes - therefore our call will yield 404 */
-					log.Printf("[WARNING] nic ID %s already removed from load balancer %s\n", o.(string), d.Id())
+					log.Printf("[WARN] nic ID %s already removed from load balancer %s\n", o.(string), d.Id())
 				} else {
 					diags := diag.FromErr(fmt.Errorf("[load balancer update] an error occured while deleting a balanced nic: %w", err))
 					return diags

--- a/ionoscloud/resource_volume.go
+++ b/ionoscloud/resource_volume.go
@@ -722,7 +722,7 @@ func getImage(ctx context.Context, client *ionoscloud.APIClient, d *schema.Resou
 			}
 			// if no image id was found with that name we look for a matching snapshot
 			if image == "" {
-				log.Printf("[*****] looking for a snapshot with id %s\n", imageName)
+				log.Printf("[DEBUG] looking for a snapshot with id %s\n", imageName)
 				image = getSnapshotId(ctx, client, imageName)
 				if image != "" {
 					isSnapshot = true

--- a/main.go
+++ b/main.go
@@ -15,7 +15,8 @@ func main() {
 	//this will enable you to debug when running plans from cli.
 	flag.BoolVar(&debugMode, "debuggable", false, "set to true to run the provider with support for debuggers like delve/goland")
 	flag.Parse()
-
+	//log levels need to be shown correctly in terraform when enabling TF_LOG
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
 	if debugMode {
 		err := plugin.Debug(context.Background(), "registry.terraform.io/ionos-cloud/ionoscloud",
 			&plugin.ServeOpts{


### PR DESCRIPTION
…TF_LOG

## What does this fix or implement?

Log levels were always shown with `INFO` instead of the correct log level. 
Now they are shown correctly and can be filtered.
`WARNING` needs to be changed to `WARN` as TF_LOG uses `WARN`

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
