### PR TITLE
fix: do not throw error if ionoscloud_object_storage_acesskey is not …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.7.3
 ### Fixes
 - Remove cpu_family, availability_zone and rockylinux-8-GenericCloud-20230518 from docs
+- Do not return an error if `ionoscloud_object_storage_acesskey` is not found
 ## 6.7.2
 ### Fixes
 - Fix provider crashing when `canonical_user_id` is `nil` in the response for object storage access key

--- a/internal/framework/services/objectstoragemanagement/resource_object_storage_accesskey.go
+++ b/internal/framework/services/objectstoragemanagement/resource_object_storage_accesskey.go
@@ -128,7 +128,7 @@ func (r *accesskeyResource) Create(ctx context.Context, req resource.CreateReque
 
 	accessKeyRead, _, err := r.client.GetAccessKey(ctx, data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Access Key API error", err.Error())
+		resp.Diagnostics.AddError("access Key API error", err.Error())
 		return
 	}
 
@@ -150,9 +150,13 @@ func (r *accesskeyResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	accessKey, _, err := r.client.GetAccessKey(ctx, data.ID.ValueString())
+	accessKey, apiResponse, err := r.client.GetAccessKey(ctx, data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Access Key API error", err.Error())
+		resp.Diagnostics.AddError("read Access Key API error", err.Error())
+		return
+	}
+	if apiResponse.HttpNotFound() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -197,7 +201,7 @@ func (r *accesskeyResource) Update(ctx context.Context, req resource.UpdateReque
 
 	accessKeyRead, _, err := r.client.GetAccessKey(ctx, *accessKeyResponse.Id)
 	if err != nil {
-		resp.Diagnostics.AddError("Access Key API error", err.Error())
+		resp.Diagnostics.AddError("on update, read access Key API error", err.Error())
 		return
 	}
 

--- a/services/objectstoragemanagement/accesskeys.go
+++ b/services/objectstoragemanagement/accesskeys.go
@@ -55,6 +55,9 @@ func (c *Client) modifyConfigURL() {
 func (c *Client) GetAccessKey(ctx context.Context, accessKeyID string) (objectstoragemanagement.AccessKeyRead, *objectstoragemanagement.APIResponse, error) {
 	c.modifyConfigURL()
 	accessKey, apiResponse, err := c.client.AccesskeysApi.AccesskeysFindById(ctx, accessKeyID).Execute()
+	if apiResponse.HttpNotFound() {
+		return accessKey, apiResponse, nil
+	}
 	apiResponse.LogInfo()
 	return accessKey, apiResponse, err
 }


### PR DESCRIPTION
…found

## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
