### PR TITLE
fix: Fix boot device selection crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.7.18
+### Fixes
+- Fix provider crash on `terraform plan / terraform refresh` after the external deletion of a server in a boot device selection resource
+
 ## 6.7.17
 ### Features
 - Add `get_users_data` attribute to the `ionoscloud_group` resource  and data source, this makes fetching user details optional to prevent performance issues in environments with many users or groups.

--- a/services/cloudapi/cloudapiserver/server.go
+++ b/services/cloudapi/cloudapiserver/server.go
@@ -19,9 +19,9 @@ import (
 
 var (
 	// ErrSuspendCubeLast signals to the Server Resource UpdateContext that the cube server will be suspended so that the operation is deferred
-	ErrSuspendCubeLast error
+	ErrSuspendCubeLast = errors.New("suspend cube")
 	// ErrServerNotFound returned when the server with the requested ID does not exist
-	ErrServerNotFound error
+	ErrServerNotFound = errors.New("server not found")
 	// ErrNoBootDevice is returned if the Server does not have a boot cdrom or boot volume set
 	ErrNoBootDevice = errors.New("server has no boot device")
 )


### PR DESCRIPTION
## What does this fix or implement?

Fix boot device selection crash by providing a value for the error sentinel. With the previous version, the `err` was `nil` and this condition:

```
if err != nil {
		if errors.Is(err, cloudapiserver.ErrServerNotFound) {
			d.SetId("")
			return nil
		}
		return diag.FromErr(err)
}
```
Was not met, even when the server didn't exist.

**Other observations:**

- I provided a value for `ErrSuspendCubeLast` also, but this is rather used as a signal instead of an actual error, maybe this is not the right approach for this but redesigning it it's out of the scope of this PR 

	

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
