### PR TITLE
fix: changing ionoscloud_server type doesn't replace server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - `ionoscloud_pg_cluster_v2`: Fix query pagination loop where `Links.HasNext()` remained set past the last page, causing offsets to grow indefinitely.
+- `ionoscloud_server`: Fix `type` changes with `allow_replace = true` silently doing nothing instead of destroying and re-creating the server.
 
 ### Refactor
 - Remove invalid plan modifier for some InMemoryDB v2 cluster resource attributes.

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -94,6 +94,7 @@ func resourceServer() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
+				ForceNew:         true,
 				Description:      "server usages: ENTERPRISE, VCPU or CUBE",
 				DiffSuppressFunc: utils.DiffToLower,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"CUBE", "VCPU", "ENTERPRISE"}, true)),


### PR DESCRIPTION
## What does this fix or implement?

We are currently switching the type of some servers, the type object has already the allow_replace check set, but when changing the type and doing a apply nothing gets redeployed as the ForceNew flag is missing.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
