### PR TITLE
fix: kafka remove mentions of 3.7.0 as it is no longer supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.7.8
+### Documentation
+- Remove mentions of `kafka` 3.7.0 version as it is no longer supported.
+
 ## 6.7.7
 ### Features
 - Add backup to mariadb

--- a/docs/resources/kafka_cluster.md
+++ b/docs/resources/kafka_cluster.md
@@ -112,7 +112,7 @@ resource "ionoscloud_kafka_cluster" "example" {
 * `id` - (Computed)[string] The UUID of the Kafka Cluster.
 * `name` - (Required)[string] Name of the Kafka Cluster.
 * `location` - (Optional)[string] The location of the Kafka Cluster. Possible values: `de/fra`, `de/txl`. If this is not set and if no value is provided for the `IONOS_API_URL` env var, the default `location` will be: `de/fra`.
-* `version` - (Required)[string] Version of the Kafka Cluster. Possible values: `3.7.0`, `3.8.0`
+* `version` - (Required)[string] Version of the Kafka Cluster. Possible values: `3.8.0`
 * `size` - (Required)[string] Size of the Kafka Cluster. Possible values: `XS`, `S`
 * `connections` - (Required) Connection information of the Kafka Cluster. Minimum items: 1, maximum items: 1.
     * `datacenter_id` - (Required)[string] The datacenter to connect your instance to.

--- a/ionoscloud/resource_kafka_cluster.go
+++ b/ionoscloud/resource_kafka_cluster.go
@@ -45,7 +45,7 @@ func resourceKafkaCluster() *schema.Resource {
 			},
 			"version": {
 				Type:        schema.TypeString,
-				Description: "The desired Kafka Version. Supported versions: 3.7.0, 3.8.0",
+				Description: "The desired Kafka Version. Supported versions: 3.8.0",
 				ForceNew:    true,
 				Required:    true,
 			},

--- a/ionoscloud/resource_kafka_topic_test.go
+++ b/ionoscloud/resource_kafka_topic_test.go
@@ -229,7 +229,7 @@ resource "ionoscloud_lan" "test_lan" {
 
 resource "ionoscloud_kafka_cluster" "test_kafka_cluster" {
 	name = "test_kafka_cluster"
-	version = "3.8.0"
+	version = "` + clusterAttributeVersionValue + `"
 	size = "S"
 	location = ionoscloud_datacenter.test_datacenter.location
 	connections {


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
