### PR TITLE
doc: fix inonoscloud_image to use image_alias

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -21,7 +21,7 @@ This resource will create an operational server. After this section completes, t
 data "ionoscloud_image" "example" {
     type                  = "HDD"
     cloud_init            = "V1"
-    location              = "us/las"
+    image_alias           = "ubuntu:latest"
 }
 
 resource "ionoscloud_datacenter" "example" {

--- a/docs/resources/snapshot.md
+++ b/docs/resources/snapshot.md
@@ -16,7 +16,7 @@ Manages **Snapshots** on IonosCloud.
 ```hcl
 data "ionoscloud_image" "example" {
     type                  = "HDD"
-    cloud_init            = "V1"
+    image_alias           = "ubuntu:latest"
     location              = "us/las"
 }
 


### PR DESCRIPTION
## What does this fix or implement?

FIx examples using `ionoscloud_image` and use `image_alias` instead of `version` for lookup.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
