### PR TITLE
fix: Fix provider crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 6.7.1 (Upcoming)
+## 6.7.2 -- upcoming release
+### Fixes
+- Fix provider crashing when `canonical_user_id` is `nil` in the response for object storage access key
+
+## 6.7.1
 ### Fixes
 - Remove cpu_family and availability_zone from the tests
 ### Features

--- a/services/objectstoragemanagement/accesskeys.go
+++ b/services/objectstoragemanagement/accesskeys.go
@@ -137,20 +137,13 @@ func (c *Client) DeleteAccessKey(ctx context.Context, accessKeyID string, timeou
 // SetAccessKeyPropertiesToPlan sets accesskey properties from an SDK object to a AccesskeyResourceModel
 func SetAccessKeyPropertiesToPlan(plan *AccesskeyResourceModel, accessKey objectstoragemanagement.AccessKeyRead) {
 	if accessKey.Properties != nil {
-		// Here we check the properties because based on the request not all are set and we do not want to overwrite with nil
-		if accessKey.Properties.AccessKey != nil {
-			plan.AccessKey = basetypes.NewStringPointerValue(accessKey.Properties.AccessKey)
-		}
-		if accessKey.Properties.CanonicalUserId != nil {
-			plan.CanonicalUserID = basetypes.NewStringPointerValue(accessKey.Properties.CanonicalUserId)
-		}
-		if accessKey.Properties.ContractUserId != nil {
-			plan.ContractUserID = basetypes.NewStringPointerValue(accessKey.Properties.ContractUserId)
-		}
-		if accessKey.Properties.Description != nil {
-			plan.Description = basetypes.NewStringPointerValue(accessKey.Properties.Description)
-		}
-		if accessKey.Properties.SecretKey != nil {
+		plan.AccessKey = basetypes.NewStringPointerValue(accessKey.Properties.AccessKey)
+		plan.CanonicalUserID = basetypes.NewStringPointerValue(accessKey.Properties.CanonicalUserId)
+		plan.ContractUserID = basetypes.NewStringPointerValue(accessKey.Properties.ContractUserId)
+		plan.Description = basetypes.NewStringPointerValue(accessKey.Properties.Description)
+		// The secret key is present only in the POST response, on subsequent GET calls we don't
+		// want to overwrite the secret key with nil, if the value is set just leave it as it is.
+		if plan.SecretKey.IsUnknown() {
 			plan.SecretKey = basetypes.NewStringPointerValue(accessKey.Properties.SecretKey)
 		}
 	}


### PR DESCRIPTION
## What does this fix or implement?

`canonicalUserId` can be `nil` in the API response when working with object storage access keys. In this case, the provider should not crash. This PR takes care of this: if the value is `nil` then it won't be set in the state.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
