### PR TITLE
test: Fix MariaDB tests and change the name of 'locations' constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Fixes 
 - Fail on k8s cluster and nodepool if creation or deletion entered failed state
 - K8s, dataplatform and MariaDB tests
+### Documentation
+- Update documentation for MariaDB cluster
 ## 6.4.18
 ### Features
 - Add tests for Mongo cluster and user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Move to `sdk-go-bundle` for logging sdk
 ### Fixes 
 - Fail on k8s cluster and nodepool if creation or deletion entered failed state
-- K8s and dataplatform tests
+- K8s, dataplatform and MariaDB tests
 ## 6.4.18
 ### Features
 - Add tests for Mongo cluster and user

--- a/docs/resources/dbaas_mariadb_cluster.md
+++ b/docs/resources/dbaas_mariadb_cluster.md
@@ -33,7 +33,7 @@ resource "ionoscloud_server" "example" {
   ram                     = 2048
   availability_zone       = "ZONE_1"
   cpu_family              = "INTEL_SKYLAKE"
-  image_name              = "debian-10-genericcloud-amd64-20240114-1626"
+  image_name              = "rockylinux-8-GenericCloud-20230518"
   image_password          = "password"
   volume {
     name                  = "example"

--- a/ionoscloud/data_source_dbaas_mariadb_backups.go
+++ b/ionoscloud/data_source_dbaas_mariadb_backups.go
@@ -3,6 +3,7 @@ package ionoscloud
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -30,7 +31,7 @@ func dataSourceDBaaSMariaDBBackups() *schema.Resource {
 				Type:             schema.TypeString,
 				Description:      "The cluster location",
 				Optional:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(constant.MariaDBClusterLocations, false)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(constant.Locations, false)),
 			},
 			"backups": {
 				Type:        schema.TypeList,

--- a/ionoscloud/data_source_dbaas_mariadb_cluster.go
+++ b/ionoscloud/data_source_dbaas_mariadb_cluster.go
@@ -3,13 +3,14 @@ package ionoscloud
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	dbaas "github.com/ionos-cloud/sdk-go-dbaas-mariadb"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services"
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
-	"strings"
 )
 
 func dataSourceDBaaSMariaDBCluster() *schema.Resource {
@@ -26,7 +27,7 @@ func dataSourceDBaaSMariaDBCluster() *schema.Resource {
 				Type:             schema.TypeString,
 				Description:      "The cluster location",
 				Optional:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(constant.MariaDBClusterLocations, false)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(constant.Locations, false)),
 			},
 			"display_name": {
 				Type:        schema.TypeString,

--- a/ionoscloud/resource_dbaas_mariadb_cluster.go
+++ b/ionoscloud/resource_dbaas_mariadb_cluster.go
@@ -3,11 +3,12 @@ package ionoscloud
 import (
 	"context"
 	"fmt"
-	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
 	"log"
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -37,7 +38,7 @@ func resourceDBaaSMariaDBCluster() *schema.Resource {
 				Description:      "The cluster location",
 				Optional:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(constant.MariaDBClusterLocations, false)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(constant.Locations, false)),
 			},
 			"instances": {
 				Type:             schema.TypeInt,
@@ -206,8 +207,8 @@ func mariaDBClusterImport(ctx context.Context, d *schema.ResourceData, meta inte
 		return nil, fmt.Errorf("invalid import ID: %q, expected ID in the format '<location>:<cluster_id>'", d.Id())
 	}
 	location := parts[0]
-	if !slices.Contains(constant.MariaDBClusterLocations, location) {
-		return nil, fmt.Errorf("invalid import ID: %q, location must be one of %v", d.Id(), constant.MariaDBClusterLocations)
+	if !slices.Contains(constant.Locations, location) {
+		return nil, fmt.Errorf("invalid import ID: %q, location must be one of %v", d.Id(), constant.Locations)
 	}
 	clusterID := parts[1]
 

--- a/ionoscloud/resource_dbaas_mariadb_cluster_test.go
+++ b/ionoscloud/resource_dbaas_mariadb_cluster_test.go
@@ -176,7 +176,7 @@ resource ` + constant.ServerResource + ` ` + constant.ServerTestResource + ` {
   ram                     = 2048
   availability_zone       = "ZONE_1"
   cpu_family              = "INTEL_SKYLAKE"
-  image_name              = "debian-10-genericcloud-amd64-20240114-1626"
+  image_name              = "rockylinux-8-GenericCloud-20230518"
   image_password          = ` + constant.RandomPassword + `.server_image_password.result
   volume {
     name                  = "example"

--- a/utils/constant/constants.go
+++ b/utils/constant/constants.go
@@ -270,8 +270,8 @@ const (
 	DBaaSMongoTemplateTestDataSource = "test_dbaas_mongo_template"
 )
 
-// MariaDBClusterLocations slice represents the locations in which MariaDB clusters can be created
-var MariaDBClusterLocations = []string{"de/fra", "de/txl", "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci"}
+// Locations slice represents the locations in which services are available.
+var Locations = []string{"de/fra", "de/txl", "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci"}
 
 // Container Registry Constants
 const (


### PR DESCRIPTION
## What does this fix or implement?

Fix MariaDB tests by updating the image name for the server used in the tests.

Change the name of the `locations` constant. In the beginning I named this `MariaDBClusterLocations` or something like that but the slice can be used for multiple services. We will use this slice for all the services where multiple locations are supported. If a service supports less locations, we will create a special constant for that particular service.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
