### PR TITLE
test: Modify DBaaS workflow to run tests in multiple stages

### DIFF
--- a/.github/workflows/dbaas-test-run.yml
+++ b/.github/workflows/dbaas-test-run.yml
@@ -28,5 +28,9 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-      - name: Run tests with dbaas tag
-        run: go test ./ionoscloud -v -failfast -timeout 240m -tags dbaas
+      - name: Run tests with mariadb tag
+        run: go test ./ionoscloud -v -failfast -timeout 70m -tags mariadb
+      - name: Run tests with psql tag
+        run: go test ./ionoscloud -v -failfast -timeout 140m -tags psql
+      - name: Run tests with mongo tag
+        run: go test ./ionoscloud -v -failfast -timeout 140m -tags mongo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.4.16
+### Enhancements
+- Modify DBaaS workflow to run tests in multiple stages for every service (Mongo, MariaDB, PgSQL) rather than running all tests in one stage
+
 ## 6.4.15
 ### Fixes
 - Increase max result limit of data sources for target groups (200) and IP blocks (1000), as a workaround for pagination issues.


### PR DESCRIPTION
## What does this fix or implement?

Since we have more DBaaS services now it's cleaner if we have different run stages for each service.
The timeout values were selected as follows:

1. `MariaDB` - Only one cluster is created, by default cluster creation timeout is 60 minutes so the test, in the worst case, shouldn't take more than 70 minutes.
2. `MongoDB` and `PgSQL` - Before we had a 240 minute timeout for both pipelines, so for each I thought about 120 minute but I decided to increase the value a little bit to make sure that there is plenty of time.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
