### PR TITLE
fix: ionoscloud_logging_pipeline should not crash on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Remove mentions of `kafka` 3.7.0 version as it is no longer supported.
 ### Fixes
 - Fix S3 key test, add back update test
+- `ionoscloud_logging_pipeline` crashes on read after create 
 
 ## 6.7.7
 ### Features

--- a/services/logging/pipeline.go
+++ b/services/logging/pipeline.go
@@ -201,17 +201,17 @@ func (c *Client) SetPipelineData(d *schema.ResourceData, pipeline logging.Pipeli
 		for i, logElem := range pipeline.Properties.Logs {
 			// Populate the logElem entry.
 			logEntry := make(map[string]interface{})
-			logEntry["source"] = *logElem.Source
-			logEntry["tag"] = *logElem.Tag
-			logEntry["protocol"] = *logElem.Protocol
-			logEntry["public"] = *logElem.Public
+			utils.SetPropWithNilCheck(logEntry, "source", logElem.Source)
+			utils.SetPropWithNilCheck(logEntry, "tag", logElem.Tag)
+			utils.SetPropWithNilCheck(logEntry, "protocol", logElem.Protocol)
+			utils.SetPropWithNilCheck(logEntry, "public", logElem.Public)
 
 			// Logic for destinations
 			destinations := make([]interface{}, len(logElem.Destinations))
 			for i, destination := range logElem.Destinations {
 				destinationEntry := make(map[string]interface{})
-				destinationEntry["type"] = *destination.Type
-				destinationEntry["retention_in_days"] = *destination.RetentionInDays
+				utils.SetPropWithNilCheck(destinationEntry, "type", destination.Type)
+				utils.SetPropWithNilCheck(destinationEntry, "retention_in_days", destination.RetentionInDays)
 				destinations[i] = destinationEntry
 			}
 			logEntry["destinations"] = destinations


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
