### PR TITLE
fix: move-back ASG files to ionoscloud package

### DIFF
--- a/ionoscloud/data_source_autoscaling_group.go
+++ b/ionoscloud/data_source_autoscaling_group.go
@@ -1,4 +1,4 @@
-package asg
+package ionoscloud
 
 import (
 	"context"

--- a/ionoscloud/data_source_autoscaling_group_servers.go
+++ b/ionoscloud/data_source_autoscaling_group_servers.go
@@ -1,4 +1,4 @@
-package asg
+package ionoscloud
 
 import (
 	"context"

--- a/ionoscloud/data_source_autoscaling_group_servers_test.go
+++ b/ionoscloud/data_source_autoscaling_group_servers_test.go
@@ -1,7 +1,7 @@
 //go:build all || autoscaling
 // +build all autoscaling
 
-package asg
+package ionoscloud
 
 import (
 	"testing"
@@ -15,13 +15,13 @@ import (
 func TestAccDataSourceAutoscalingGroupServers(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			ionoscloud.testAccPreCheck(t)
+			testAccPreCheck(t)
 		},
-		ProviderFactories: ionoscloud.testAccProviderFactories,
-		ExternalProviders: ionoscloud.randomProviderVersion343(),
+		ProviderFactories: testAccProviderFactories,
+		ExternalProviders: randomProviderVersion343(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAG_ConfigBasic,
+				Config: testAGConfig_basic(constant.AutoscalingGroupTestResource),
 			},
 			{
 				Config: testAccDataSourceAutoscalingGroupServers,
@@ -34,7 +34,7 @@ func TestAccDataSourceAutoscalingGroupServers(t *testing.T) {
 
 }
 
-const testAccDataSourceAutoscalingGroupServers = testAG_ConfigBasic + `
+var testAccDataSourceAutoscalingGroupServers = testAGConfig_basic(constant.AutoscalingGroupTestResource) + `
 data ` + constant.AutoscalingGroupServersResource + ` ` + constant.AutoscalingGroupServersTestDataSource + ` {
   group_id = ` + constant.AutoscalingGroupResource + `.` + constant.AutoscalingGroupTestResource + `.id
 }

--- a/ionoscloud/data_source_autoscaling_group_test.go
+++ b/ionoscloud/data_source_autoscaling_group_test.go
@@ -1,7 +1,7 @@
 //go:build all || autoscaling
 // +build all autoscaling
 
-package asg
+package ionoscloud
 
 import (
 	"fmt"
@@ -20,9 +20,9 @@ const dataSourceAutoscalingGroupName = constant.DataSource + "." + constant.Auto
 func TestAccDataSourceAutoscalingGroup(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			ionoscloud.testAccPreCheck(t)
+			testAccPreCheck(t)
 		},
-		ProviderFactories: ionoscloud.testAccProviderFactories,
+		ProviderFactories: testAccProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {
 				VersionConstraint: "3.4.3",
@@ -230,7 +230,7 @@ resource "ionoscloud_autoscaling_group"  %[1]q {
       name        = "volume_1"
       image_password = random_password.image_password.result
       size        = 30
-      ssh_keys    = ["`+ionoscloud.sshKey+`"]
+      ssh_keys    = ["`+sshKey+`"]
       type        = "HDD"
       user_data    = "ZWNobyAiSGVsbG8sIFdvcmxkIgo="
       boot_order = "AUTO"

--- a/ionoscloud/provider.go
+++ b/ionoscloud/provider.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/ionoscloud/asg"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
@@ -122,7 +120,7 @@ func Provider() *schema.Provider {
 			constant.DNSZoneResource:                           resourceDNSZone(),
 			constant.DNSRecordResource:                         resourceDNSRecord(),
 			constant.LoggingPipelineResource:                   resourceLoggingPipeline(),
-			constant.AutoscalingGroupResource:                  asg.ResourceAutoscalingGroup(),
+			constant.AutoscalingGroupResource:                  ResourceAutoscalingGroup(),
 			constant.ServerBootDeviceSelectionResource:         resourceServerBootDeviceSelection(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -181,8 +179,8 @@ func Provider() *schema.Provider {
 			constant.DNSZoneDataSource:                         dataSourceDNSZone(),
 			constant.DNSRecordDataSource:                       dataSourceDNSRecord(),
 			constant.LoggingPipelineDataSource:                 dataSourceLoggingPipeline(),
-			constant.AutoscalingGroupResource:                  asg.DataSourceAutoscalingGroup(),
-			constant.AutoscalingGroupServersResource:           asg.DataSourceAutoscalingGroupServers(),
+			constant.AutoscalingGroupResource:                  DataSourceAutoscalingGroup(),
+			constant.AutoscalingGroupServersResource:           DataSourceAutoscalingGroupServers(),
 		},
 	}
 

--- a/ionoscloud/resource_autoscaling_group.go
+++ b/ionoscloud/resource_autoscaling_group.go
@@ -1,4 +1,4 @@
-package asg
+package ionoscloud
 
 import (
 	"context"

--- a/ionoscloud/resource_autoscaling_group_test.go
+++ b/ionoscloud/resource_autoscaling_group_test.go
@@ -607,10 +607,10 @@ resource "ionoscloud_target_group" "autoscaling_target_group" {
     protocol                  = "HTTP"
 }
 
-resource "time_sleep" "wait_5_minutes" {
+resource "time_sleep" "wait_10_minutes" {
   depends_on = [ionoscloud_target_group.autoscaling_target_group]
 
-  destroy_duration = "5m"
+  destroy_duration = "10m"
 }
 
 resource  "ionoscloud_autoscaling_group"  %[1]q {
@@ -655,7 +655,7 @@ resource  "ionoscloud_autoscaling_group"  %[1]q {
 		}
 	}
 
-	depends_on = [time_sleep.wait_5_minutes]
+	depends_on = [time_sleep.wait_10_minutes]
 }
 `, rName))
 }

--- a/ionoscloud/resource_autoscaling_group_test.go
+++ b/ionoscloud/resource_autoscaling_group_test.go
@@ -1,10 +1,13 @@
 //go:build all || autoscaling
 // +build all autoscaling
 
-package asg
+package ionoscloud
 
 import (
+	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -363,6 +366,69 @@ func TestAccAutoscalingGroup_replicaWithVolume(t *testing.T) {
 		},
 	})
 
+}
+
+func testAccCheckAutoscalingGroupDestroyCheck(s *terraform.State) error {
+	client := testAccProvider.Meta().(services.SdkBundle).AutoscalingClient
+
+	ctx, cancel := context.WithTimeout(context.Background(), *resourceDefaultTimeouts.Default)
+
+	if cancel != nil {
+		defer cancel()
+	}
+
+	for _, rs := range s.RootModule().Resources {
+
+		if rs.Type != constant.AutoscalingGroupResource {
+			continue
+		}
+		_, apiResponse, err := client.GetGroup(ctx, rs.Primary.ID, 0)
+		if err != nil {
+			if !apiResponse.HttpNotFound() {
+				return fmt.Errorf("an error occurred while checking for the destruction of autoscaling group %s: %w",
+					rs.Primary.ID, err)
+			}
+		} else {
+			return fmt.Errorf("autoscaling group %s still exists", rs.Primary.ID)
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckAutoscalingGroupExists(name string, autoscalingGroup *autoscaling.Group) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(services.SdkBundle).AutoscalingClient
+
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no Record ID is set")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), *resourceDefaultTimeouts.Default)
+
+		if cancel != nil {
+			defer cancel()
+		}
+
+		foundGroup, _, err := client.GetGroup(ctx, rs.Primary.ID, 0)
+		if err != nil {
+			return fmt.Errorf("error occurred while fetching autoscaling group: %s, %w", rs.Primary.ID, err)
+		}
+
+		if *foundGroup.Id != rs.Primary.ID {
+			return fmt.Errorf("record not found")
+		}
+		autoscalingGroup = &foundGroup
+
+		return nil
+	}
 }
 
 func testAGConfig_base() string {


### PR DESCRIPTION


## What does this fix or implement?

The refactoring of ASG resources in their own package generates too much refactoring for now so i will leave them as the other resources in the ionoscloud big package.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
