### PR TITLE
test: add gateway resource tests

### DIFF
--- a/ionoscloud/import_apigateway_test.go
+++ b/ionoscloud/import_apigateway_test.go
@@ -1,0 +1,43 @@
+//go:build apigateway || all || gateway
+
+package ionoscloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccApiGateway_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckApiGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckApiGatewayConfig_basic,
+			},
+			{
+				ResourceName:      "ionoscloud_apigateway.example",
+				ImportStateIdFunc: testAccApiGatewayImportStateId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccApiGatewayImportStateId(s *terraform.State) (string, error) {
+	importID := ""
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ionoscloud_apigateway" {
+			continue
+		}
+
+		importID = rs.Primary.Attributes["id"]
+	}
+
+	return importID, nil
+}

--- a/ionoscloud/resource_apigateway_test.go
+++ b/ionoscloud/resource_apigateway_test.go
@@ -1,3 +1,5 @@
+//go:build apigateway || all || gateway
+
 package ionoscloud
 
 import (
@@ -7,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	ionoscloud "github.com/ionos-cloud/sdk-go-apigateway"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"
 )
 
@@ -22,31 +25,6 @@ resource "ionoscloud_apigateway" "example" {
 }
 `
 
-func TestAccApiGateway_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckApiGatewayConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
-					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "name", "example"),
-					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "logs", "true"),
-					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "metrics", "true"),
-					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "custom_domains.0.name", "example.com"),
-					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "custom_domains.0.certificate_id", "example-certificate-id"),
-				),
-			},
-			{
-				ResourceName:      "ionoscloud_apigateway.example",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 var testAccCheckApiGatewayConfig_update = `
 resource "ionoscloud_apigateway" "example" {
   name = "example_updated"
@@ -59,21 +37,31 @@ resource "ionoscloud_apigateway" "example" {
 }
 `
 
-func TestAccApiGateway_update(t *testing.T) {
+func TestAccApiGateway_basic(t *testing.T) {
+	var apiGateway ionoscloud.GatewayRead
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckApiGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckApiGatewayConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
+					testAccCheckApiGatewayExists("ionoscloud_apigateway.example", &apiGateway),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "name", "example"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "logs", "true"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "metrics", "true"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "custom_domains.0.name", "example.com"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "custom_domains.0.certificate_id", "example-certificate-id"),
 				),
 			},
 			{
 				Config: testAccCheckApiGatewayConfig_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
+					testAccCheckApiGatewayExists("ionoscloud_apigateway.example", &apiGateway),
 					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "name", "example_updated"),
 					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "logs", "false"),
 					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "metrics", "false"),
@@ -85,53 +73,27 @@ func TestAccApiGateway_update(t *testing.T) {
 	})
 }
 
-func TestAccApiGateway_destroy(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckApiGatewayConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
-				),
-			},
-		},
-		CheckDestroy: testAccCheckApiGatewayDestroy,
-	})
+func testAccCheckApiGatewayDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(services.SdkBundle).ApiGatewayClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ionoscloud_apigateway" {
+			continue
+		}
+
+		_, resp, err := client.GetApiGatewayById(context.Background(), rs.Primary.ID)
+		if resp != nil && resp.StatusCode != 404 {
+			return fmt.Errorf("API Gateway still exists: %s", rs.Primary.ID)
+		}
+		if err != nil {
+			return fmt.Errorf("error fetching API Gateway with ID %s: %v", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
 }
 
-func TestAccApiGateway_import(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckApiGatewayConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
-				),
-			},
-			{
-				ResourceName:      "ionoscloud_apigateway.example",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateId:     "example_import_id",
-			},
-			{
-				Config: testAccCheckApiGatewayConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
-				),
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateId:     "example_import_id",
-			},
-		},
-	})
-}
-
-func testAccCheckApiGatewayExists(n string) resource.TestCheckFunc {
+func testAccCheckApiGatewayExists(n string, apiGateway *ionoscloud.GatewayRead) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -139,27 +101,16 @@ func testAccCheckApiGatewayExists(n string) resource.TestCheckFunc {
 		}
 
 		client := testAccProvider.Meta().(services.SdkBundle).ApiGatewayClient
-		_, _, err := client.GetApiGatewayById(context.Background(), rs.Primary.ID)
+		found, _, err := client.GetApiGatewayById(context.Background(), rs.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("error fetching API Gateway with ID: %v, error: %w", rs.Primary.ID, err)
+			return fmt.Errorf("error fetching API Gateway with ID %s: %v", rs.Primary.ID, err)
 		}
 
+		if found.Id != nil && *found.Id != rs.Primary.ID {
+			return fmt.Errorf("API Gateway not found")
+		}
+
+		*apiGateway = found
 		return nil
 	}
-}
-
-func testAccCheckApiGatewayDestroy(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "ionoscloud_apigateway" {
-			continue
-		}
-
-		client := testAccProvider.Meta().(services.SdkBundle).ApiGatewayClient
-		_, resp, _ := client.GetApiGatewayById(context.Background(), rs.Primary.ID)
-		if resp != nil && resp.StatusCode != 404 {
-			return fmt.Errorf("API Gateway still exists: %s", rs.Primary.ID)
-		}
-	}
-
-	return nil
 }

--- a/ionoscloud/resource_apigateway_test.go
+++ b/ionoscloud/resource_apigateway_test.go
@@ -1,0 +1,165 @@
+package ionoscloud
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"
+)
+
+var testAccCheckApiGatewayConfig_basic = `
+resource "ionoscloud_apigateway" "example" {
+  name = "example"
+  logs = true
+  metrics = true
+  custom_domains {
+    name = "example.com"
+    certificate_id = "example-certificate-id"
+  }
+}
+`
+
+func TestAccApiGateway_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckApiGatewayConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "name", "example"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "logs", "true"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "metrics", "true"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "custom_domains.0.name", "example.com"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "custom_domains.0.certificate_id", "example-certificate-id"),
+				),
+			},
+			{
+				ResourceName:      "ionoscloud_apigateway.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var testAccCheckApiGatewayConfig_update = `
+resource "ionoscloud_apigateway" "example" {
+  name = "example_updated"
+  logs = false
+  metrics = false
+  custom_domains {
+    name = "example_updated.com"
+    certificate_id = "example-certificate-id-updated"
+  }
+}
+`
+
+func TestAccApiGateway_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckApiGatewayConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
+				),
+			},
+			{
+				Config: testAccCheckApiGatewayConfig_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "name", "example_updated"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "logs", "false"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "metrics", "false"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "custom_domains.0.name", "example_updated.com"),
+					resource.TestCheckResourceAttr("ionoscloud_apigateway.example", "custom_domains.0.certificate_id", "example-certificate-id-updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccApiGateway_destroy(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckApiGatewayConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
+				),
+			},
+		},
+		CheckDestroy: testAccCheckApiGatewayDestroy,
+	})
+}
+
+func TestAccApiGateway_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckApiGatewayConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
+				),
+			},
+			{
+				ResourceName:      "ionoscloud_apigateway.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "example_import_id",
+			},
+			{
+				Config: testAccCheckApiGatewayConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayExists("ionoscloud_apigateway.example"),
+				),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "example_import_id",
+			},
+		},
+	})
+}
+
+func testAccCheckApiGatewayExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		client := testAccProvider.Meta().(services.SdkBundle).ApiGatewayClient
+		_, _, err := client.GetApiGatewayById(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error fetching API Gateway with ID: %v, error: %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckApiGatewayDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ionoscloud_apigateway" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(services.SdkBundle).ApiGatewayClient
+		_, resp, _ := client.GetApiGatewayById(context.Background(), rs.Primary.ID)
+		if resp != nil && resp.StatusCode != 404 {
+			return fmt.Errorf("API Gateway still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds Gateway tests

note: don't merge this until the API works seamlessly with the prod JWTs, currently it requires staging tokens which reset periodically and it would be a pain to manage separately.