### PR TITLE
fix: Fix S3 bucket read bug for K8s cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Fixes
 - `ionoscloud_vpn_wireguard_peer`: Fix `gateway_id` changes attempting an in-place update against the API and failing with an error, instead of destroying and re-creating the peer.
 - `ionoscloud_k8s_cluster`: Fix `s3_buckets` set incorrectly in the state when `s3_buckets` was an empty list in the API response.
+### Testing
+- Update K8s tests with new versions. 
 
 ## 6.7.35
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.7.36 -- upcoming release
 ### Fixes
 - `ionoscloud_vpn_wireguard_peer`: Fix `gateway_id` changes attempting an in-place update against the API and failing with an error, instead of destroying and re-creating the peer.
+- `ionoscloud_k8s_cluster`: Fix `s3_buckets` set incorrectly in the state when `s3_buckets` was an empty list in the API response.
 
 ## 6.7.35
 

--- a/ionoscloud/resource_k8s_cluster.go
+++ b/ionoscloud/resource_k8s_cluster.go
@@ -636,6 +636,11 @@ func setK8sClusterData(d *schema.ResourceData, cluster *ionoscloud.KubernetesClu
 			if err := d.Set("s3_buckets", s3Buckets); err != nil {
 				return fmt.Errorf("error while setting s3_buckets property for cluser %s: %w", d.Id(), err)
 			}
+		} else {
+			var emptySlice []any
+			if err := d.Set("s3_buckets", emptySlice); err != nil {
+				return fmt.Errorf("error while setting s3_buckets property for cluser %s: %w", d.Id(), err)
+			}
 		}
 
 	}

--- a/ionoscloud/test_constants.go
+++ b/ionoscloud/test_constants.go
@@ -1895,8 +1895,8 @@ resource "random_string" "simple_string" {
 
 // K8s values
 const (
-	K8sVersion                  = "1.29.6"
-	UpgradedK8sVersion          = "1.29.7"
+	K8sVersion                  = "1.32.6"
+	UpgradedK8sVersion          = "1.32.7"
 	K8sBucket                   = "test_k8s_terraform_v7"
 	K8sPrivateClusterNodeSubnet = "192.168.0.0/16"
 )


### PR DESCRIPTION
## What does this fix or implement?

`s3_buckets` was set only when the API returned a non-empty list (leading to drifts), but `s3_buckets` must be set all the time in order to reflect the actual value from the API. 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
