### PR TITLE
Feat/implement volume boot order

### DIFF
--- a/docs/data-sources/cube_server.md
+++ b/docs/data-sources/cube_server.md
@@ -99,6 +99,7 @@ The following attributes are returned by the datasource:
   * `pci_slot` - The PCI slot number of the storage volume
   * `backup_unit_id` - The uuid of the Backup Unit that user has access to
   * `user_data` - The cloud-init configuration for the volume as base64 encoded string
+  * `is_boot_volume` - The volume is set as primary boot device
 * `nics` - list of
   * `id` - Id of the attached nic
   * `name` - Name of the attached nid

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -101,7 +101,7 @@ The following attributes are returned by the datasource:
   * `pci_slot` - The PCI slot number of the storage volume
   * `backup_unit_id` - The uuid of the Backup Unit that user has access to
   * `user_data` - The cloud-init configuration for the volume as base64 encoded string
-  * `boot_order` - The volume can be set as a primary boot device.
+  * `is_boot_volume` - The volume is set as primary boot device
 * `nics` - list of
   * `id` - Id of the attached nic
   * `name` - Name of the attached nid

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -101,6 +101,7 @@ The following attributes are returned by the datasource:
   * `pci_slot` - The PCI slot number of the storage volume
   * `backup_unit_id` - The uuid of the Backup Unit that user has access to
   * `user_data` - The cloud-init configuration for the volume as base64 encoded string
+  * `boot_order` - The volume can be set as a primary boot device.
 * `nics` - list of
   * `id` - Id of the attached nic
   * `name` - Name of the attached nid

--- a/docs/data-sources/vcpu_server.md
+++ b/docs/data-sources/vcpu_server.md
@@ -100,6 +100,7 @@ The following attributes are returned by the datasource:
   * `pci_slot` - The PCI slot number of the storage volume
   * `backup_unit_id` - The uuid of the Backup Unit that user has access to
   * `user_data` - The cloud-init configuration for the volume as base64 encoded string
+  * `is_boot_volume` - The volume is set as primary boot device
 * `nics` - list of
   * `id` - Id of the attached nic
   * `name` - Name of the attached nid

--- a/docs/data-sources/volume.md
+++ b/docs/data-sources/volume.md
@@ -64,4 +64,4 @@ The following attributes are returned by the datasource:
 * `disc_virtio_hot_plug` - Is capable of Virt-IO drive hot plug (no reboot required)
 * `disc_virtio_hot_unplug` - Is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines.
 * `boot_server` - The UUID of the attached server.
-* `boot_order` - The volume can be set as a primary boot device.
+* `is_boot_volume` - The volume can be set as a primary boot device.

--- a/docs/data-sources/volume.md
+++ b/docs/data-sources/volume.md
@@ -64,3 +64,4 @@ The following attributes are returned by the datasource:
 * `disc_virtio_hot_plug` - Is capable of Virt-IO drive hot plug (no reboot required)
 * `disc_virtio_hot_unplug` - Is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines.
 * `boot_server` - The UUID of the attached server.
+* `boot_order` - The volume can be set as a primary boot device.

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -144,7 +144,7 @@ resource "random_password" "volume_image_password" {
 * `disc_virtio_hot_plug` - (Computed)[string] Is capable of Virt-IO drive hot plug (no reboot required)
 * `disc_virtio_hot_unplug` - (Computed)[string] Is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines.
 * `boot_server` - (Computed)[string] The UUID of the attached server.
-* `is_boot_volume` - (Computed)(Optional)[boolean] The volume can be set as the primary boot device of the server to which it is attached. If the property is omited, the inline volume will be set as primary boot device, by default. Setting this property while a different volume is already the primary boot device will result in the other volume being unset, and the current volume becoming the primary boot device. There will always be one boot volume for the server.
+* `is_boot_volume` - (Computed)(Optional)[boolean] The volume can be set as the primary boot device of the server to which it is attached. If the property is omitted, the inline volume will be set as primary boot device, by default. Setting this property while a different volume is already the primary boot device will result in the other volume being unset, and the current volume becoming the primary boot device. There will always be one boot volume for the server.
 > **⚠ WARNING**
 >
 > ssh_key_path and ssh_keys fields are immutable.

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -13,7 +13,7 @@ Manages a **Volume** on IonosCloud.
 
 ## Example Usage
 
-A primary volume will be created with the server. If there is a need for additional volumes, this resource handles it.
+A primary volume will be created with the server. If there is a need for additional volumes, this resource handles it. Any of the additional volumes can be used as a boot volume.
 
 ```hcl
 data "ionoscloud_image" "example" {
@@ -58,6 +58,7 @@ resource "ionoscloud_server" "example" {
         user_data         = "foo"
         bus               = "VIRTIO"
         availability_zone = "ZONE_1"
+        boot_order        = "NONE"
     }
     nic {
         lan               = ionoscloud_lan.example.id
@@ -90,6 +91,7 @@ resource "ionoscloud_volume" "example" {
   image_name              = data.ionoscloud_image.example.id
   image_password          = random_password.volume_image_password.result
   user_data               = "foo"
+  boot_order              = "PRIMARY"
 }
 
 resource "ionoscloud_volume" "example" {
@@ -142,6 +144,7 @@ resource "random_password" "volume_image_password" {
 * `disc_virtio_hot_plug` - (Computed)[string] Is capable of Virt-IO drive hot plug (no reboot required)
 * `disc_virtio_hot_unplug` - (Computed)[string] Is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines.
 * `boot_server` - (Computed)[string] The UUID of the attached server.
+* `boot_order` - (Optional)[string] The volume can be used as a primary boot device: AUTO, PRIMARY, NONE. By default, the inline volume of the server will always be the primary boot volume unless a different external volume is set as PRIMARY or the inline volume is explicitly set to NONE.
 > **⚠ WARNING**
 >
 > ssh_key_path and ssh_keys fields are immutable.

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -58,7 +58,7 @@ resource "ionoscloud_server" "example" {
         user_data         = "foo"
         bus               = "VIRTIO"
         availability_zone = "ZONE_1"
-        boot_order        = "NONE"
+        is_boot_volume    = false
     }
     nic {
         lan               = ionoscloud_lan.example.id
@@ -91,7 +91,7 @@ resource "ionoscloud_volume" "example" {
   image_name              = data.ionoscloud_image.example.id
   image_password          = random_password.volume_image_password.result
   user_data               = "foo"
-  boot_order              = "PRIMARY"
+  is_boot_volume          = true
 }
 
 resource "ionoscloud_volume" "example" {
@@ -144,7 +144,7 @@ resource "random_password" "volume_image_password" {
 * `disc_virtio_hot_plug` - (Computed)[string] Is capable of Virt-IO drive hot plug (no reboot required)
 * `disc_virtio_hot_unplug` - (Computed)[string] Is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines.
 * `boot_server` - (Computed)[string] The UUID of the attached server.
-* `boot_order` - (Optional)[string] The volume can be used as a primary boot device: AUTO, PRIMARY, NONE. By default, the inline volume of the server will always be the primary boot volume unless a different external volume is set as PRIMARY or the inline volume is explicitly set to NONE.
+* `is_boot_volume` - (Computed)(Optional)[boolean] The volume can be set as the primary boot device of the server to which it is attached. If the property is omited, the inline volume will be set as primary boot device, by default. Setting this property while a different volume is already the primary boot device will result in the other volume being unset, and the current volume becoming the primary boot device. There will always be one boot volume for the server.
 > **⚠ WARNING**
 >
 > ssh_key_path and ssh_keys fields are immutable.

--- a/ionoscloud/data_source_cube_server.go
+++ b/ionoscloud/data_source_cube_server.go
@@ -158,6 +158,10 @@ func dataSourceCubeServer() *schema.Resource {
 							Description: "The UUID of the attached server.",
 							Computed:    true,
 						},
+						"is_boot_volume": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/ionoscloud/data_source_server.go
+++ b/ionoscloud/data_source_server.go
@@ -172,6 +172,10 @@ func dataSourceServer() *schema.Resource {
 							Description: "The UUID of the attached server.",
 							Computed:    true,
 						},
+						"boot_order": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/ionoscloud/data_source_server.go
+++ b/ionoscloud/data_source_server.go
@@ -172,8 +172,8 @@ func dataSourceServer() *schema.Resource {
 							Description: "The UUID of the attached server.",
 							Computed:    true,
 						},
-						"boot_order": {
-							Type:     schema.TypeString,
+						"is_boot_volume": {
+							Type:     schema.TypeBool,
 							Computed: true,
 						},
 					},

--- a/ionoscloud/data_source_vcpu_server.go
+++ b/ionoscloud/data_source_vcpu_server.go
@@ -160,6 +160,10 @@ func dataSourceVCPUServer() *schema.Resource {
 							Description: "The UUID of the attached server.",
 							Computed:    true,
 						},
+						"is_boot_volume": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/ionoscloud/data_source_volume.go
+++ b/ionoscloud/data_source_volume.go
@@ -104,6 +104,10 @@ func dataSourceVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"boot_order": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 		Timeouts: &resourceDefaultTimeouts,
 	}

--- a/ionoscloud/data_source_volume.go
+++ b/ionoscloud/data_source_volume.go
@@ -104,9 +104,10 @@ func dataSourceVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"boot_order": {
-				Type:     schema.TypeString,
-				Computed: true,
+			"is_boot_volume": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "The volume is set as the primary boot device.",
 			},
 		},
 		Timeouts: &resourceDefaultTimeouts,

--- a/ionoscloud/import_volume_test.go
+++ b/ionoscloud/import_volume_test.go
@@ -29,7 +29,7 @@ func TestAccVolumeImportBasic(t *testing.T) {
 				ImportStateIdFunc:       testAccVolumeImportStateId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image_password", "ssh_key_path.#", "image_name", "user_data", "backup_unit_id"},
+				ImportStateVerifyIgnore: []string{"image_password", "ssh_key_path.#", "image_name", "user_data", "backup_unit_id", "boot_order"},
 			},
 		},
 	})

--- a/ionoscloud/import_volume_test.go
+++ b/ionoscloud/import_volume_test.go
@@ -29,7 +29,7 @@ func TestAccVolumeImportBasic(t *testing.T) {
 				ImportStateIdFunc:       testAccVolumeImportStateId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image_password", "ssh_key_path.#", "image_name", "user_data", "backup_unit_id", "boot_order"},
+				ImportStateVerifyIgnore: []string{"image_password", "ssh_key_path.#", "image_name", "user_data", "backup_unit_id", "is_boot_volume"},
 			},
 		},
 	})

--- a/ionoscloud/resource_nic_test.go
+++ b/ionoscloud/resource_nic_test.go
@@ -1,3 +1,5 @@
+//go:build compute || all || nic
+
 package ionoscloud
 
 import (

--- a/ionoscloud/resource_server_cube.go
+++ b/ionoscloud/resource_server_cube.go
@@ -217,7 +217,7 @@ func resourceCubeServer() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Computed:    true,
-							Description: "Sets this volume as the primary boot volume of the server. If there is another volume is already set as the primary boot volume, it will be unset.",
+							Description: "Sets this volume as the primary boot volume of the server. If a different volume is already set as the primary boot device, it will be overriden by this volume.",
 						},
 					},
 				},

--- a/ionoscloud/resource_server_cube.go
+++ b/ionoscloud/resource_server_cube.go
@@ -740,7 +740,7 @@ func resourceCubeServerRead(ctx context.Context, d *schema.ResourceData, meta in
 			var inlineVolumeIds []string
 			inlineVolumeIds = append(inlineVolumeIds, bootVolume)
 			if err := d.Set("inline_volume_ids", inlineVolumeIds); err != nil {
-				return diag.FromErr(utils.GenerateSetError("server", "inline_volume_ids", err))
+				return diag.FromErr(utils.GenerateSetError("cube_server", "inline_volume_ids", err))
 			}
 		}
 	}

--- a/ionoscloud/resource_server_cube_test.go
+++ b/ionoscloud/resource_server_cube_test.go
@@ -346,16 +346,35 @@ func TestAccCubeServerPrimaryBootVolume(t *testing.T) {
 		CheckDestroy:      testAccCheckCubeServerDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCubeServerNoFirewall,
+				Config: testAccCheckCubeServerConfigPrimaryBootVolume,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCubeServerExists(constant.ServerCubeResource+"."+constant.ServerTestResource, &server),
 					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "name", constant.ServerTestResource),
 					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "availability_zone", "AUTO"),
 					resource.TestCheckResourceAttrPair(constant.ServerCubeResource+"."+constant.ServerTestResource, "image_password", constant.RandomPassword+".server_image_password", "result"),
-					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.name", "system"),
+					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.name", "Inline"),
 					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.disk_type", "DAS"),
 					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.bus", "VIRTIO"),
 					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.availability_zone", "AUTO"),
+					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.is_boot_volume", "true"),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "name", "External"),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "is_boot_volume", "false"),
+				),
+			},
+			{
+				Config: testAccCheckCubeServerConfigPrimaryBootVolumeUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCubeServerExists(constant.ServerCubeResource+"."+constant.ServerTestResource, &server),
+					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "name", constant.ServerTestResource),
+					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "availability_zone", "AUTO"),
+					resource.TestCheckResourceAttrPair(constant.ServerCubeResource+"."+constant.ServerTestResource, "image_password", constant.RandomPassword+".server_image_password", "result"),
+					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.name", "Inline Updated"),
+					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.disk_type", "DAS"),
+					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.bus", "VIRTIO"),
+					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.availability_zone", "AUTO"),
+					resource.TestCheckResourceAttr(constant.ServerCubeResource+"."+constant.ServerTestResource, "volume.0.is_boot_volume", "false"),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "name", "External Updated"),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "is_boot_volume", "true"),
 				),
 			},
 		},
@@ -759,15 +778,15 @@ resource ` + constant.LanResource + ` ` + constant.LanTestResource + ` {
   name = "public"
 }
 resource ` + constant.ServerCubeResource + ` ` + constant.ServerTestResource + ` {
-  name = "` + constant.UpdatedResources + `"
+  name = "` + constant.ServerTestResource + `"
   datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
   availability_zone = "AUTO"
   image_name ="ubuntu:latest"
-  image_password = ` + constant.RandomPassword + `.server_image_password_updated.result
+  image_password = ` + constant.RandomPassword + `.server_image_password.result
   template_uuid = data.ionoscloud_template.` + constant.ServerTestResource + `.id
 
   volume {
-    name = "` + constant.ServerTestResource + `"
+    name = "Inline"
     licence_type = "LINUX"
     disk_type = "DAS"
     is_boot_volume = true
@@ -784,8 +803,8 @@ resource ` + constant.ServerCubeResource + ` ` + constant.ServerTestResource + `
 
 resource ` + constant.VolumeResource + ` ` + constant.VolumeTestResource + ` {
     datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
-    server_id = ` + constant.ServerResource + `.` + constant.ServerTestResource + `.id
-    name = "External Volume"
+    server_id = ` + constant.ServerCubeResource + `.` + constant.ServerTestResource + `.id
+    name = "External"
     availability_zone = "ZONE_1"
     size = 10
     disk_type = "SSD Standard"
@@ -794,4 +813,66 @@ resource ` + constant.VolumeResource + ` ` + constant.VolumeTestResource + ` {
     image_name = "debian:latest"
     image_password = ` + constant.RandomPassword + `.server_image_password.result
   }
-` + ServerImagePasswordUpdated
+` + ServerImagePassword
+
+const testAccCheckCubeServerConfigPrimaryBootVolumeUpdate = `
+data "ionoscloud_template" ` + constant.ServerTestResource + ` {
+    name  = "CUBES XS"
+    cores = 1
+    ram   = 1024
+    storage_size = 30
+}
+
+resource ` + constant.DatacenterResource + ` ` + constant.DatacenterTestResource + ` {
+	name = "server-test"
+	location = "de/fra"
+}
+
+resource "ionoscloud_ipblock" "webserver_ipblock" {
+  location = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.location
+  size = 4
+  name = "webserver_ipblock"
+}
+resource ` + constant.LanResource + ` ` + constant.LanTestResource + ` {
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  public = true
+  name = "public"
+}
+resource ` + constant.ServerCubeResource + ` ` + constant.ServerTestResource + ` {
+  name = "` + constant.ServerTestResource + `"
+  datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+  availability_zone = "AUTO"
+  image_name ="ubuntu:latest"
+  image_password = ` + constant.RandomPassword + `.server_image_password.result
+  template_uuid = data.ionoscloud_template.` + constant.ServerTestResource + `.id
+
+  volume {
+    name = "Inline Updated"
+    licence_type = "LINUX"
+    disk_type = "DAS"
+    is_boot_volume = false
+  }
+  nic {
+    lan = ` + constant.LanResource + `.` + constant.LanTestResource + `.id
+    name = "` + constant.UpdatedResources + `"
+    dhcp = true
+    firewall_active = true
+    firewall_type = "BIDIRECTIONAL"
+    ips = [ ionoscloud_ipblock.webserver_ipblock.ips[0], ionoscloud_ipblock.webserver_ipblock.ips[1] ]
+  }
+}
+
+resource ` + constant.VolumeResource + ` ` + constant.VolumeTestResource + ` {
+    datacenter_id = ` + constant.DatacenterResource + `.` + constant.DatacenterTestResource + `.id
+    server_id = ` + constant.ServerCubeResource + `.` + constant.ServerTestResource + `.id
+    name = "External Updated"
+    availability_zone = "ZONE_1"
+    size = 10
+    disk_type = "SSD Standard"
+    bus = "VIRTIO"
+    licence_type = "OTHER"
+    image_name = "debian:latest"
+    is_boot_volume = true
+    image_password = ` + constant.RandomPassword + `.server_image_password.result
+  }
+` + ServerImagePassword

--- a/ionoscloud/resource_server_test.go
+++ b/ionoscloud/resource_server_test.go
@@ -344,8 +344,8 @@ func TestAccServerPrimaryBootVolume(t *testing.T) {
 					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.disk_type", "SSD Standard"),
 					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.bus", "VIRTIO"),
 					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.availability_zone", "AUTO"),
-					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.boot_order", "AUTO"),
-					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order", "PRIMARY"),
+					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.is_boot_volume", "false"),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "is_boot_volume", "true"),
 				),
 			},
 			{
@@ -358,8 +358,8 @@ func TestAccServerPrimaryBootVolume(t *testing.T) {
 					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.disk_type", "SSD Standard"),
 					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.bus", "VIRTIO"),
 					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.availability_zone", "AUTO"),
-					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.boot_order", "AUTO"),
-					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order", "NONE"),
+					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.is_boot_volume", "true"),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "is_boot_volume", "false"),
 				),
 			},
 		},
@@ -1938,7 +1938,7 @@ resource ` + constant.ServerResource + ` ` + constant.ServerTestResource + ` {
     disk_type = "SSD Standard"
     bus = "VIRTIO"
     availability_zone = "AUTO"
-    boot_order = "AUTO"
+    is_boot_volume = "false"
   }
   nic {
     lan = ` + constant.LanResource + `.` + constant.LanTestResource + `.id
@@ -1960,7 +1960,7 @@ resource ` + constant.VolumeResource + ` ` + constant.VolumeTestResource + ` {
   licence_type            = "OTHER"
   image_password          = ` + constant.RandomPassword + `.server_image_password.result
   image_name              = "debian:latest"
-  boot_order              = "PRIMARY"
+  is_boot_volume              = "true"
 }
 
 resource ` + constant.RandomPassword + ` "server_image_password" {
@@ -1997,7 +1997,7 @@ resource ` + constant.ServerResource + ` ` + constant.ServerTestResource + ` {
     disk_type = "SSD Standard"
     bus = "VIRTIO"
     availability_zone = "AUTO"
-    boot_order = "PRIMARY"
+    is_boot_volume = "true"
   }
   nic {
     lan = ` + constant.LanResource + `.` + constant.LanTestResource + `.id
@@ -2019,7 +2019,7 @@ resource ` + constant.VolumeResource + ` ` + constant.VolumeTestResource + ` {
   licence_type            = "OTHER"
   image_name              = "debian:latest"
   image_password          = ` + constant.RandomPassword + `.server_image_password.result
-  boot_order              = "NONE"
+  is_boot_volume              = "false"
 }
 
 resource ` + constant.RandomPassword + ` "server_image_password" {

--- a/ionoscloud/resource_server_vcpu.go
+++ b/ionoscloud/resource_server_vcpu.go
@@ -206,7 +206,7 @@ func resourceVCPUServer() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Computed:    true,
-							Description: "The volume is set as primary boot device.",
+							Description: "Sets this volume as the primary boot volume of the server. If a different volume is already set as the primary boot device, it will be overriden by this volume.",
 						},
 					},
 				},

--- a/ionoscloud/resource_server_vcpu.go
+++ b/ionoscloud/resource_server_vcpu.go
@@ -202,6 +202,13 @@ func resourceVCPUServer() *schema.Resource {
 							Description: "The UUID of the attached server.",
 							Computed:    true,
 						},
+						"boot_order": {
+							Type:             schema.TypeString,
+							Default:          constant.BootOrderAuto,
+							Optional:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{constant.BootOrderAuto, constant.BootOrderNone, constant.BootOrderPrimary}, true)),
+							Description:      "Determines if the volume will be used as the boot device. Possible values: 'AUTO' (default), 'NONE', 'PRIMARY'. The default behavior set by 'AUTO' means that the volume will be set as the boot device if there are no other volumes or cdrom devices. 'PRIMARY' will set this volume as the boot device and unset other devices, if they exist.",
+						},
 					},
 				},
 			},

--- a/ionoscloud/resource_server_vcpu.go
+++ b/ionoscloud/resource_server_vcpu.go
@@ -202,12 +202,11 @@ func resourceVCPUServer() *schema.Resource {
 							Description: "The UUID of the attached server.",
 							Computed:    true,
 						},
-						"boot_order": {
-							Type:             schema.TypeString,
-							Default:          constant.BootOrderAuto,
-							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{constant.BootOrderAuto, constant.BootOrderNone, constant.BootOrderPrimary}, true)),
-							Description:      "Determines if the volume will be used as the boot device. Possible values: 'AUTO' (default), 'NONE', 'PRIMARY'. The default behavior set by 'AUTO' means that the volume will be set as the boot device if there are no other volumes or cdrom devices. 'PRIMARY' will set this volume as the boot device and unset other devices, if they exist.",
+						"is_boot_volume": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "The volume is set as primary boot device.",
 						},
 					},
 				},

--- a/ionoscloud/resource_volume_test.go
+++ b/ionoscloud/resource_volume_test.go
@@ -1,4 +1,4 @@
-//go:build compute || all || volumes
+//go:build compute || all || volume
 
 package ionoscloud
 
@@ -42,8 +42,8 @@ func TestAccVolumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "disk_type", "SSD Standard"),
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "bus", "VIRTIO"),
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "availability_zone", "ZONE_1"),
-					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order", constant.BootOrderPrimary),
-					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.boot_order", constant.BootOrderAuto),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "is_boot_volume", "true"),
+					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.is_boot_volume", "false"),
 					resource.TestCheckResourceAttrSet(constant.VolumeResource+"."+constant.VolumeTestResource, "image_name"),
 					resource.TestCheckResourceAttrPair(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_server", constant.ServerResource+"."+constant.ServerTestResource, "id"),
 					resource.TestCheckResourceAttrPair(constant.VolumeResource+"."+constant.VolumeTestResource, "image_password", constant.RandomPassword+".server_image_password", "result"),
@@ -66,7 +66,7 @@ func TestAccVolumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "disc_virtio_hot_plug", constant.VolumeResource+"."+constant.VolumeTestResource, "disc_virtio_hot_plug"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "disc_virtio_hot_unplug", constant.VolumeResource+"."+constant.VolumeTestResource, "disc_virtio_hot_unplug"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "device_number", constant.VolumeResource+"."+constant.VolumeTestResource, "device_number"),
-					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "boot_order", constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "is_boot_volume", constant.VolumeResource+"."+constant.VolumeTestResource, "is_boot_volume"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "boot_server", constant.ServerResource+"."+constant.ServerTestResource, "id"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "id", constant.ServerResource+"."+constant.ServerTestResource, "boot_volume"),
 				),
@@ -88,7 +88,7 @@ func TestAccVolumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "disc_virtio_hot_plug", constant.VolumeResource+"."+constant.VolumeTestResource, "disc_virtio_hot_plug"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "disc_virtio_hot_unplug", constant.VolumeResource+"."+constant.VolumeTestResource, "disc_virtio_hot_unplug"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "device_number", constant.VolumeResource+"."+constant.VolumeTestResource, "device_number"),
-					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "boot_order", constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "is_boot_volume", constant.VolumeResource+"."+constant.VolumeTestResource, "is_boot_volume"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "boot_server", constant.ServerResource+"."+constant.ServerTestResource, "id"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "id", constant.ServerResource+"."+constant.ServerTestResource, "boot_volume"),
 				),
@@ -105,8 +105,8 @@ func TestAccVolumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "disk_type", "SSD Standard"),
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "bus", "VIRTIO"),
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "availability_zone", "ZONE_1"),
-					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order", constant.BootOrderNone),
-					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource+"updated", "volume.0.boot_order", constant.BootOrderAuto),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "is_boot_volume", "false"),
+					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource+"updated", "volume.0.is_boot_volume", "true"),
 					resource.TestCheckResourceAttrSet(constant.VolumeResource+"."+constant.VolumeTestResource, "image_name"),
 					resource.TestCheckResourceAttrPair(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_server", constant.ServerResource+"."+constant.ServerTestResource+"updated", "id"),
 					resource.TestCheckResourceAttrPair(constant.VolumeResource+"."+constant.VolumeTestResource, "image_password", constant.RandomPassword+".server_image_password_updated", "result"),
@@ -252,6 +252,7 @@ resource ` + constant.ServerResource + ` ` + constant.ServerTestResource + `{
     name = "system"
     size = 5
     disk_type = "HDD"
+    is_boot_volume = false
   }
   nic {
     lan = ` + constant.LanResource + `.` + constant.LanTestResource + `.id
@@ -270,7 +271,8 @@ resource ` + constant.VolumeResource + ` ` + constant.VolumeTestResource + ` {
 	image_name ="ubuntu:latest"
 	image_password = ` + constant.RandomPassword + `.server_image_password.result
 	user_data = "foo"
-	boot_order = "` + constant.BootOrderPrimary + `"
+	is_boot_volume = true
+
 }
 ` + ServerImagePassword
 
@@ -322,6 +324,7 @@ resource ` + constant.ServerResource + ` ` + constant.ServerTestResource + `upda
     name = "system"
     size = 5
     disk_type = "HDD"
+    is_boot_volume = true
   }
   nic {
     lan = ` + constant.LanResource + `.` + constant.LanTestResource + `.id
@@ -340,7 +343,7 @@ resource ` + constant.VolumeResource + ` ` + constant.VolumeTestResource + ` {
 	image_name ="ubuntu:latest"
 	image_password = ` + constant.RandomPassword + `.server_image_password_updated.result
 	user_data = "foo"
-	boot_order = "` + constant.BootOrderNone + `"
+	is_boot_volume = false
 }
 ` + ServerImagePassword + ServerImagePasswordUpdated
 

--- a/ionoscloud/resource_volume_test.go
+++ b/ionoscloud/resource_volume_test.go
@@ -1,4 +1,4 @@
-//go:build compute || all || volume
+//go:build compute || all || volumes
 
 package ionoscloud
 
@@ -42,6 +42,8 @@ func TestAccVolumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "disk_type", "SSD Standard"),
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "bus", "VIRTIO"),
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "availability_zone", "ZONE_1"),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order", constant.BootOrderPrimary),
+					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource, "volume.0.boot_order", constant.BootOrderAuto),
 					resource.TestCheckResourceAttrSet(constant.VolumeResource+"."+constant.VolumeTestResource, "image_name"),
 					resource.TestCheckResourceAttrPair(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_server", constant.ServerResource+"."+constant.ServerTestResource, "id"),
 					resource.TestCheckResourceAttrPair(constant.VolumeResource+"."+constant.VolumeTestResource, "image_password", constant.RandomPassword+".server_image_password", "result"),
@@ -64,7 +66,9 @@ func TestAccVolumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "disc_virtio_hot_plug", constant.VolumeResource+"."+constant.VolumeTestResource, "disc_virtio_hot_plug"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "disc_virtio_hot_unplug", constant.VolumeResource+"."+constant.VolumeTestResource, "disc_virtio_hot_unplug"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "device_number", constant.VolumeResource+"."+constant.VolumeTestResource, "device_number"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "boot_order", constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "boot_server", constant.ServerResource+"."+constant.ServerTestResource, "id"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceById, "id", constant.ServerResource+"."+constant.ServerTestResource, "boot_volume"),
 				),
 			},
 			{
@@ -84,7 +88,9 @@ func TestAccVolumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "disc_virtio_hot_plug", constant.VolumeResource+"."+constant.VolumeTestResource, "disc_virtio_hot_plug"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "disc_virtio_hot_unplug", constant.VolumeResource+"."+constant.VolumeTestResource, "disc_virtio_hot_unplug"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "device_number", constant.VolumeResource+"."+constant.VolumeTestResource, "device_number"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "boot_order", constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order"),
 					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "boot_server", constant.ServerResource+"."+constant.ServerTestResource, "id"),
+					resource.TestCheckResourceAttrPair(constant.DataSource+"."+constant.VolumeResource+"."+constant.VolumeDataSourceByName, "id", constant.ServerResource+"."+constant.ServerTestResource, "boot_volume"),
 				),
 			},
 			{
@@ -99,6 +105,8 @@ func TestAccVolumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "disk_type", "SSD Standard"),
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "bus", "VIRTIO"),
 					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "availability_zone", "ZONE_1"),
+					resource.TestCheckResourceAttr(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_order", constant.BootOrderNone),
+					resource.TestCheckResourceAttr(constant.ServerResource+"."+constant.ServerTestResource+"updated", "volume.0.boot_order", constant.BootOrderAuto),
 					resource.TestCheckResourceAttrSet(constant.VolumeResource+"."+constant.VolumeTestResource, "image_name"),
 					resource.TestCheckResourceAttrPair(constant.VolumeResource+"."+constant.VolumeTestResource, "boot_server", constant.ServerResource+"."+constant.ServerTestResource+"updated", "id"),
 					resource.TestCheckResourceAttrPair(constant.VolumeResource+"."+constant.VolumeTestResource, "image_password", constant.RandomPassword+".server_image_password_updated", "result"),
@@ -262,6 +270,7 @@ resource ` + constant.VolumeResource + ` ` + constant.VolumeTestResource + ` {
 	image_name ="ubuntu:latest"
 	image_password = ` + constant.RandomPassword + `.server_image_password.result
 	user_data = "foo"
+	boot_order = "` + constant.BootOrderPrimary + `"
 }
 ` + ServerImagePassword
 
@@ -331,6 +340,7 @@ resource ` + constant.VolumeResource + ` ` + constant.VolumeTestResource + ` {
 	image_name ="ubuntu:latest"
 	image_password = ` + constant.RandomPassword + `.server_image_password_updated.result
 	user_data = "foo"
+	boot_order = "` + constant.BootOrderNone + `"
 }
 ` + ServerImagePassword + ServerImagePasswordUpdated
 

--- a/utils/constant/constants.go
+++ b/utils/constant/constants.go
@@ -324,3 +324,10 @@ const (
 
 const VCPUType = "VCPU"
 const RepoURL = "https://github.com/ionos-cloud/terraform-provider-ionoscloud"
+
+const (
+	// Volume Boot Order values
+	BootOrderPrimary = "PRIMARY"
+	BootOrderNone    = "NONE"
+	BootOrderAuto    = "AUTO"
+)


### PR DESCRIPTION
## What does this fix or implement?
Ability to select the primary boot volume for `ionoscloud_server`
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
