### PR TITLE
docs: Update server_id reference in boot device selection

### DIFF
--- a/docs/resources/server_boot_device_selection.md
+++ b/docs/resources/server_boot_device_selection.md
@@ -107,7 +107,7 @@ resource "ionoscloud_volume" "example" {
 ```hcl
 resource "ionoscloud_server_boot_device_selection" "example"{
   datacenter_id  = ionoscloud_datacenter.example.id
-  server_id      = ionoscloud_server.example.inline_volume_ids[0]
+  server_id      = ionoscloud_server.example.id
   boot_device_id = data.ionoscloud_image.example.id
 }
 
@@ -155,8 +155,8 @@ data "ionoscloud_image" "example" {
 ### Perform a network boot
 ```hcl
 resource "ionoscloud_server_boot_device_selection" "example"{
-  datacenter_id  = ionoscloud_datacenter.example.id
-  server_id      = ionoscloud_server.example.inline_volume_ids[0]
+  datacenter_id = ionoscloud_datacenter.example.id
+  server_id     = ionoscloud_server.example.id
   # boot_device_id = data.ionoscloud_image.example.id   VM will boot in the PXE shell when boot_device_id is omitted
 }
 


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixed a couple of references in `ionoscloud_server_boot_device_selection`.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [X] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [X] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
