### PR TITLE
fix: Fix name validation for Dataplatform resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Fixes
 - Increase max result limit of data sources for target groups (200) and IP blocks (1000), as a workaround for pagination issues.
 - Add email filter for user data source, fixes pagination issues for users.
+- Fix name validation for Dataplatform resources
 
 ## 6.4.14
 ### Features

--- a/ionoscloud/data_source_dataplatform_cluster.go
+++ b/ionoscloud/data_source_dataplatform_cluster.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -15,7 +14,6 @@ import (
 	dataplatform "github.com/ionos-cloud/sdk-go-dataplatform"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"
 	dataplatformService "github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/dataplatform"
-	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
 	"gopkg.in/yaml.v3"
 )
 
@@ -27,7 +25,7 @@ func dataSourceDataplatformCluster() *schema.Resource {
 				Type:             schema.TypeString,
 				Description:      "The id of your cluster.",
 				Optional:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(constant.DataPlatformNameRegexConstraint), constant.DataPlatformRegexNameError)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IsUUID),
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/ionoscloud/data_source_dataplatform_node_pool.go
+++ b/ionoscloud/data_source_dataplatform_node_pool.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -14,7 +13,6 @@ import (
 	dataplatform "github.com/ionos-cloud/sdk-go-dataplatform"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"
 	dataplatformService "github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/dataplatform"
-	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
 )
 
 func dataSourceDataplatformNodePool() *schema.Resource {
@@ -24,7 +22,7 @@ func dataSourceDataplatformNodePool() *schema.Resource {
 			"id": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(constant.DataPlatformNameRegexConstraint), "")),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IsUUID),
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -116,7 +114,7 @@ func dataSourceDataplatformNodePool() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				Description:      "The UUID of an existing Dataplatform cluster",
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(constant.DataPlatformNameRegexConstraint), "")),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IsUUID),
 			},
 		},
 		Timeouts: &resourceDefaultTimeouts,

--- a/ionoscloud/data_source_dataplatform_node_pools.go
+++ b/ionoscloud/data_source_dataplatform_node_pools.go
@@ -3,15 +3,12 @@ package ionoscloud
 import (
 	"context"
 	"fmt"
-	"regexp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	dataplatform "github.com/ionos-cloud/sdk-go-dataplatform"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"
 	dataplatformService "github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/dataplatform"
-	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
 )
 
 func dataSourceDataplatformNodePools() *schema.Resource {
@@ -22,7 +19,7 @@ func dataSourceDataplatformNodePools() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				Description:      "The UUID of an existing Dataplatform cluster",
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(constant.DataPlatformNameRegexConstraint), constant.DataPlatformRegexNameError)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IsUUID),
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/ionoscloud/resource_dataplatform_nodepool.go
+++ b/ionoscloud/resource_dataplatform_nodepool.go
@@ -27,9 +27,8 @@ func resourceDataplatformNodePool() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The name of your cluster. Must be 63 characters or less and must be empty or begin and end with an alphanumeric character ([a-z0-9A-Z]). It can contain dashes (-), underscores (_), dots (.), and alphanumerics in-between.",
+				Description: "The name of your node pool. Must be 63 characters or less and must be empty or begin and end with an alphanumeric character ([a-z0-9A-Z]). It can contain dashes (-), underscores (_), dots (.), and alphanumerics in-between.",
 				Required:    true,
-
 				ValidateDiagFunc: validation.AllDiag(validation.ToDiagFunc(validation.StringLenBetween(0, 63)),
 					validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(constant.DataPlatformNameRegexConstraint), constant.DataPlatformRegexNameError))),
 				ForceNew: true,
@@ -134,7 +133,7 @@ func resourceDataplatformNodePool() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				Description:      "The UUID of an existing Dataplatform cluster.",
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(constant.DataPlatformNameRegexConstraint), constant.DataPlatformRegexNameError)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IsUUID),
 			},
 		},
 		Timeouts: &resourceDefaultTimeouts,

--- a/utils/constant/constants.go
+++ b/utils/constant/constants.go
@@ -296,7 +296,7 @@ const (
 	DataplatformVersionsTestDataSource       = "test_dataplatform_versions"
 	// DataPlatformVersion lowest 'available' version is now 23.7
 	DataPlatformVersion             = "23.7"
-	DataPlatformNameRegexConstraint = "^[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9]$\""
+	DataPlatformNameRegexConstraint = "^[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9]$"
 	DataPlatformRegexNameError      = "name should match " + DataPlatformNameRegexConstraint
 )
 


### PR DESCRIPTION
## What does this fix or implement?

Fix the name validation by modifying the regex (the old one was invalid).
Fix the validation for resources IDs (before the validation was done using the name regex, now we use `validation.IsUUID`).

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
