### PR TITLE
refactor: Remove 'workflow_dispatch' from K8s workflow

### DIFF
--- a/.github/workflows/k8s-test-run.yml
+++ b/.github/workflows/k8s-test-run.yml
@@ -3,12 +3,6 @@ on:
   schedule:
     # At 09:00:00 - UTC, every week on Monday.
     - cron: '0 09 * * MON'
-  workflow_dispatch:
-      inputs:
-        branch:
-            description: 'Branch on which to run the tests'
-            required: true
-            default: 'master'
 
 jobs:
   test:
@@ -26,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.branch || 'master' }}
+          ref: master
       - name: Install Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
## What does this fix or implement?

I added `workflow_dispatch` on K8s workflow because I wanted to be able to run the tests manually, but the tests can be run using the `Test suite` action that is highly customizable.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
