### PR TITLE
fix: is_system_user should be computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 6.4.11 (upcoming release)
+## 6.4.12 (upcoming release)
+
+### Fixes
+- `is_system_user` is actually only read-only. You cannot actually set it.
+- 
+## 6.4.11
 ### Documentation
 - Refactor readme files to better explain the usage of the provider
 

--- a/docs/resources/dbaas_pgsql_user.md
+++ b/docs/resources/dbaas_pgsql_user.md
@@ -21,7 +21,6 @@ resource "ionoscloud_pg_user" "example_pg_user" {
   cluster_id = ionoscloud_pg_cluster.example.id
   username = "exampleuser"
   password = random_password.user_password.result
-  is_system_user = false
 }
 
 resource "random_password" "user_password" {
@@ -36,7 +35,7 @@ resource "random_password" "user_password" {
 * `cluster_id` - (Required)[string] The unique ID of the cluster. Updates to the value of the field force the cluster to be re-created.
 * `username` - (Required)[string] Used for authentication. Updates to the value of the field force the cluster to be re-created.
 * `password` - (Required)[string] User password.
-* `is_system_user` - (Optional)[bool] Describes whether this user is a system user or not. A system user cannot be updated or deleted.
+* `is_system_user` - (Computed)[bool] Describes whether this user is a system user or not. A system user cannot be updated or deleted.
 
 ## Import
 

--- a/ionoscloud/resource_dbaas_pgsql_user.go
+++ b/ionoscloud/resource_dbaas_pgsql_user.go
@@ -44,7 +44,6 @@ func resourceDbaasPgSqlUser() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Describes whether this user is a system user or not. A system user cannot be updated or deleted.",
 				Computed:    true,
-				Optional:    true,
 			},
 		},
 		Timeouts: &resourceDefaultTimeouts,
@@ -64,14 +63,9 @@ func resourceDbaasPgSqlUserCreate(ctx context.Context, d *schema.ResourceData, m
 	request.Properties.Username = &username
 	request.Properties.Password = &password
 
-	if isSystemUser, ok := d.GetOk("is_system_user"); ok {
-		isSystemUserValue := isSystemUser.(bool)
-		request.Properties.System = &isSystemUserValue
-	}
-
 	user, _, err := client.CreateUser(ctx, clusterId, request)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("an error occured while adding the user: %s to the PgSql cluster with ID: %s, error: %w", username, clusterId, err))
+		return diag.FromErr(fmt.Errorf("an error occurred while adding the user: %s to the PgSql cluster with ID: %s, error: %w", username, clusterId, err))
 	}
 	d.SetId(*user.Id)
 	// Wait for the cluster to be ready again (when creating/updating the user, the cluster enters

--- a/ionoscloud/resource_dbaas_pgsql_user_test.go
+++ b/ionoscloud/resource_dbaas_pgsql_user_test.go
@@ -152,7 +152,6 @@ resource ` + constant.PsqlUserResource + ` ` + constant.UserTestResource + ` {
   ` + clusterIdAttribute + ` = ` + constant.PsqlClusterResource + `.` + constant.DBaaSClusterTestResource + `.id 
   ` + usernameAttribute + ` = "` + usernameValue + `"
   ` + passwordAttribute + ` = ` + constant.RandomPassword + `.user_password.result
-  ` + isSystemUserAttribute + ` = ` + isSystemUserValue + `
 }
 
 resource ` + constant.RandomPassword + ` "cluster_password" {

--- a/ionoscloud/resource_nic_test.go
+++ b/ionoscloud/resource_nic_test.go
@@ -1,3 +1,5 @@
+//go:build compute || all || nic
+
 package ionoscloud
 
 import (


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

You cannot set a user to be a system user in the API. It's only reaonly.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
