### PR TITLE
test: Update tests for Mongo DB users, update documentation for Mongo…

### DIFF
--- a/docs/resources/dbaas_mongo_cluster.md
+++ b/docs/resources/dbaas_mongo_cluster.md
@@ -29,7 +29,7 @@ resource "ionoscloud_lan"  "lan_example" {
 resource ionoscloud_mongo_cluster "example_mongo_cluster" {
   maintenance_window {
     day_of_the_week  = "Sunday"
-    time             = "09:00:00"
+  time             = "09:00:00"
   }
   mongodb_version = "5.0"
   instances          = 1
@@ -41,10 +41,6 @@ resource ionoscloud_mongo_cluster "example_mongo_cluster" {
     cidr_list            =  ["192.168.1.108/24"]
   }
   template_id = "6b78ea06-ee0e-4689-998c-fc9c46e781f6"
-  credentials {
-    username = "username"
-    password = random_password.cluster_password.result
-  }
 }
 
 resource "random_password" "cluster_password" {
@@ -84,10 +80,6 @@ resource ionoscloud_mongo_cluster "example_mongo_cluster" {
     lan_id          =  ionoscloud_lan.lan_example.id
     cidr_list       =  ["192.168.1.108/24", "192.168.1.109/24", "192.168.1.110/24"]
   }
-  credentials {
-  	username = "username"
-    password = random_password.cluster_password.result
-  }
   type = "sharded-cluster"
   shards = 2
   edition = "enterprise"
@@ -119,9 +111,6 @@ resource "random_password" "cluster_password" {
 * `maintenance_window` - (Optional)(Computed)[string] A weekly 4 hour-long window, during which maintenance might occur.  Updates to the value of the field force the cluster to be re-created.
     * `time` - (Required)[string]
     * `day_of_the_week` - (Required)[string]
-* `credentials` - (Required)[string] Credentials for the database user to be created. This attribute is immutable(disallowed in update requests). Updates to the value of the field force the cluster to be re-created.
-    * `username` - (Required)[string] The username for the initial mongoDB user.
-    * `password` - (Required)[string] 
 * `connection_string` - (Computed)[string] The physical location where the cluster will be created. This will be where all of your instances live. Updates to the value of the field force the cluster to be re-created. Available locations: de/txl, gb/lhr, es/vit
 * `ram` - (Optional)(Computed)[int]The amount of memory per instance in megabytes. Required for enterprise edition.
 * `storage_size` - (Optional)(Computed)[int] The amount of storage per instance in MB. Required for enterprise edition.

--- a/ionoscloud/resource_dbaas_mongo_user_test.go
+++ b/ionoscloud/resource_dbaas_mongo_user_test.go
@@ -158,11 +158,6 @@ resource ` + constant.DBaasMongoClusterResource + ` ` + constant.DBaaSClusterTes
     cidr_list            =  ["192.168.1.108/24", "192.168.1.109/24", "192.168.1.110/24"]
   }
   template_id = "6b78ea06-ee0e-4689-998c-fc9c46e781f6"
-  
-  credentials {
-  	username = "username"
-	password = ` + constant.RandomPassword + `.user_password.result
-  }
 }
 
 resource ` + constant.RandomPassword + ` "user_password" {
@@ -213,11 +208,6 @@ resource ` + constant.DBaasMongoClusterResource + ` ` + constant.DBaaSClusterTes
     cidr_list            =  ["192.168.1.108/24", "192.168.1.109/24", "192.168.1.110/24"]
   }
   template_id = "6b78ea06-ee0e-4689-998c-fc9c46e781f6"
-  
-  credentials {
-  	username = "username"
-	password = ` + constant.RandomPassword + `.user_password.result
-  }
 }
 
 resource ` + constant.DBaasMongoUserResource + ` ` + constant.UserTestResource + ` {
@@ -230,12 +220,6 @@ resource ` + constant.DBaasMongoUserResource + ` ` + constant.UserTestResource +
   }
 }
 resource ` + constant.RandomPassword + ` "user_password" {
-  length           = 16
-  special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
-}
-
-resource ` + constant.RandomPassword + ` "user_password_updated" {
   length           = 16
   special          = true
   override_special = "!#$%&*()-_=+[]{}<>:?"

--- a/ionoscloud/resource_dbaas_mongo_user_test.go
+++ b/ionoscloud/resource_dbaas_mongo_user_test.go
@@ -219,7 +219,7 @@ resource ` + constant.DBaasMongoUserResource + ` ` + constant.UserTestResource +
     database = "db1"
   }
 }
-resource ` + constant.RandomPassword + ` "user_password" {
+resource ` + constant.RandomPassword + ` "user_password_updated" {
   length           = 16
   special          = true
   override_special = "!#$%&*()-_=+[]{}<>:?"

--- a/ionoscloud/resource_dbaas_mongodb_cluster.go
+++ b/ionoscloud/resource_dbaas_mongodb_cluster.go
@@ -394,7 +394,7 @@ func resourceDbaasMongoClusterDelete(ctx context.Context, d *schema.ResourceData
 
 	err = utils.WaitForResourceToBeDeleted(ctx, d, client.IsClusterDeleted)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed checking if deleted %w", err))
+		return diag.FromErr(fmt.Errorf("The check for cluster deletion failed with the following error: %w", err))
 	}
 	// wait 15 seconds after the deletion of the cluster, for the lan to be freed
 	time.Sleep(constant.SleepInterval * 3)

--- a/ionoscloud/resource_dbaas_pgsql_cluster.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster.go
@@ -307,7 +307,7 @@ func resourceDbaasPgSqlClusterDelete(ctx context.Context, d *schema.ResourceData
 
 	err = utils.WaitForResourceToBeDeleted(ctx, d, client.IsClusterDeleted)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed checking if deleted %w", err))
+		return diag.FromErr(fmt.Errorf("The check for cluster deletion failed with the following error: %w", err))
 	}
 
 	// wait 15 seconds after the deletion of the cluster, for the lan to be freed


### PR DESCRIPTION
… DB clusters

Made some changes in order to fix these tests: https://github.com/ionos-cloud/terraform-provider-ionoscloud/actions/runs/8153596918/job/22285311093

Also updated the documentation for MariaDB clusters since `credentials` does not exist in the resource anymore, the field was removed in a previous PR: https://github.com/ionos-cloud/terraform-provider-ionoscloud/pull/515

## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [x] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
