### PR TITLE
fix: remove deprecated SYNCHRONOUS synchronization mode from schema v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Upcoming release
 
+### Fixes
+- `ionoscloud_pg_cluster`: remove deprecated `SYNCHRONOUS` synchronization mode from schema validation; only `ASYNCHRONOUS` and `STRICTLY_SYNCHRONOUS` are accepted for new clusters.
+
 ### Testing
 - Add more test cases for `compute` data sources.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Upcoming release
 
 ### Fixes
-- `ionoscloud_pg_cluster`: remove deprecated `SYNCHRONOUS` synchronization mode from schema validation; only `ASYNCHRONOUS` and `STRICTLY_SYNCHRONOUS` are accepted for new clusters.
+- `ionoscloud_pg_cluster`: remove schema-level validation on `synchronization_mode` to preserve backward compatibility with existing clusters; validation is delegated to the API.
 
 ### Testing
 - Add more test cases for `compute` data sources.

--- a/docs/resources/dbaas_pgsql_cluster.md
+++ b/docs/resources/dbaas_pgsql_cluster.md
@@ -28,10 +28,10 @@ resource "ionoscloud_lan"  "example" {
 }
 
 resource "ionoscloud_pg_cluster" "example" {
-  postgres_version        = "12"
+  postgres_version        = "16"
   instances               = 1
   cores                   = 4
-  ram                     = 2048
+  ram                     = 4096
   storage_size            = 10240
   storage_type            = "HDD"
   connection_pooler {
@@ -160,7 +160,7 @@ resource "random_password" "cluster_password" {
 * `credentials` - (Required)[string] Credentials for the database user to be created. This attribute is immutable(disallowed in update requests).
     * `username` - (Required)[string] The username for the initial postgres user. Some system usernames are restricted (e.g. "postgres", "admin", "standby")
     * `password` - (Required)[string]
-* `synchronization_mode` - (Required) [string] Represents different modes of replication. Can have one of the following values: ASYNCHRONOUS, STRICTLY_SYNCHRONOUS. The SYNCHRONOUS value has been deprecated for create requests.
+* `synchronization_mode` - (Required) [string] Represents different modes of replication. Can have one of the following values: `ASYNCHRONOUS`, `STRICTLY_SYNCHRONOUS`.
 * `from_backup` - (Optional)[string] The unique ID of the backup you want to restore. This attribute is immutable(disallowed in update requests).
   * `backup_id` - (Required)[string] The unique ID of the backup you want to restore.
   * `recovery_target_time` - (Optional)[string] If this value is supplied as ISO 8601 timestamp, the backup will be replayed up until the given timestamp. If empty, the backup will be applied completely.

--- a/ionoscloud/resource_dbaas_pgsql_cluster.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster.go
@@ -195,7 +195,7 @@ func resourceDbaasPgSqlCluster() *schema.Resource {
 				Type:             schema.TypeString,
 				Description:      "Represents different modes of replication.",
 				Required:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"ASYNCHRONOUS", "SYNCHRONOUS", "STRICTLY_SYNCHRONOUS"}, false)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"ASYNCHRONOUS", "STRICTLY_SYNCHRONOUS"}, false)),
 			},
 			"from_backup": {
 				Type:        schema.TypeList,

--- a/ionoscloud/resource_dbaas_pgsql_cluster.go
+++ b/ionoscloud/resource_dbaas_pgsql_cluster.go
@@ -192,10 +192,9 @@ func resourceDbaasPgSqlCluster() *schema.Resource {
 				},
 			},
 			"synchronization_mode": {
-				Type:             schema.TypeString,
-				Description:      "Represents different modes of replication.",
-				Required:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"ASYNCHRONOUS", "STRICTLY_SYNCHRONOUS"}, false)),
+				Type:        schema.TypeString,
+				Description: "Represents different modes of replication.",
+				Required:    true,
 			},
 			"from_backup": {
 				Type:        schema.TypeList,


### PR DESCRIPTION
Remove schema-level validation on `synchronization_mode` for `ionoscloud_pg_cluster` (psql v1) to preserve backward compatibility with existing clusters.

## Changes
- `synchronization_mode` field validation removed from provider schema — validation is now delegated to the API, allowing existing clusters with any value (including `SYNCHRONOUS`) to continue working without plan errors
- Docs example updated: `postgres_version` changed from `"12"` to `"16"`, `ram` changed from `2048` to `4096` (previous values are no longer accepted by the API)

## Testing

Example used:

```
resource "ionoscloud_datacenter" "example" {
  name                    = "example"
  location                = "de/txl"
  description             = "Datacenter for testing psql cluster"
} 

resource "ionoscloud_lan"  "example" {
  datacenter_id           = ionoscloud_datacenter.example.id
  public                  = false
  name                    = "example"
}

resource "ionoscloud_pg_cluster" "example" {
  postgres_version        = "16"
  instances               = 1
  cores                   = 4
  ram                     = 4096
  storage_size            = 10240
  storage_type            = "HDD"
  connection_pooler {
    enabled = true
    pool_mode = "session"
  }
  connections   {
    datacenter_id         =  ionoscloud_datacenter.example.id
    lan_id                =  ionoscloud_lan.example.id
    cidr                  =  "192.168.100.1/24"
  }
  location                = ionoscloud_datacenter.example.location
  display_name            = "PostgreSQL_cluster"
  maintenance_window {
    day_of_the_week       = "Sunday"
    time                  = "09:00:00"
  }
  credentials {
    username              = "username"
    password              = "strongPassword"
  }
  synchronization_mode    = "SYNCHRONOUS"
}
```

Error received (expected):

```
│ Error: an error occurred while updating a dbaas cluster: 400 Bad Request: {"httpStatus":400,"messages":[{"message":"Validation failed: Field 'synchronizationMode' is invalid. Allowed synchronization modes are ASYNCHRONOUS and STRICTLY_SYNCHRONOUS. See documentation for details.","errorCode":"dbaas-err-api-53"}]}
│ 
│ Resource ID: f18ceb81-9c32-4730-8ebe-68ad9d85d449
│ Resource Name: PostgreSQL_cluster
│ Contract number: 36941109
│ 
│   with ionoscloud_pg_cluster.example,
│   on main.tf line 22, in resource "ionoscloud_pg_cluster" "example":
│   22: resource "ionoscloud_pg_cluster" "example" {
```

Also tested the STRICTLY_SYNCHRONOUS mode with `instances` set to 1 and received the following error (expected):

```
 Error: an error occurred while updating a dbaas cluster: 400 Bad Request: {"httpStatus":400,"messages":[{"message":"Not enough instances: The requested synchronization mode requires at least 3 instances.","errorCode":"dbaas-err-api-54"}]}
│ 
│ Resource ID: f18ceb81-9c32-4730-8ebe-68ad9d85d449
│ Resource Name: PostgreSQL_cluster
│ Contract number: 36941109
│ 
│   with ionoscloud_pg_cluster.example,
│   on main.tf line 22, in resource "ionoscloud_pg_cluster" "example":
│   22: resource "ionoscloud_pg_cluster" "example" {
│ 
```
