### PR TITLE
fix: increase notfoundchecks to 9999 for k8s large clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - `ssh_keys` was no longer being set if server was not vcpu.
 - `ssh_keys` will no longer be computed on any type of server
 - `ssh_key_path` will now be set to schema on creation
-- Fix setting explicit `ipv6_cidr_block` on `nic` resource.
+- Allow setting explicit `ipv6_cidr_block` on `nic` resource.
+- #449. Increase `NotFoundChecks` to 9999.
 
 ## 6.4.7
 ### Features

--- a/services/cloudapi/state.go
+++ b/services/cloudapi/state.go
@@ -3,11 +3,12 @@ package cloudapi
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"
-	"log"
-	"time"
 )
 
 // GetStateChangeConf gets the default configuration for tracking a request progress
@@ -18,8 +19,8 @@ func GetStateChangeConf(meta interface{}, d *schema.ResourceData, location strin
 		Refresh:        resourceStateRefreshFunc(meta, location),
 		Timeout:        d.Timeout(timeoutType),
 		MinTimeout:     5 * time.Second,
-		Delay:          0,   // Don't delay the start
-		NotFoundChecks: 600, //Setting high number, to support long timeouts
+		Delay:          0,    // Don't delay the start
+		NotFoundChecks: 9999, //Setting high number, to support long timeouts
 	}
 
 	return stateConf


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
