### PR TITLE
fix: Fix 'lans' attribute for DataPlatform clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixes
 - Fix MongoDB user import
 - Fix k8s cluster tests
+- Fix #552 in order to allow Dataplatform cluster creation without `lans` or `routes`
 
 ## 6.4.15
 ### Fixes

--- a/services/dataplatform/cluster.go
+++ b/services/dataplatform/cluster.go
@@ -138,7 +138,7 @@ func setPatchClusterRequestProperties(d *schema.ResourceData) *dataplatform.Patc
 }
 
 func setLansData(d *schema.ResourceData) *[]dataplatform.Lan {
-	var lansBody []dataplatform.Lan
+	lansBody := make([]dataplatform.Lan, 0)
 	if lansData, ok := d.GetOk("lans"); ok {
 		if lansData, ok := lansData.(*schema.Set); ok {
 			for _, lanData := range lansData.List() {
@@ -158,7 +158,7 @@ func setLansData(d *schema.ResourceData) *[]dataplatform.Lan {
 }
 
 func setRoutesData(lan map[string]interface{}) *[]dataplatform.Route {
-	var routesBody []dataplatform.Route
+	routesBody := make([]dataplatform.Route, 0)
 	if routesData, ok := lan["routes"].(*schema.Set); ok {
 		for _, routeData := range routesData.List() {
 			if route, ok := routeData.(map[string]interface{}); ok {


### PR DESCRIPTION
## What does this fix or implement?

Fixes the first point presented here: https://github.com/ionos-cloud/terraform-provider-ionoscloud/issues/552.

Before this fix, if the `lans` wasn't present in the tf file, `lans: nil` would be send in the request, same for `routes`.

This led to a validation error since the API accepts `lans: null` only on `PATCH` requests, `routes: null` is not accepted at all.
The error looks like this:
```
│ Error: an error occured  while creating a Dataplatform Cluster: 422 Unprocessable Entity: {"httpStatus":422,"messages":[{"errorCode":"dsaas-400","message":"'Value is not nullable' caused by field /properties/lans"}]}
```

I modified the code and now, if the `lans` or `routes` are missing, instead of `nil` we send an empty list in the body request.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
