### PR TITLE
fix: Fix client init for DNS

### DIFF
--- a/services/dns/client.go
+++ b/services/dns/client.go
@@ -22,7 +22,6 @@ type Client struct {
 
 func NewClient(clientOptions clientoptions.TerraformClientOptions, fileConfig *fileconfiguration.FileConfig) *Client {
 	loadedconfig.SetGlobalClientOptionsFromFileConfig(&clientOptions, fileConfig, fileconfiguration.DNS)
-
 	config := shared.NewConfiguration(clientOptions.Credentials.Username, clientOptions.Credentials.Password, clientOptions.Credentials.Token, clientOptions.Endpoint)
 
 	config.MaxRetries = constant.MaxRetries
@@ -37,5 +36,5 @@ func NewClient(clientOptions clientoptions.TerraformClientOptions, fileConfig *f
 	}
 	client.sdkClient.GetConfig().HTTPClient = &http.Client{Transport: shared.CreateTransport(clientOptions.SkipTLSVerify, clientOptions.Certificate)}
 
-	return &Client{sdkClient: *dns.NewAPIClient(config)}
+	return client
 }


### PR DESCRIPTION
## What does this fix or implement?

During the rebase process for the DNS bundle integration PR: https://github.com/ionos-cloud/terraform-provider-ionoscloud/pull/753, I missed a faulty client initialization that doesn't take into consideration some important values. 

This PR fixes the problem.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
