### PR TITLE
Fix: Set server field for k8s cluster data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Fixes
 - #524 `filters` is now optional for `ionoscloud_servers` data source. If not provided, all servers in the configured datacenter will be returned.
 - `filters` is now optional for `ionoscloud_clusters` data source. If not provided, all k8s clusters will be returned.
+- populate `server` field for k8s cluster data sources
+
 ### Documentation
 - Update documentation for pgsql cluster and mongo cluster
 

--- a/ionoscloud/data_source_k8s_cluster.go
+++ b/ionoscloud/data_source_k8s_cluster.go
@@ -336,7 +336,7 @@ func dataSourceK8sReadCluster(ctx context.Context, d *schema.ResourceData, meta 
 
 func setK8sConfigData(d *schema.ResourceData, configStr string) error {
 
-	err, kubeConfig := parseClusterKubeconfig(configStr)
+	kubeConfig, err := parseClusterKubeconfig(configStr)
 	if err != nil {
 		return err
 	}
@@ -472,11 +472,11 @@ func setAdditionalK8sClusterData(d *schema.ResourceData, cluster *ionoscloud.Kub
 	return nil
 }
 
-func parseClusterKubeconfig(configStr string) (error, KubeConfig) {
+func parseClusterKubeconfig(configStr string) (KubeConfig, error) {
 	var kubeConfig KubeConfig
 	err := yaml.Unmarshal([]byte(configStr), &kubeConfig)
 	if err != nil {
 		err = fmt.Errorf("error parsing cluster kubeconfig: %w", err)
 	}
-	return err, kubeConfig
+	return kubeConfig, err
 }

--- a/ionoscloud/data_source_k8s_clusters.go
+++ b/ionoscloud/data_source_k8s_clusters.go
@@ -10,10 +10,11 @@ import (
 	"github.com/iancoleman/strcase"
 	"gopkg.in/yaml.v3"
 
-	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/internal/uuidgen"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils"
+
+	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 )
 
 func dataSourceK8sClusters() *schema.Resource {
@@ -199,6 +200,9 @@ func setKubeConfigData(clusterConfig string) (map[string]any, error) {
 		}
 		decodedCert = string(caCert)
 		clusters[i] = map[string]any{"name": c.Name, "cluster": map[string]string{"server": c.Cluster.Server, "certificate_authority_data": decodedCert}}
+	}
+	if len(kubeConfig.Clusters) != 0 {
+		clusterProperties["server"] = kubeConfig.Clusters[0].Cluster.Server
 	}
 	clusterConfigProperties["clusters"] = clusters
 

--- a/ionoscloud/data_source_k8s_clusters.go
+++ b/ionoscloud/data_source_k8s_clusters.go
@@ -179,7 +179,7 @@ func K8sClusterProperties(ctx context.Context, cluster ionoscloud.KubernetesClus
 
 func setKubeConfigData(clusterConfig string) (map[string]any, error) {
 
-	err, kubeConfig := parseClusterKubeconfig(clusterConfig)
+	kubeConfig, err := parseClusterKubeconfig(clusterConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/ionoscloud/resource_networkloadbalancer.go
+++ b/ionoscloud/resource_networkloadbalancer.go
@@ -46,7 +46,6 @@ func resourceNetworkLoadBalancer() *schema.Resource {
 					"listenerLan must be a customer reserved IP for the public load balancer and private IP " +
 					"for the private load balancer.",
 				Optional: true,
-				// Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/ionoscloud/resource_networkloadbalancer.go
+++ b/ionoscloud/resource_networkloadbalancer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 )
 
@@ -45,6 +46,7 @@ func resourceNetworkLoadBalancer() *schema.Resource {
 					"listenerLan must be a customer reserved IP for the public load balancer and private IP " +
 					"for the private load balancer.",
 				Optional: true,
+				// Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -280,7 +282,7 @@ func resourceNetworkLoadBalancerUpdate(ctx context.Context, d *schema.ResourceDa
 					}
 					err := fw.CreateOrPatchForNLB(ctx, dcId, d.Id(), firstFlowLogId, flowLog)
 					if err != nil {
-						//if we have a create that failed, we do not want to save in state
+						// if we have a create that failed, we do not want to save in state
 						// saving in state would mean a diff that would force a re-create
 						if firstFlowLogId == "" {
 							_ = d.Set("flowlog", nil)


### PR DESCRIPTION
## What does this fix or implement?
Fixes an issue with the `server` field of K8s cluster data sources not being set
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
