### PR TITLE
fix: Fix IP Failover resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Upcoming
 
+### Fixes
+- Fix IP Failover resource
+
 ### Documentation
 - Improve share docs
 

--- a/ionoscloud/resource_ipfailover.go
+++ b/ionoscloud/resource_ipfailover.go
@@ -95,8 +95,8 @@ func resourceLanIPFailoverCreate(ctx context.Context, d *schema.ResourceData, me
 		NicUuid: &nicUuid,
 	})
 
-	// Modify the LAN using the new list
-	lan, apiResponse, err = client.LANsApi.DatacentersLansPatch(ctx, dcId, lanId).Lan(*lan.Properties).Execute()
+	patchProps := ionoscloud.LanProperties{IpFailover: lan.Properties.IpFailover}
+	_, apiResponse, err = client.LANsApi.DatacentersLansPatch(ctx, dcId, lanId).Lan(patchProps).Execute()
 	apiResponse.LogInfo()
 	if err != nil {
 		requestLocation, _ := apiResponse.SafeLocation()
@@ -203,7 +203,8 @@ func resourceLanIPFailoverUpdate(ctx context.Context, d *schema.ResourceData, me
 			NicUuid: &oldNicUuid,
 		})
 
-		_, apiResponse, err = client.LANsApi.DatacentersLansPatch(ctx, dcId, lanId).Lan(*lan.Properties).Execute()
+		patchProps := ionoscloud.LanProperties{IpFailover: lan.Properties.IpFailover}
+		_, apiResponse, err = client.LANsApi.DatacentersLansPatch(ctx, dcId, lanId).Lan(patchProps).Execute()
 		apiResponse.LogInfo()
 		if err != nil {
 			requestLocation, _ := apiResponse.SafeLocation()
@@ -248,7 +249,8 @@ func resourceLanIPFailoverDelete(ctx context.Context, d *schema.ResourceData, me
 		NicUuid: &nicUuid,
 	})
 
-	_, apiResponse, err = client.LANsApi.DatacentersLansPatch(ctx, dcId, lanId).Lan(*lan.Properties).Execute()
+	patchProps := ionoscloud.LanProperties{IpFailover: lan.Properties.IpFailover}
+	_, apiResponse, err = client.LANsApi.DatacentersLansPatch(ctx, dcId, lanId).Lan(patchProps).Execute()
 	apiResponse.LogInfo()
 	if err != nil {
 		requestLocation, _ := apiResponse.SafeLocation()


### PR DESCRIPTION
## What does this fix or implement?

Fix the `create` / `delete` / `update` behavior for the IP Failover resource. The following error was occurring:

```
Error: an error occurred while patching a lans IP failover group, LAN ID: 1, error: 422 Unprocessable Entity {                                                                                          
    "httpStatus" : 422,
    "messages" : [ {                                                                                                                                                                                      
      "errorCode" : "105",                               
      "message" : "[(root).properties.ipv4CidrBlock] Attribute is read-only"   
}
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
