### PR TITLE
fix: inline volume external deletion bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.7.16 -- upcoming release
 ### Fixes
 - Fix [#864](https://github.com/ionos-cloud/terraform-provider-ionoscloud/issues/864) by marking `allow_replace` as `Computed` for PgSQL clusters
+- Fix [#867](https://github.com/ionos-cloud/terraform-provider-ionoscloud/issues/867)
 
 ## 6.7.15
 ### Features


### PR DESCRIPTION
## What does this fix or implement?

Fixes https://github.com/ionos-cloud/terraform-provider-ionoscloud/issues/867 (the part related to volumes).

The issue describes behavior for two scenarios:

1. Inline NIC is deleted outside Terraform - the behavior described in the issue is normal since the firewall rule contains a required attribute: `nic_id`, if `nic_id` points to the `primary_nic` inside the `server` resource and the `primary_nic` is modified (using an external deletion of the NIC) then some extra steps are needed to make sure that, before creating a firewall rule, the `nic_id` attribute has a valid, non-empty value - for this scenario no fix is required.

2. Inline volume is deleted oustside Terraform - customer is blocked, running `terraform plan` / `terraform apply` doesn't work because an error is always shown: `the volume X cannot be found` - the PR contains the fix for this situation, the customer shouldn't be blocked and should be able to work with Terraform even if the volume was deleted from the infrastructure.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
