### PR TITLE
Fx: metadata for docs that are not rendering correctly in TF registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.7
+### Fixes
+  - Fix documentation rendering of `autoscaling_group` resource and data source, `dbaas_mongo_template` data source and `server_boot_device_selection` resource in Terraform registry
+
 ## 6.5.6
 ### Fixes
 - Fix `kafka` remove unavailable locations from resources and data sources

--- a/docs/data-sources/autoscaling_group.md
+++ b/docs/data-sources/autoscaling_group.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Autoscaling"
 layout: "ionoscloud"
 page_title: "IonosCloud : autoscaling_group"
 sidebar_current: "docs-datasource-autoscaling_group"

--- a/docs/data-sources/autoscaling_group_servers.md
+++ b/docs/data-sources/autoscaling_group_servers.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Autoscaling"
 layout: "ionoscloud"
 page_title: "IonosCloud : ionoscloud_autoscaling_group_servers"
 sidebar_current: "docs-ionoscloud_autoscaling_group_servers"

--- a/docs/data-sources/dbaas_mongo_template.md
+++ b/docs/data-sources/dbaas_mongo_template.md
@@ -1,3 +1,12 @@
+---
+subcategory: "Database as a Service - MongoDB"
+layout: "ionoscloud"
+page_title: "IonosCloud: ionoscloud_mongo_template"
+sidebar_current: "docs-ionoscloud_mongo_template"
+description: |-
+  Get information on DbaaS MongoDB Cluster objects.
+---
+
 # ionoscloud_mongo_template
 
 The **DbaaS Mongo Template data source** can be used to search for and return an existing DbaaS MongoDB Template.

--- a/docs/resources/autoscaling_group.md
+++ b/docs/resources/autoscaling_group.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Autoscaling"
 layout: "ionoscloud"
 page_title: "IonosCloud: autoscaling_group"
 sidebar_current: "docs-resource-autoscaling_group"

--- a/docs/resources/server_boot_device_selection.md
+++ b/docs/resources/server_boot_device_selection.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Engine"
 layout: "ionoscloud"
 page_title: "IonosCloud: Server Boot Device Selection"
 sidebar_current: "docs-resource-server-boot-device-selection"


### PR DESCRIPTION
## What does this fix or implement?
Places some docs under the correct categories on TF registry

![image](https://github.com/user-attachments/assets/85aebc21-d060-4eb0-aa13-1a1e9759fe6c)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
