### PR TITLE
refactor: Remove 'image_alias' from volume resource/ds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.5.8 - upcoming release
+### Refactor
+  - Remove `image_alias` sets from `ionoscloud_volume` data source and resource
+### Documentation
+  - Remove `image_alias` from `ionocloud_volume` data source and resource docs
 ## 6.5.7
 ### Fixes
   - Fix documentation rendering of `autoscaling_group` resource and data source, `dbaas_mongo_template` data source and `server_boot_device_selection` resource in Terraform registry

--- a/docs/data-sources/volume.md
+++ b/docs/data-sources/volume.md
@@ -51,7 +51,6 @@ The following attributes are returned by the datasource:
 * `sshkey` - The associated public SSH key.
 * `image_password` - Required if `sshkey_path` is not provided.
 * `image` - The image or snapshot UUID.
-* `image_alias` - The image alias.
 * `licence_type` - The type of the licence.
 * `availability_zone` - The storage availability zone assigned to the volume: AUTO, ZONE_1, ZONE_2, or ZONE_3. This property is immutable.
 * `user_data` - The cloud-init configuration for the volume as base64 encoded string. The property is immutable and is only allowed to be set on a new volume creation. This option will work only with cloud-init compatible images.

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -128,7 +128,6 @@ resource "random_password" "volume_image_password" {
 * `image_password` - (Optional)[string] Required if `sshkey_path` is not provided.
 * `image_name` - (Optional)[string] The name, ID or alias of the image. May also be a snapshot ID. It is required if `licence_type` is not provided. Attribute is immutable.
 * `image` - (Computed) The image or snapshot UUID.
-* `image_alias` - (Computed) The image alias.
 * `licence_type` - (Optional)[string] Required if `image_name` is not provided.
 * `name` - (Optional)[string] The name of the volume.
 * `availability_zone` - (Optional)[string] The storage availability zone assigned to the volume: AUTO, ZONE_1, ZONE_2, or ZONE_3. This property is immutable

--- a/ionoscloud/data_source_volume.go
+++ b/ionoscloud/data_source_volume.go
@@ -28,10 +28,6 @@ func dataSourceVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"image_alias": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"size": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/ionoscloud/resource_volume.go
+++ b/ionoscloud/resource_volume.go
@@ -499,13 +499,6 @@ func setVolumeData(d *schema.ResourceData, volume *ionoscloud.Volume) error {
 		}
 	}
 
-	if volume.Properties.ImageAlias != nil {
-		err := d.Set("image_alias", *volume.Properties.ImageAlias)
-		if err != nil {
-			return fmt.Errorf("error while setting image_alias property for volume %s: %w", d.Id(), err)
-		}
-	}
-
 	if volume.Properties.AvailabilityZone != nil {
 		err := d.Set("availability_zone", *volume.Properties.AvailabilityZone)
 		if err != nil {


### PR DESCRIPTION
## What does this fix or implement?

`image_alias` it's not returned in the response for a `GET` on volumes, therefore we can't store `image_alias` in the state.

For `ionoscloud_volume` RESOURCE we simply removed the sets related to `image_alias` from the read function.

For `ionoscloud_volume` DATA SOURCE we also removed the `image_alias` from the DS schema. This isn't a breaking change since the field wasn't set before (the `GET` response for the volume doesn't contain info about `image_alias`, so nothing was set, even though the `image_alias` was present in the schema for the DS).

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
