### PR TITLE
fix: allow custom value for ipv6_cidr_block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.4.7
+## 6.4.8
 ### Fixes
 - Fix setting explicit `ipv6_cidr_block` on `nic` resource.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 6.4.7
+### Fixes
+- Fix setting explicit `ipv6_cidr_block` on `nic` resource.
+
+## 6.4.7
 ### Features
 - Add support for mongo clusters enterprise edition
 

--- a/docs/resources/lan.md
+++ b/docs/resources/lan.md
@@ -34,6 +34,24 @@ resource "ionoscloud_lan" "example" {
 }
 ```
 
+## Example Usage With IPv6 Enabled
+
+```hcl
+resource "ionoscloud_datacenter" "example" {
+  name                  = "Datacenter Example"
+  location              = "de/txl"
+  description           = "Datacenter Description"
+  sec_auth_protection   = false
+}
+
+resource "ionoscloud_lan" "example" {
+  datacenter_id         = ionoscloud_datacenter.example.id
+  public                = true
+  name                  = "Lan IPv6 Example"
+  ipv6_cidr_block       = "AUTO"
+}
+```
+
 ## Argument reference
 
 * `datacenter_id` - (Required)[string] The ID of a Virtual Data Center.

--- a/docs/resources/nic.md
+++ b/docs/resources/nic.md
@@ -10,7 +10,6 @@ description: |-
 # ionoscloud_nic
 
 Manages a **NIC** on IonosCloud.
-
 ## Example Usage
 
 ```hcl
@@ -31,6 +30,61 @@ resource "ionoscloud_lan" "example"{
   datacenter_id     = ionoscloud_datacenter.example.id
   public            = true
   name              = "Lan"
+}
+
+resource "ionoscloud_server" "example" {
+    name                  = "Server Example"
+    datacenter_id         = ionoscloud_datacenter.example.id
+    cores                 = 1
+    ram                   = 1024
+    availability_zone     = "ZONE_1"
+    cpu_family            = "AMD_OPTERON"
+    image_name            = "Ubuntu-20.04"
+    image_password        = random_password.server_image_password.result
+    volume {
+      name                = "system"
+      size                = 14
+      disk_type           = "SSD"
+    }
+    nic {
+      lan                 = "1"
+      dhcp                = true
+      firewall_active     = true
+    }
+}
+
+resource "ionoscloud_nic" "example" {
+    datacenter_id         = ionoscloud_datacenter.example.id
+    server_id             = ionoscloud_server.example.id
+    lan                   = ionoscloud_lan.example.id
+    name                  = "NIC"
+    lan                   = 2
+    dhcp                  = true
+    firewall_active       = true
+    firewall_type         = "INGRESS"
+    ips                   = [ ionoscloud_ipblock.example.ips[0], ionoscloud_ipblock.example.ips[1] ]
+}
+
+resource "random_password" "server_image_password" {
+  length           = 16
+  special          = false
+}
+```
+
+## Example Usage with IPv6
+
+```hcl
+resource "ionoscloud_datacenter" "example" {
+	name                = "Datacenter Example"
+	location            = "us/las"
+	description         = "Datacenter Description"
+	sec_auth_protection = false
+}
+
+resource "ionoscloud_lan" "example"{
+  datacenter_id     = ionoscloud_datacenter.example.id
+  public            = true
+  name              = "IPv6 Enabled LAN"
   ipv6_cidr_block   = cidrsubnet(ionoscloud_datacenter.example.ipv6_cidr_block,8,2)
 }
 
@@ -60,11 +114,9 @@ resource "ionoscloud_nic" "example" {
     server_id             = ionoscloud_server.example.id
     lan                   = ionoscloud_lan.example.id
     name                  = "IPv6 Enabled NIC"
-    lan                   = 2
     dhcp                  = true
     firewall_active       = true
     firewall_type         = "INGRESS"
-    ips                   = [ ionoscloud_ipblock.example.ips[0], ionoscloud_ipblock.example.ips[1] ]
     dhcpv6                = false
     ipv6_cidr_block       = cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14)
     ipv6_ips              = [ 

--- a/docs/resources/nic.md
+++ b/docs/resources/nic.md
@@ -27,6 +27,13 @@ resource "ionoscloud_ipblock" "example" {
     name                = "IP Block Example"
 }
 
+resource "ionoscloud_lan" "example"{
+  datacenter_id     = ionoscloud_datacenter.example.id
+  public            = true
+  name              = "Lan"
+  ipv6_cidr_block   = cidrsubnet(ionoscloud_datacenter.example.ipv6_cidr_block,8,2)
+}
+
 resource "ionoscloud_server" "example" {
     name                  = "Server Example"
     datacenter_id         = ionoscloud_datacenter.example.id
@@ -51,13 +58,22 @@ resource "ionoscloud_server" "example" {
 resource "ionoscloud_nic" "example" {
     datacenter_id         = ionoscloud_datacenter.example.id
     server_id             = ionoscloud_server.example.id
-    name                  = "Nic Example"
+    lan                   = ionoscloud_lan.example.id
+    name                  = "IPv6 Enabled NIC"
     lan                   = 2
     dhcp                  = true
     firewall_active       = true
     firewall_type         = "INGRESS"
     ips                   = [ ionoscloud_ipblock.example.ips[0], ionoscloud_ipblock.example.ips[1] ]
+    dhcpv6                = false
+    ipv6_cidr_block       = cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14)
+    ipv6_ips              = [ 
+                              cidrhost(cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14),10),
+                              cidrhost(cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14),20),
+                              cidrhost(cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14),30)
+                            ]
 }
+
 resource "random_password" "server_image_password" {
   length           = 16
   special          = false

--- a/docs/resources/nic.md
+++ b/docs/resources/nic.md
@@ -14,16 +14,16 @@ Manages a **NIC** on IonosCloud.
 
 ```hcl
 resource "ionoscloud_datacenter" "example" {
-	name                = "Datacenter Example"
-	location            = "us/las"
-	description         = "Datacenter Description"
-	sec_auth_protection = false
+  name                = "Datacenter Example"
+  location            = "us/las"
+  description         = "Datacenter Description"
+  sec_auth_protection = false
 }
 
 resource "ionoscloud_ipblock" "example" {
-    location            = ionoscloud_datacenter.example.location
-    size                = 2
-    name                = "IP Block Example"
+  location            = ionoscloud_datacenter.example.location
+  size                = 2
+  name                = "IP Block Example"
 }
 
 resource "ionoscloud_lan" "example"{
@@ -33,36 +33,36 @@ resource "ionoscloud_lan" "example"{
 }
 
 resource "ionoscloud_server" "example" {
-    name                  = "Server Example"
-    datacenter_id         = ionoscloud_datacenter.example.id
-    cores                 = 1
-    ram                   = 1024
-    availability_zone     = "ZONE_1"
-    cpu_family            = "AMD_OPTERON"
-    image_name            = "Ubuntu-20.04"
-    image_password        = random_password.server_image_password.result
-    volume {
-      name                = "system"
-      size                = 14
-      disk_type           = "SSD"
-    }
-    nic {
-      lan                 = "1"
-      dhcp                = true
-      firewall_active     = true
-    }
+  name                  = "Server Example"
+  datacenter_id         = ionoscloud_datacenter.example.id
+  cores                 = 1
+  ram                   = 1024
+  availability_zone     = "ZONE_1"
+  cpu_family            = "AMD_OPTERON"
+  image_name            = "Ubuntu-20.04"
+  image_password        = random_password.server_image_password.result
+  volume {
+    name                = "system"
+    size                = 14
+    disk_type           = "SSD"
+  }
+  nic {
+    lan                 = "1"
+    dhcp                = true
+    firewall_active     = true
+  }
 }
 
 resource "ionoscloud_nic" "example" {
-    datacenter_id         = ionoscloud_datacenter.example.id
-    server_id             = ionoscloud_server.example.id
-    lan                   = ionoscloud_lan.example.id
-    name                  = "NIC"
-    lan                   = 2
-    dhcp                  = true
-    firewall_active       = true
-    firewall_type         = "INGRESS"
-    ips                   = [ ionoscloud_ipblock.example.ips[0], ionoscloud_ipblock.example.ips[1] ]
+  datacenter_id         = ionoscloud_datacenter.example.id
+  server_id             = ionoscloud_server.example.id
+  lan                   = ionoscloud_lan.example.id
+  name                  = "NIC"
+  lan                   = 2
+  dhcp                  = true
+  firewall_active       = true
+  firewall_type         = "INGRESS"
+  ips                   = [ ionoscloud_ipblock.example.ips[0], ionoscloud_ipblock.example.ips[1] ]
 }
 
 resource "random_password" "server_image_password" {
@@ -75,10 +75,10 @@ resource "random_password" "server_image_password" {
 
 ```hcl
 resource "ionoscloud_datacenter" "example" {
-	name                = "Datacenter Example"
-	location            = "us/las"
-	description         = "Datacenter Description"
-	sec_auth_protection = false
+  name                = "Datacenter Example"
+  location            = "us/las"
+  description         = "Datacenter Description"
+  sec_auth_protection = false
 }
 
 resource "ionoscloud_lan" "example"{
@@ -89,41 +89,41 @@ resource "ionoscloud_lan" "example"{
 }
 
 resource "ionoscloud_server" "example" {
-    name                  = "Server Example"
-    datacenter_id         = ionoscloud_datacenter.example.id
-    cores                 = 1
-    ram                   = 1024
-    availability_zone     = "ZONE_1"
-    cpu_family            = "AMD_OPTERON"
-    image_name            = "Ubuntu-20.04"
-    image_password        = random_password.server_image_password.result
-    volume {
-      name                = "system"
-      size                = 14
-      disk_type           = "SSD"
-    }
-    nic {
-      lan                 = "1"
-      dhcp                = true
-      firewall_active     = true
-    }
+  name                  = "Server Example"
+  datacenter_id         = ionoscloud_datacenter.example.id
+  cores                 = 1
+  ram                   = 1024
+  availability_zone     = "ZONE_1"
+  cpu_family            = "AMD_OPTERON"
+  image_name            = "Ubuntu-20.04"
+  image_password        = random_password.server_image_password.result
+  volume {
+    name                = "system"
+    size                = 14
+    disk_type           = "SSD"
+  }
+  nic {
+    lan                 = "1"
+    dhcp                = true
+    firewall_active     = true
+  }
 }
 
 resource "ionoscloud_nic" "example" {
-    datacenter_id         = ionoscloud_datacenter.example.id
-    server_id             = ionoscloud_server.example.id
-    lan                   = ionoscloud_lan.example.id
-    name                  = "IPv6 Enabled NIC"
-    dhcp                  = true
-    firewall_active       = true
-    firewall_type         = "INGRESS"
-    dhcpv6                = false
-    ipv6_cidr_block       = cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14)
-    ipv6_ips              = [ 
+  datacenter_id         = ionoscloud_datacenter.example.id
+  server_id             = ionoscloud_server.example.id
+  lan                   = ionoscloud_lan.example.id
+  name                  = "IPv6 Enabled NIC"
+  dhcp                  = true
+  firewall_active       = true
+  firewall_type         = "INGRESS"
+  dhcpv6                = false
+  ipv6_cidr_block       = cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14)
+  ipv6_ips              = [ 
                               cidrhost(cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14),10),
                               cidrhost(cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14),20),
                               cidrhost(cidrsubnet(ionoscloud_lan.example.ipv6_cidr_block,16,14),30)
-                            ]
+                          ]
 }
 
 resource "random_password" "server_image_password" {

--- a/ionoscloud/data_source_nic_test.go
+++ b/ionoscloud/data_source_nic_test.go
@@ -17,8 +17,10 @@ func Test_dataSourceNicRead(t *testing.T) {
 	mac := "testMac"
 	testName := "testname"
 	dhcp := true
+	dhcpv6 := false
 	firewallActive := true
 	firewallType := "Bidirectional"
+	ipv6CidrBlock := "AUTO"
 	nic := ionoscloud.Nic{
 		Id:       &id,
 		Type:     nil,
@@ -28,7 +30,10 @@ func Test_dataSourceNicRead(t *testing.T) {
 			Name:           &testName,
 			Mac:            &mac,
 			Ips:            nil,
+			Ipv6Ips:        nil,
 			Dhcp:           &dhcp,
+			Dhcpv6:         &dhcpv6,
+			Ipv6CidrBlock:  &ipv6CidrBlock,
 			Lan:            nil,
 			FirewallActive: &firewallActive,
 			FirewallType:   &firewallType,
@@ -70,6 +75,12 @@ func Test_dataSourceNicRead(t *testing.T) {
 		t.Fatalf("expected '%s', got '%s'", *nic.Properties.Mac, data.Get("mac"))
 	}
 	if *nic.Properties.Dhcp != data.Get("dhcp").(bool) {
+		t.Fatalf("expected '%t', got '%s'", *nic.Properties.Dhcp, data.Get("dhcp"))
+	}
+	if *nic.Properties.Dhcpv6 != data.Get("dhcpv6").(bool) {
+		t.Fatalf("expected '%t', got '%s'", *nic.Properties.Dhcp, data.Get("dhcp"))
+	}
+	if *nic.Properties.Ipv6CidrBlock != data.Get("ipv6_cidr_block").(string) {
 		t.Fatalf("expected '%t', got '%s'", *nic.Properties.Dhcp, data.Get("dhcp"))
 	}
 	if *nic.Properties.FirewallActive != data.Get("firewall_active").(bool) {

--- a/ionoscloud/data_source_nic_test.go
+++ b/ionoscloud/data_source_nic_test.go
@@ -78,10 +78,10 @@ func Test_dataSourceNicRead(t *testing.T) {
 		t.Fatalf("expected '%t', got '%s'", *nic.Properties.Dhcp, data.Get("dhcp"))
 	}
 	if *nic.Properties.Dhcpv6 != data.Get("dhcpv6").(bool) {
-		t.Fatalf("expected '%t', got '%s'", *nic.Properties.Dhcp, data.Get("dhcp"))
+		t.Fatalf("expected '%t', got '%s'", *nic.Properties.Dhcpv6, data.Get("dhcpv6"))
 	}
 	if *nic.Properties.Ipv6CidrBlock != data.Get("ipv6_cidr_block").(string) {
-		t.Fatalf("expected '%t', got '%s'", *nic.Properties.Dhcp, data.Get("dhcp"))
+		t.Fatalf("expected '%t', got '%s'", *nic.Properties.Ipv6CidrBlock, data.Get("ipv6CidrBlock"))
 	}
 	if *nic.Properties.FirewallActive != data.Get("firewall_active").(bool) {
 		t.Fatalf("expected '%t', got '%s'", *nic.Properties.FirewallActive, data.Get("firewallActive"))

--- a/ionoscloud/resource_lan_test.go
+++ b/ionoscloud/resource_lan_test.go
@@ -145,6 +145,7 @@ resource ` + constant.LanResource + ` ` + constant.LanTestResource + ` {
   public = false
   name = "` + constant.UpdatedResources + `"
   pcc = ` + constant.PCCResource + `.` + constant.PCCTestResource + `.id
+  ipv6_cidr_block = cidrsubnet(` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.ipv6_cidr_block` + `,8,2)
 }`
 
 const testAccDataSourceLanMatchId = testAccCheckLanConfigBasic + `

--- a/ionoscloud/resource_lan_test.go
+++ b/ionoscloud/resource_lan_test.go
@@ -70,6 +70,7 @@ func TestAccLanBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(constant.LanResource+"."+constant.LanTestResource, "name", constant.UpdatedResources),
 					resource.TestCheckResourceAttr(constant.LanResource+"."+constant.LanTestResource, "public", "false"),
 					resource.TestCheckResourceAttrPair(constant.LanResource+"."+constant.LanTestResource, "pcc", constant.PCCResource+"."+constant.PCCTestResource, "id"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.LanResource+"."+constant.LanDataSourceById, "ipv6_cidr_block", constant.LanResource+"."+constant.LanTestResource, "ipv6_cidr_block"),
 				),
 			},
 		},
@@ -146,7 +147,12 @@ resource ` + constant.LanResource + ` ` + constant.LanTestResource + ` {
   name = "` + constant.UpdatedResources + `"
   pcc = ` + constant.PCCResource + `.` + constant.PCCTestResource + `.id
   ipv6_cidr_block = cidrsubnet(` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.ipv6_cidr_block` + `,8,2)
-}`
+}
+data ` + constant.LanResource + ` ` + constant.LanDataSourceById + ` {
+	datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+	id			= ` + constant.LanResource + `.` + constant.LanTestResource + `.id
+}
+`
 
 const testAccDataSourceLanMatchId = testAccCheckLanConfigBasic + `
 data ` + constant.LanResource + ` ` + constant.LanDataSourceById + ` {

--- a/ionoscloud/resource_lan_test.go
+++ b/ionoscloud/resource_lan_test.go
@@ -149,8 +149,8 @@ resource ` + constant.LanResource + ` ` + constant.LanTestResource + ` {
   ipv6_cidr_block = cidrsubnet(` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.ipv6_cidr_block` + `,8,2)
 }
 data ` + constant.LanResource + ` ` + constant.LanDataSourceById + ` {
-	datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
-	id			= ` + constant.LanResource + `.` + constant.LanTestResource + `.id
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  id = ` + constant.LanResource + `.` + constant.LanTestResource + `.id
 }
 `
 

--- a/ionoscloud/resource_nic.go
+++ b/ionoscloud/resource_nic.go
@@ -294,6 +294,11 @@ func getNicData(d *schema.ResourceData, path string) ionoscloud.Nic {
 		}
 	}
 
+	if v, ok := d.GetOk(path + "ipv6_cidr_block"); ok {
+		ipv6_block := v.(string)
+		nic.Properties.Ipv6CidrBlock = &ipv6_block
+	}
+
 	return nic
 }
 

--- a/ionoscloud/resource_nic.go
+++ b/ionoscloud/resource_nic.go
@@ -287,16 +287,16 @@ func getNicData(d *schema.ResourceData, path string) ionoscloud.Nic {
 
 	if v, ok := d.GetOk(path + "ipv6_ips"); ok {
 		raw := v.([]interface{})
-		ipv6_ips := make([]string, len(raw))
-		utils.DecodeInterfaceToStruct(raw, ipv6_ips)
-		if len(ipv6_ips) > 0 {
-			nic.Properties.Ipv6Ips = &ipv6_ips
+		ipv6Ips := make([]string, len(raw))
+		utils.DecodeInterfaceToStruct(raw, ipv6Ips)
+		if len(ipv6Ips) > 0 {
+			nic.Properties.Ipv6Ips = &ipv6Ips
 		}
 	}
 
 	if v, ok := d.GetOk(path + "ipv6_cidr_block"); ok {
-		ipv6_block := v.(string)
-		nic.Properties.Ipv6CidrBlock = &ipv6_block
+		ipv6Block := v.(string)
+		nic.Properties.Ipv6CidrBlock = &ipv6Block
 	}
 
 	return nic

--- a/ionoscloud/resource_nic_test.go
+++ b/ionoscloud/resource_nic_test.go
@@ -96,6 +96,8 @@ func TestAccNicBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(constant.FullNicResourceName, "dhcpv6", "false"),
 					resource.TestCheckResourceAttr(constant.FullNicResourceName, "firewall_active", "false"),
 					resource.TestCheckResourceAttr(constant.FullNicResourceName, "firewall_type", "BIDIRECTIONAL"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+dataSourceNicById, "ipv6_cidr_block", constant.FullNicResourceName, "ipv6_cidr_block"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+dataSourceNicById, "ipv6_ips", constant.FullNicResourceName, "ipv6_ips"),
 				),
 			},
 		},
@@ -242,6 +244,12 @@ resource ` + constant.NicResource + ` "database_nic" {
 				cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),2),
 				cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),3)
 			]
+}
+
+data ` + constant.NicResource + ` test_nic_data {
+	datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+	server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
+	id = ` + constant.FullNicResourceName + `.id
 }
 `
 const dataSourceNicById = constant.NicResource + ".test_nic_data"

--- a/ionoscloud/resource_nic_test.go
+++ b/ionoscloud/resource_nic_test.go
@@ -173,8 +173,8 @@ func testAccCheckNICExists(n string, nic *ionoscloud.Nic) resource.TestCheckFunc
 
 const testCreateDataCenterAndServer = `
 resource "ionoscloud_datacenter" "test_datacenter" {
-	name       = "nic-test"
-	location = "us/las"
+  name = "nic-test"
+  location = "us/las"
 }
 resource "ionoscloud_ipblock" "test_server" {
   location = ionoscloud_datacenter.test_datacenter.location
@@ -240,16 +240,16 @@ resource ` + constant.NicResource + ` "database_nic" {
   name = "updated"
   ipv6_cidr_block = cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12)
   ipv6_ips = [ 
-				cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),1),
-				cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),2),
-				cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),3)
-			]
+                cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),1),
+                cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),2),
+                cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),3)
+             ]
 }
 
 data ` + constant.NicResource + ` test_nic_data {
-	datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
-	server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
-	id = ` + constant.FullNicResourceName + `.id
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
+  id = ` + constant.FullNicResourceName + `.id
 }
 `
 const dataSourceNicById = constant.NicResource + ".test_nic_data"
@@ -264,24 +264,24 @@ data ` + constant.NicResource + ` test_nic_data {
 
 const testAccDataSourceNicMatchName = testAccCheckNicConfigBasic + `
 data ` + constant.NicResource + ` test_nic_data {
-  	datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
-	server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
-	name = ` + constant.FullNicResourceName + `.name 
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
+  name = ` + constant.FullNicResourceName + `.name 
 }`
 
 const testAccDataSourceNicMatchNameError = testAccCheckNicConfigBasic + `
 data ` + constant.NicResource + ` test_nic_data {
-  	datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
-	server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
-	name = "DoesNotExist"
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
+  name = "DoesNotExist"
 }`
 
 const testAccDataSourceNicMatchIdAndNameError = testAccCheckNicConfigBasic + `
 data ` + constant.NicResource + ` test_nic_data {
-  	datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
-	server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
-	id = ` + constant.FullNicResourceName + `.id
-	name = "doesNotExist"
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
+  id = ` + constant.FullNicResourceName + `.id
+  name = "doesNotExist"
 }`
 
 const testAccDataSourceNicMultipleResultsError = testAccCheckNicConfigBasic + `
@@ -302,7 +302,7 @@ resource ` + constant.NicResource + ` "database_nic_multiple_results" {
 }
 
 data ` + constant.NicResource + ` test_nic_data {
-  	datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
-	server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
-	name = ` + constant.FullNicResourceName + `.name 
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
+  name = ` + constant.FullNicResourceName + `.name 
 }`

--- a/ionoscloud/resource_nic_test.go
+++ b/ionoscloud/resource_nic_test.go
@@ -100,6 +100,13 @@ func TestAccNicBasic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+dataSourceNicById, "ipv6_ips", constant.FullNicResourceName, "ipv6_ips"),
 				),
 			},
+			{
+				Config: testAccCheckNicConfigUpdateIpv6,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+dataSourceNicById, "ipv6_cidr_block", constant.FullNicResourceName, "ipv6_cidr_block"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+dataSourceNicById, "ipv6_ips", constant.FullNicResourceName, "ipv6_ips"),
+				),
+			},
 		},
 	})
 }
@@ -252,6 +259,32 @@ data ` + constant.NicResource + ` test_nic_data {
   id = ` + constant.FullNicResourceName + `.id
 }
 `
+
+const testAccCheckNicConfigUpdateIpv6 = testCreateDataCenterAndServer + `
+resource ` + constant.NicResource + ` "database_nic" {
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
+  lan = "${ionoscloud_lan.test_lan_2.id}"
+  dhcp = false
+  dhcpv6 = false
+  firewall_active = false
+  firewall_type = "BIDIRECTIONAL"
+  ips = [ ionoscloud_ipblock.test_server.ips[0], ionoscloud_ipblock.test_server.ips[1] ]
+  name = "updated"
+  ipv6_cidr_block = cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,16)
+  ipv6_ips = [ 
+                cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,16),10),
+                cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,16),30)
+             ]
+}
+
+data ` + constant.NicResource + ` test_nic_data {
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
+  id = ` + constant.FullNicResourceName + `.id
+}
+`
+
 const dataSourceNicById = constant.NicResource + ".test_nic_data"
 
 const testAccDataSourceNicMatchId = testAccCheckNicConfigBasic + `

--- a/ionoscloud/resource_nic_test.go
+++ b/ionoscloud/resource_nic_test.go
@@ -236,6 +236,12 @@ resource ` + constant.NicResource + ` "database_nic" {
   firewall_type = "BIDIRECTIONAL"
   ips = [ ionoscloud_ipblock.test_server.ips[0], ionoscloud_ipblock.test_server.ips[1] ]
   name = "updated"
+  ipv6_cidr_block = cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12)
+  ipv6_ips = [ 
+				cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),1),
+				cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),2),
+				cidrhost(cidrsubnet(ionoscloud_lan.test_lan_2.ipv6_cidr_block,16,12),3)
+			]
 }
 `
 const dataSourceNicById = constant.NicResource + ".test_nic_data"


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Allows user supplied values other than `AUTO` for the `ipv6_cidr_block` field of the nic resource.
## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
