### PR TITLE
doc: Update documentation for S3 bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 6.7.23 -- upcoming release
 ### Features
-- Added Kafka users data source: `ionoscloud_kafka_users`, user access credentials data source: `ionoscloud_kafka_user_credentials` and user access credentials ephemeral resource: `ionoscloud_kafka_user_credentials`
+- Added Kafka users data source: `ionoscloud_kafka_users`, user access credentials data source: `ionoscloud_kafka_user_credentials` and user access credentials ephemeral resource: `ionoscloud_kafka_user_credentials`.
+### Documentation
+- Updated documentation for S3 buckets.
 
 ## 6.7.22
 ### Features

--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -57,8 +57,14 @@ The following arguments are supported:
 
 ## Import
 
-Resource Bucket can be imported using the `bucket name`
+A bucket can be imported using the `bucket name` and the `region`:
 
 ```shell
-terraform import ionoscloud_s3_bucket.example example
+terraform import ionoscloud_s3_bucket.example region:bucket_name
+```
+
+The `region` can be omitted, in which case the bucket will be imported from the default location: `eu-central-3`.
+
+```shell
+terraform import ionoscloud_s3_bucket.example bucket_name
 ```


### PR DESCRIPTION
## What does this fix or implement?

Update the `S3 bucket` documentation with information about how to import a bucket from a region different than the default one: `eu-central-3`. 

Fixes https://github.com/ionos-cloud/terraform-provider-ionoscloud/issues/921.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
