### PR TITLE
refactor: Add 'workflow_dispatch' option in workflows

### DIFF
--- a/.github/workflows/compute-test-run.yml
+++ b/.github/workflows/compute-test-run.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     # At 09:00:00 - UTC, every week on Wednesday.
     - cron: '0 09 * * WED'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch on which to run the tests'
+        required: true
+        default: 'master'
 
 jobs:
   test:
@@ -21,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: master
+          ref: ${{ github.event.inputs.branch || 'master' }}
       - name: Install Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/dbaas-test-run.yml
+++ b/.github/workflows/dbaas-test-run.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     # At 09:00:00 - UTC, every week on Tuesday.
     - cron: '0 09 * * TUE'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch on which to run the tests'
+        required: true
+        default: 'master'
 
 jobs:
   test:
@@ -21,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: master
+          ref: ${{ github.event.inputs.branch || 'master' }}
       - name: Install Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/server-test-run.yml
+++ b/.github/workflows/server-test-run.yml
@@ -1,8 +1,17 @@
 name: Test run for server resources
 on:
-  schedule:
-    # At 11:00:00 - UTC, every Monday, Wednesday and Friday
-    - cron: '0 11 * * MON,WED,FRI'
+  # This pipeline will fail since there are some known problems, there is no need to run it every
+  # two days since we already know that it will fail. When the fix will be made, this 'schedule'
+  # section will be uncommented.
+  #  schedule:
+  #    # At 11:00:00 - UTC, every Monday, Wednesday and Friday
+  #    - cron: '0 11 * * MON,WED,FRI'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch on which to run the tests'
+        required: true
+        default: 'master'
 
 jobs:
   test:
@@ -20,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: master
+          ref: ${{ github.event.inputs.branch || 'master' }}
       - name: Install Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
## What does this fix or implement?

There are cases in which we want to run a specific pipeline after we merge a fix in master and we don't want to wait until next scheduled run, this is why I added the possibility to run the pipeline manually.

In this PR, I also removed the `schedule` option for `server` but this is only a temporary change.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
