### PR TITLE
fix: save user group ids in state when reading or importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 6.4.18
 
 ### Fixes
-- wrap missing base error for resource fetching errors
-- properly persist user group ids in state when syncing with remote configuration 
+- Wrap missing base error for resource fetching errors
+- Properly persist user group ids in state when syncing with remote configuration 
 ### Enhancements
 - Add `grafana_address` attribute to `ionoscloud_logging_pipeline` resource and data source
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - wrap missing base error for resource fetching errors
+- properly persist user group ids in state when syncing with remote configuration 
 ### Enhancements
 - Add `grafana_address` attribute to `ionoscloud_logging_pipeline` resource and data source
 

--- a/ionoscloud/data_source_user.go
+++ b/ionoscloud/data_source_user.go
@@ -130,8 +130,61 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	if err = setUserData(d, &user); err != nil {
+	if err = setDataSourceUserData(d, &user); err != nil {
 		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func setDataSourceUserData(d *schema.ResourceData, user *ionoscloud.User) error {
+	d.SetId(*user.Id)
+
+	if user.Properties != nil {
+		if user.Properties.Firstname != nil {
+			if err := d.Set("first_name", *user.Properties.Firstname); err != nil {
+				return err
+			}
+		}
+
+		if user.Properties.Lastname != nil {
+			if err := d.Set("last_name", *user.Properties.Lastname); err != nil {
+				return err
+			}
+		}
+		if user.Properties.Email != nil {
+			if err := d.Set("email", *user.Properties.Email); err != nil {
+				return err
+			}
+		}
+		if user.Properties.Administrator != nil {
+			if err := d.Set("administrator", *user.Properties.Administrator); err != nil {
+				return err
+			}
+		}
+		if user.Properties.ForceSecAuth != nil {
+			if err := d.Set("force_sec_auth", *user.Properties.ForceSecAuth); err != nil {
+				return err
+			}
+		}
+
+		if user.Properties.SecAuthActive != nil {
+			if err := d.Set("sec_auth_active", *user.Properties.SecAuthActive); err != nil {
+				return err
+			}
+		}
+
+		if user.Properties.S3CanonicalUserId != nil {
+			if err := d.Set("s3_canonical_user_id", *user.Properties.S3CanonicalUserId); err != nil {
+				return err
+			}
+		}
+
+		if user.Properties.Active != nil {
+			if err := d.Set("active", *user.Properties.Active); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/ionoscloud/data_source_user.go
+++ b/ionoscloud/data_source_user.go
@@ -130,65 +130,13 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	if err = setDataSourceUserData(d, &user); err != nil {
+	if err = setUserData(d, &user); err != nil {
 		return diag.FromErr(err)
 	}
 
 	return nil
 }
 
-func setDataSourceUserData(d *schema.ResourceData, user *ionoscloud.User) error {
-	d.SetId(*user.Id)
-
-	if user.Properties != nil {
-		if user.Properties.Firstname != nil {
-			if err := d.Set("first_name", *user.Properties.Firstname); err != nil {
-				return err
-			}
-		}
-
-		if user.Properties.Lastname != nil {
-			if err := d.Set("last_name", *user.Properties.Lastname); err != nil {
-				return err
-			}
-		}
-		if user.Properties.Email != nil {
-			if err := d.Set("email", *user.Properties.Email); err != nil {
-				return err
-			}
-		}
-		if user.Properties.Administrator != nil {
-			if err := d.Set("administrator", *user.Properties.Administrator); err != nil {
-				return err
-			}
-		}
-		if user.Properties.ForceSecAuth != nil {
-			if err := d.Set("force_sec_auth", *user.Properties.ForceSecAuth); err != nil {
-				return err
-			}
-		}
-
-		if user.Properties.SecAuthActive != nil {
-			if err := d.Set("sec_auth_active", *user.Properties.SecAuthActive); err != nil {
-				return err
-			}
-		}
-
-		if user.Properties.S3CanonicalUserId != nil {
-			if err := d.Set("s3_canonical_user_id", *user.Properties.S3CanonicalUserId); err != nil {
-				return err
-			}
-		}
-
-		if user.Properties.Active != nil {
-			if err := d.Set("active", *user.Properties.Active); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
 func setUsersForGroup(ctx context.Context, d *schema.ResourceData, user *ionoscloud.User, client ionoscloud.APIClient) error {
 	if user == nil {
 		return fmt.Errorf("did not expect empty user")

--- a/ionoscloud/import_user_test.go
+++ b/ionoscloud/import_user_test.go
@@ -55,7 +55,17 @@ resource ` + constant.UserResource + ` ` + constant.UserTestResource + ` {
   last_name = "` + constant.UserTestResource + `"
   email = "` + utils.GenerateEmail() + `"
   password = "abc123-321CBA"
-  administrator = true
   force_sec_auth= true
   active  = true
-}`
+  group_ids 		= [ ionoscloud_group.group1.id]
+}
+
+resource "ionoscloud_group" "group1" {
+  name = "group1"
+  create_datacenter = true
+  create_snapshot = true
+  reserve_ip = true
+  access_activity_log = false
+  create_k8s_cluster = true
+}
+`

--- a/ionoscloud/resource_user.go
+++ b/ionoscloud/resource_user.go
@@ -174,7 +174,11 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diags
 	}
 
-	if err := setUserData(d, &user); err != nil {
+	if err = setUserData(d, &user); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err = d.Set("group_ids", getUserGroups(&user)); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -318,7 +322,11 @@ func resourceUserImporter(ctx context.Context, d *schema.ResourceData, meta inte
 
 	}
 
-	if err := setUserData(d, &user); err != nil {
+	if err = setUserData(d, &user); err != nil {
+		return nil, err
+	}
+
+	if err = d.Set("group_ids", getUserGroups(&user)); err != nil {
 		return nil, err
 	}
 
@@ -377,7 +385,7 @@ func setUserData(d *schema.ResourceData, user *ionoscloud.User) error {
 		}
 	}
 
-	return d.Set("group_ids", getUserGroups(user))
+	return nil
 }
 
 func getUserGroups(user *ionoscloud.User) []string {

--- a/ionoscloud/resource_user_test.go
+++ b/ionoscloud/resource_user_test.go
@@ -205,7 +205,7 @@ func testAccRemoveUserFromGroup(group, user string) resource.TestCheckFunc {
 			return fmt.Errorf("testAccRemoveUserFromGroup: group not found: %s", group)
 		}
 		if gr.Primary.ID == "" {
-			return fmt.Errorf("no group Record ID is set")
+			return fmt.Errorf("missing group id")
 		}
 
 		u, ok := s.RootModule().Resources[user]

--- a/ionoscloud/resource_user_test.go
+++ b/ionoscloud/resource_user_test.go
@@ -126,12 +126,6 @@ func TestAccUserBasic(t *testing.T) {
 					})),
 			},
 			{
-				Config:      testAccCheckNewUserGroup,
-				ExpectError: regexp.MustCompile("the plan was not empty"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccRemoveUserFromGroup(constant.GroupResource+".group1", constant.UserResource+"."+constant.NewUserResource)),
-			},
-			{
 				Config:             testAccCheckNewUserGroup,
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(

--- a/ionoscloud/resource_user_test.go
+++ b/ionoscloud/resource_user_test.go
@@ -5,6 +5,7 @@ package ionoscloud
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"

--- a/ionoscloud/resource_user_test.go
+++ b/ionoscloud/resource_user_test.go
@@ -210,7 +210,7 @@ func testAccRemoveUserFromGroup(group, user string) resource.TestCheckFunc {
 
 		u, ok := s.RootModule().Resources[user]
 		if !ok {
-			return fmt.Errorf("testAccRemoveUserFromGroup: user not found: %s", group)
+			return fmt.Errorf("testAccRemoveUserFromGroup: user not found: %s", user)
 		}
 		if u.Primary.ID == "" {
 			return fmt.Errorf("missing user id")


### PR DESCRIPTION
## What does this fix or implement?
- fetch group ids using the depth of 1
- store group ids in state when fetching user resources
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [x] Jira task updated
