### PR TITLE
fix: Implement workaround for the BackupUnits API bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix for vpn wireguard peer when there is no endpoint set
 - Minor fixes to documentation for api gateway route resource.
 - Remove `public_endpoint` from api gateway route resource.
+- Add temporary fix for backup units resources.
 
 ### Documentation
 - Update documentation for S3 bucket resource

--- a/ionoscloud/data_source_backup_unit.go
+++ b/ionoscloud/data_source_backup_unit.go
@@ -59,7 +59,7 @@ func dataSourceBackupUnitRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	if idOk {
 		/* search by ID */
-		backupUnit, apiResponse, err = client.BackupUnitsApi.BackupunitsFindById(ctx, id.(string)).Execute()
+		backupUnit, apiResponse, err = BackupUnitFindByID(ctx, id.(string), client)
 		logApiRequestTime(apiResponse)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("an error occurred while fetching the backup unit %s: %w", id.(string), err))
@@ -82,7 +82,7 @@ func dataSourceBackupUnitRead(ctx context.Context, d *schema.ResourceData, meta 
 		if backupUnits.Items != nil {
 			for _, bu := range *backupUnits.Items {
 				if bu.Properties != nil && bu.Properties.Name != nil && *bu.Properties.Name == name.(string) {
-					tmpBackupUnit, apiResponse, err := client.BackupUnitsApi.BackupunitsFindById(ctx, *bu.Id).Execute()
+					tmpBackupUnit, apiResponse, err := BackupUnitFindByID(ctx, *bu.Id, client)
 					logApiRequestTime(apiResponse)
 					if err != nil {
 						return diag.FromErr(fmt.Errorf("an error occurred while fetching backup unit with ID %s: %w", *bu.Id, err))

--- a/ionoscloud/resource_backup_unit_test.go
+++ b/ionoscloud/resource_backup_unit_test.go
@@ -93,7 +93,7 @@ func testAccCheckBackupUnitDestroyCheck(s *terraform.State) error {
 			continue
 		}
 
-		_, apiResponse, err := client.BackupUnitsApi.BackupunitsFindById(ctx, rs.Primary.ID).Execute()
+		_, apiResponse, err := BackupUnitFindByID(ctx, rs.Primary.ID, client)
 		logApiRequestTime(apiResponse)
 
 		if err != nil {
@@ -129,7 +129,7 @@ func testAccCheckBackupUnitExists(n string, backupUnit *ionoscloud.BackupUnit) r
 			defer cancel()
 		}
 
-		foundBackupUnit, apiResponse, err := client.BackupUnitsApi.BackupunitsFindById(ctx, rs.Primary.ID).Execute()
+		foundBackupUnit, apiResponse, err := BackupUnitFindByID(ctx, rs.Primary.ID, client)
 		logApiRequestTime(apiResponse)
 
 		if err != nil {


### PR DESCRIPTION
## What does this fix or implement?

Fixes https://github.com/ionos-cloud/terraform-provider-ionoscloud/issues/641

There is a problem with the BackupUnits API:
- `GET` on all the BackupUnits works properly;
- `GET` on `BackupUnits/BackupUnitID` doesn't work properly (the state in the response is `BUSY` and some fields are not populated properly)

Because of that, the client method `BackupunitsFindById` doesn't work properly.

I will open a bug for the API team, but until then I implemented a workaround: I created a method that simulates the `BackupunitsFindById` client method. The difference is that this method fetches all the backup units and then returns the searched one using ID matching.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
