### PR TITLE
fix: Fix 'ionoscloud_certificate' data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Fixes
 - Fix `kafka` remove unavailable locations from resources and data sources
 - Fix update behavior for container registry property: `apiSubnetAllowList`
+- Fix `ionoscloud_certificate` data source
 
 ## 6.5.5
 ### Fixes

--- a/docs/data-sources/certificate_manager_certificate.md
+++ b/docs/data-sources/certificate_manager_certificate.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 * `name` - (Optional) Name of an existing certificate that you want to search for.
 * `id` - (Optional) ID of the certificate you want to search for.
 
-Either `name` or `id` must be provided. If none, or both are provided, the datasource will return an error.
+Either `name` or `id` must be provided, or both. If none are provided, the datasource will return an error.
 
 ## Attributes Reference
 

--- a/ionoscloud/data_source_certificate_manager_certificate.go
+++ b/ionoscloud/data_source_certificate_manager_certificate.go
@@ -69,7 +69,7 @@ func dataSourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 		if nameOk {
 			if certificate.Properties != nil && certificate.Properties.Name != nil &&
-				strings.EqualFold(*certificate.Properties.Name, name) {
+				!strings.EqualFold(*certificate.Properties.Name, name) {
 				return diag.FromErr(fmt.Errorf("name of cert (UUID=%s, name=%s) does not match expected name: %s",
 					*certificate.Id, *certificate.Properties.Name, name))
 			}


### PR DESCRIPTION
## What does this fix or implement?

From the code, it looks like we want to be able to get a certificate using both `ID` and `name`. The functionality was not correct and I fixed it. However, I am not sure why would we want to get a certificate using both `ID` and `name`, one of them should be enough, just like we do for the other resources. I kept the functionality but maybe we need to change it (`ID` or `name`, not both, but it will be a breaking change). 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
