### PR TITLE
Fix/dhcpv6 server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.4.6
 
 - Fix `ipv6_ips` should not request a re-apply of the plan if `ipv6_cidr_block` is not set on the lan
+- Fix `dhcpv6` should not be set on server nic if IPv6 is not enabled on the lan
 
 ## 6.4.5
 ### Features

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -1005,11 +1005,15 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 
 			dhcp := d.Get("nic.0.dhcp").(bool)
-			dhcpv6 := d.Get("nic.0.dhcpv6").(bool)
 			fwRule := d.Get("nic.0.firewall_active").(bool)
 			nicProperties.Dhcp = &dhcp
-			nicProperties.Dhcpv6 = &dhcpv6
 			nicProperties.FirewallActive = &fwRule
+			if dhcpv6, ok := d.GetOk("nic.0.dhcpv6"); ok {
+				dhcpv6 := dhcpv6.(bool)
+				nicProperties.Dhcpv6 = &dhcpv6
+			} else {
+				nicProperties.SetDhcpv6Nil()
+			}
 
 			if v, ok := d.GetOk("nic.0.firewall_type"); ok {
 				vStr := v.(string)


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
`dhcpv6` should not be set on server nic if IPv6 is not enabled on the lan
## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
