### PR TITLE
fix: Fix VPN Wireguard peer resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.7.36 -- upcoming release
+### Fixes
+- `ionoscloud_vpn_wireguard_peer`: Fix `gateway_id` changes attempting an in-place update against the API and failing with an error, instead of destroying and re-creating the peer.
+
 ## 6.7.35
 
 ### Features

--- a/ionoscloud/resource_vpn_wireguard_peer.go
+++ b/ionoscloud/resource_vpn_wireguard_peer.go
@@ -29,7 +29,8 @@ func resourceVpnWireguardPeer() *schema.Resource {
 			"gateway_id": {
 				Type:             schema.TypeString,
 				Required:         true,
-				Description:      "The ID of the WireGuard Peer that the peer will connect to.",
+				ForceNew:         true,
+				Description:      "The ID of the WireGuard Gateway that the peer will connect to.",
 				ValidateDiagFunc: validation.ToDiagFunc(validation.IsUUID),
 			},
 			"location": {


### PR DESCRIPTION
## What does this fix or implement?

A customer wants to be able to change the `gateway_id` value for a Wireguard peer. When doing that, an error was displayed:

```
│ Error: error updating WireGuard Peer: 422 Unprocessable Entity: {"httpStatus":422,"messages":[{"errorCode":"vpn-common-0021","message":"unprocessable entity: id does not match the one in url"}]}
```

This happens because our provider tries to do a `PUT` request, which is incorrect in this case. Instead, it should delete and re-create the peer for the appropriate gateway. 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
