### PR TITLE
fix: allow VCPU as CPU type

### DIFF
--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -94,9 +94,9 @@ func resourceServer() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				Description:      "server usages: ENTERPRISE or CUBE",
+				Description:      "server usages: ENTERPRISE, VCPU or CUBE",
 				DiffSuppressFunc: utils.DiffToLower,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"CUBE", "ENTERPRISE"}, true)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"CUBE", "VCPU", "ENTERPRISE"}, true)),
 			},
 			"boot_image": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## What does this fix or implement?

In the docs it's statet that the type in the ionoscloud_server resource an be als VCPU, when using VCPU as type the terraform apply fails due to the constraint only allowing cube and enterprise type.


## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
