### PR TITLE
fix: failing WaitForResourceToBeReady test

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -240,18 +240,17 @@ func WaitForResourceToBeReady(ctx context.Context, d *schema.ResourceData, fn Re
 	if d.Id() == "" {
 		return fmt.Errorf("resource with id %s not ready, still trying ", d.Id())
 	}
-	err := retry.RetryContext(ctx, DefaultTimeout, func() *retry.RetryError {
+	return retry.RetryContext(ctx, DefaultTimeout, func() *retry.RetryError {
 		isReady, err := fn(ctx, d)
-		if isReady == true {
+		if isReady {
 			return nil
 		}
 		if err != nil {
-			retry.NonRetryableError(err)
+			return retry.NonRetryableError(err)
 		}
 		log.Printf("[DEBUG] resource with id %s not ready, still trying ", d.Id())
 		return retry.RetryableError(fmt.Errorf("resource with id %s not ready, still trying ", d.Id()))
 	})
-	return err
 }
 
 // IsResourceDeletedFunc polls api to see if resource exists based on id
@@ -316,7 +315,7 @@ func PointerEmptyToNil() mapstructure.DecodeHookFuncType {
 // checks if value['1'] of key[`id`] is present inside a slice of maps[string]interface{}
 func IsValueInSliceOfMap[T comparable](sliceOfMaps []interface{}, key string, value T) bool {
 	for _, mmap := range sliceOfMaps {
-		//do not delete if the id in the old rule is present in the new rules to be updated
+		// do not delete if the id in the old rule is present in the new rules to be updated
 		if value == mmap.(map[string]interface{})[key] {
 			return true
 		}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -45,6 +45,7 @@ func TestWaitForResourceToBeReady(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt.args.d.SetId("test")
 		t.Run(tt.name, func(t *testing.T) {
 			if err := WaitForResourceToBeReady(tt.args.ctx, tt.args.d, tt.args.fn); (err != nil) != tt.wantErr {
 				t.Errorf("WaitForResourceToBeReady() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Fixes a missed return and adds an ID to fix this test

```
=== RUN   TestWaitForResourceToBeReady
=== RUN   TestWaitForResourceToBeReady/TestReturnTrue
2024/07/11 12:03:12 [DEBUG] Waiting for state to become: [success]
=== RUN   TestWaitForResourceToBeReady/TestTimeoutOnReturnFalse
2024/07/11 12:03:12 [DEBUG] Waiting for state to become: [success]
2024/07/11 12:03:12 [DEBUG] resource with id test not ready, still trying 
2024/07/11 12:03:12 [TRACE] Waiting 500ms before next try
2024/07/11 12:03:13 [DEBUG] resource with id test not ready, still trying 
2024/07/11 12:03:13 [TRACE] Waiting 1s before next try
--- PASS: TestWaitForResourceToBeReady (1.00s)
    --- PASS: TestWaitForResourceToBeReady/TestReturnTrue (0.00s)
    --- PASS: TestWaitForResourceToBeReady/TestTimeoutOnReturnFalse (1.00s)
PASS
```