### PR TITLE
chore: align brand references to IONOS CLOUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - New list resource: `ionoscloud_pg_cluster_v2` — list PostgreSQL v2 clusters via `terraform query`, with optional filtering using `name` or `location` (requires Terraform 1.14+).
 - Support child locations (e.g. `de/fra/2`): image and image alias resolution for `ionoscloud_server`, `ionoscloud_cube_server`, `ionoscloud_gpu_server` and `ionoscloud_volume` also considers the parent location the child inherits images from; the `ionoscloud_image` and `ionoscloud_snapshot` data sources accept results from the parent location; new `metro_region` attribute on the `ionoscloud_location` data source.
 
+### Documentation
+- Align brand references in docs and schema descriptions to `IONOS CLOUD`.
+
 ## 6.7.30
 
 ### Features

--- a/docs/data-sources/user_object_storage_bucket.md
+++ b/docs/data-sources/user_object_storage_bucket.md
@@ -1,7 +1,7 @@
 ---
 subcategory: "Object Storage"
 layout: "ionoscloud"
-page_title: "IonosCloud: user_object_storage_bucket"
+page_title: "IONOS CLOUD: user_object_storage_bucket"
 sidebar_current: "docs-ionoscloud-datasource-user_object_storage_bucket"
 description: |-
   Get information about IONOS User-Owned Object Storage Buckets.

--- a/docs/resources/user_object_storage_bucket.md
+++ b/docs/resources/user_object_storage_bucket.md
@@ -1,7 +1,7 @@
 ---
 subcategory: "Object Storage"
 layout: "ionoscloud"
-page_title: "IonosCloud: user_object_storage_bucket"
+page_title: "IONOS CLOUD: user_object_storage_bucket"
 sidebar_current: "docs-resource-user_object_storage_bucket"
 description: |-
   Creates and manages IONOS User-Owned Object Storage Buckets.
@@ -9,7 +9,7 @@ description: |-
 
 # ionoscloud_user_object_storage_bucket
 
-Manages user-owned IONOS Object Storage Buckets on IonosCloud.
+Manages user-owned IONOS Object Storage Buckets on IONOS CLOUD.
 
 > ⚠️ **Deprecation notice:** User-owned buckets are a legacy bucket type. IONOS recommends using **contract-owned buckets** ([`ionoscloud_s3_bucket`](s3_bucket.md)) for all new workloads. Contract-owned buckets offer broader regional availability, full Terraform sub-resource support (versioning, lifecycle, CORS, SSE, etc.), and are the actively developed offering. Migrate existing user-owned buckets to contract-owned buckets where possible.
 

--- a/internal/framework/services/compute/data_source_contracts.go
+++ b/internal/framework/services/compute/data_source_contracts.go
@@ -36,7 +36,7 @@ func (d *contractsDataSource) Schema(_ context.Context, req datasource.SchemaReq
 		Attributes: map[string]schema.Attribute{
 			"contracts": schema.ListNestedAttribute{
 				Computed:    true,
-				Description: "A list of contracts attached to your Ionos account.",
+				Description: "A list of contracts attached to your IONOS CLOUD account.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"contract_number": schema.Int64Attribute{


### PR DESCRIPTION
Scope: align customer-facing brand references to `IONOS CLOUD` in two Object Storage docs pages (`page_title` and body prose) and one schema description in `data_source_contracts.go`.

Out of scope: Go identifiers (`IonosCloudProvider`, test names), package paths (`github.com/ionos-cloud/...`), HCL resource names (`ionoscloud_*`), and env vars are unchanged.

Verification: no remaining `IonosCloud:` or `on IonosCloud.` in docs, no `your Ionos account` in internal, no duplicated brand tokens, `gofmt` clean.