### PR TITLE
fix: enabled_features for vcpu_server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 6.7.37
 
 ### Fixes
-- `ionoscloud_vcpu_server`: Fix `error setting enabled_features` on every plan/apply/refresh by adding the missing `enabled_features` (Computed) attribute to the resource schema, introduced in 6.7.36 by the Confidential Computing change.
+- `ionoscloud_vcpu_server`: Fix `error setting enabled_features` on every plan/apply/refresh by adding the missing `enabled_features` and `confidential` (both Computed) attributes to the resource schema. The shared server reader (`setResourceServerData`) sets both unconditionally, so both keys must exist; the crash was introduced in 6.7.36 by the Confidential Computing change.
 
 ## 6.7.36
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.7.37
+
+### Fixes
+- `ionoscloud_vcpu_server`: Fix `error setting enabled_features` on every plan/apply/refresh by adding the missing `enabled_features` (Computed) attribute to the resource schema, introduced in 6.7.36 by the Confidential Computing change.
+
 ## 6.7.36
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 6.7.37
 
 ### Fixes
-- `ionoscloud_vcpu_server`: Fix `error setting enabled_features` on every plan/apply/refresh by adding the missing `enabled_features` and `confidential` (both Computed) attributes to the resource schema. The shared server reader (`setResourceServerData`) sets both unconditionally, so both keys must exist; the crash was introduced in 6.7.36 by the Confidential Computing change.
+- `ionoscloud_vcpu_server`: Fix `error setting enabled_features` on every plan/apply/refresh (introduced in 6.7.36 by the Confidential Computing change). Adds the missing `enabled_features` and `confidential` (both Computed) attributes to the resource schema, and gives `ionoscloud_vcpu_server` its own read/import/state-writer decoupled from `ionoscloud_server` so the two schemas can no longer break each other; create/update read-back now dispatches by server type.
 
 ## 6.7.36
 

--- a/docs/resources/vcpu_server.md
+++ b/docs/resources/vcpu_server.md
@@ -109,6 +109,7 @@ resource "random_password" "server_image_password" {
 - `boot_volume` - (Computed) The associated boot volume.
 - `boot_cdrom` - ***DEPRECATED*** Please refer to [ionoscloud_server_boot_device_selection](server_boot_device_selection.md) (Optional)[string] The associated boot drive, if any. Must be the UUID of a bootable CDROM image that can be retrieved using the [ionoscloud_image](./../data-sources/image.md) data source.
 - `boot_image` - (Optional)[string] The image or snapshot UUID / name. May also be an image alias. It is required if `licence_type` is not provided.
+- `enabled_features` - (Computed)[list] Features enabled on the server, e.g. `SEV-SNP` for a Confidential Computing VM.
 - `primary_nic` - (Computed) The associated NIC.
 - `primary_ip` - (Computed) The associated IP address.
 - `firewallrule_id` - (Computed) The associated firewall rule.

--- a/docs/resources/vcpu_server.md
+++ b/docs/resources/vcpu_server.md
@@ -110,6 +110,7 @@ resource "random_password" "server_image_password" {
 - `boot_cdrom` - ***DEPRECATED*** Please refer to [ionoscloud_server_boot_device_selection](server_boot_device_selection.md) (Optional)[string] The associated boot drive, if any. Must be the UUID of a bootable CDROM image that can be retrieved using the [ionoscloud_image](./../data-sources/image.md) data source.
 - `boot_image` - (Optional)[string] The image or snapshot UUID / name. May also be an image alias. It is required if `licence_type` is not provided.
 - `enabled_features` - (Computed)[list] Features enabled on the server, e.g. `SEV-SNP` for a Confidential Computing VM.
+- `confidential` - (Computed)[bool] Whether the server is a Confidential Computing (SEV-SNP) VM. Computed on read from the server's enabled features; always `false` for VCPU servers, which cannot be Confidential Computing VMs. Present in state because the shared server reader always sets it.
 - `primary_nic` - (Computed) The associated NIC.
 - `primary_ip` - (Computed) The associated IP address.
 - `firewallrule_id` - (Computed) The associated firewall rule.

--- a/docs/resources/vcpu_server.md
+++ b/docs/resources/vcpu_server.md
@@ -110,7 +110,7 @@ resource "random_password" "server_image_password" {
 - `boot_cdrom` - ***DEPRECATED*** Please refer to [ionoscloud_server_boot_device_selection](server_boot_device_selection.md) (Optional)[string] The associated boot drive, if any. Must be the UUID of a bootable CDROM image that can be retrieved using the [ionoscloud_image](./../data-sources/image.md) data source.
 - `boot_image` - (Optional)[string] The image or snapshot UUID / name. May also be an image alias. It is required if `licence_type` is not provided.
 - `enabled_features` - (Computed)[list] Features enabled on the server, e.g. `SEV-SNP` for a Confidential Computing VM.
-- `confidential` - (Computed)[bool] Whether the server is a Confidential Computing (SEV-SNP) VM. Computed on read from the server's enabled features; always `false` for VCPU servers, which cannot be Confidential Computing VMs. Present in state because the shared server reader always sets it.
+- `confidential` - (Computed)[bool] Whether the server is a Confidential Computing (SEV-SNP) VM. Derived on read from the server's enabled features; normally `false` for VCPU servers, which are not Confidential Computing VMs.
 - `primary_nic` - (Computed) The associated NIC.
 - `primary_ip` - (Computed) The associated IP address.
 - `firewallrule_id` - (Computed) The associated firewall rule.

--- a/ionoscloud/resource_confidential_visibility_test.go
+++ b/ionoscloud/resource_confidential_visibility_test.go
@@ -57,6 +57,20 @@ func TestSetDatacenterDataCPUArchEnabledFeatures(t *testing.T) {
 	}
 }
 
+// Regression for the 6.7.36 crash (https://github.com/ionos-cloud/terraform-provider-ionoscloud):
+// ionoscloud_vcpu_server reads through the shared server state-writer (resourceServerRead ->
+// setResourceServerData), which unconditionally calls d.Set for enabled_features and confidential.
+// Both keys must exist in the VCPU resource schema or every plan/apply/refresh fails with
+// "error setting enabled_features Invalid address to set".
+func TestVCPUServerSchemaHasConfidentialVisibilityKeys(t *testing.T) {
+	s := resourceVCPUServer().Schema
+	for _, key := range []string{"enabled_features", "confidential"} {
+		if _, ok := s[key]; !ok {
+			t.Errorf("VCPU server schema missing %q; shared server state-writer sets it and will fail", key)
+		}
+	}
+}
+
 // serverIsConfidential drives the destroy volume-ordering, derived from the API-reported features
 // so it stays correct for imported/drifted servers.
 func TestServerIsConfidential(t *testing.T) {

--- a/ionoscloud/resource_confidential_visibility_test.go
+++ b/ionoscloud/resource_confidential_visibility_test.go
@@ -57,16 +57,59 @@ func TestSetDatacenterDataCPUArchEnabledFeatures(t *testing.T) {
 	}
 }
 
+// sharedServerReadWriterKeys are the keys that setResourceServerData (the state-writer behind the
+// shared resourceServerRead) calls d.Set on unconditionally, i.e. not gated on the key existing in
+// the caller's schema. Every resource wired to resourceServerRead MUST declare all of them, or that
+// resource crashes at plan/apply/refresh with "Invalid address to set". Keep this list in sync with
+// the unconditional d.Set calls in setResourceServerData (resource_server.go).
+var sharedServerReadWriterKeys = []string{"enabled_features", "confidential"}
+
+// sharedServerReadResources are the resources that reuse resourceServerRead / setResourceServerData
+// as their read path. ionoscloud_cube_server is deliberately excluded: it has its own reader
+// (resourceCubeServerRead) that does not set these keys.
+var sharedServerReadResources = map[string]func() *schema.Resource{
+	"ionoscloud_server":      resourceServer,
+	"ionoscloud_vcpu_server": resourceVCPUServer,
+}
+
 // Regression for the 6.7.36 crash (https://github.com/ionos-cloud/terraform-provider-ionoscloud):
 // ionoscloud_vcpu_server reads through the shared server state-writer (resourceServerRead ->
 // setResourceServerData), which unconditionally calls d.Set for enabled_features and confidential.
-// Both keys must exist in the VCPU resource schema or every plan/apply/refresh fails with
-// "error setting enabled_features Invalid address to set".
-func TestVCPUServerSchemaHasConfidentialVisibilityKeys(t *testing.T) {
-	s := resourceVCPUServer().Schema
-	for _, key := range []string{"enabled_features", "confidential"} {
-		if _, ok := s[key]; !ok {
-			t.Errorf("VCPU server schema missing %q; shared server state-writer sets it and will fail", key)
+// Both keys must exist in every schema wired to that reader or plan/apply/refresh fails with
+// "error setting enabled_features Invalid address to set". This guards the whole class, not just
+// the one attribute/one resource that broke in 6.7.36.
+func TestSharedServerReadWriterKeysPresentInSchemas(t *testing.T) {
+	for name, ctor := range sharedServerReadResources {
+		s := ctor().Schema
+		for _, key := range sharedServerReadWriterKeys {
+			if _, ok := s[key]; !ok {
+				t.Errorf("%s schema missing %q; shared server state-writer sets it unconditionally and will crash at read", name, key)
+			}
+		}
+	}
+}
+
+// Reproduces the exact failing calls from setResourceServerData (resource_server.go:1566, 1576)
+// against every shared-reader schema: enabled_features as a []string and confidential as a bool.
+// Stronger than the presence check — it also catches a type mismatch (e.g. someone re-declaring
+// enabled_features as TypeString), which would still fail d.Set at runtime.
+func TestSharedServerReadWriterSetRoundTrip(t *testing.T) {
+	for name, ctor := range sharedServerReadResources {
+		d := schema.TestResourceDataRaw(t, ctor().Schema, nil)
+
+		if err := d.Set("enabled_features", []string{"SEV-SNP"}); err != nil {
+			t.Errorf("%s: d.Set(enabled_features) = %v, want nil", name, err)
+		}
+		if err := d.Set("confidential", true); err != nil {
+			t.Errorf("%s: d.Set(confidential) = %v, want nil", name, err)
+		}
+
+		feats := d.Get("enabled_features").([]any)
+		if len(feats) != 1 || feats[0].(string) != "SEV-SNP" {
+			t.Errorf("%s: enabled_features = %v, want [SEV-SNP]", name, feats)
+		}
+		if d.Get("confidential").(bool) != true {
+			t.Errorf("%s: confidential = false, want true", name)
 		}
 	}
 }

--- a/ionoscloud/resource_confidential_visibility_test.go
+++ b/ionoscloud/resource_confidential_visibility_test.go
@@ -57,51 +57,57 @@ func TestSetDatacenterDataCPUArchEnabledFeatures(t *testing.T) {
 	}
 }
 
-// sharedServerReadWriterKeys are the keys that setResourceServerData (the state-writer behind the
-// shared resourceServerRead) calls d.Set on unconditionally, i.e. not gated on the key existing in
-// the caller's schema. Every resource wired to resourceServerRead MUST declare all of them, or that
-// resource crashes at plan/apply/refresh with "Invalid address to set". Keep this list in sync with
-// the unconditional d.Set calls in setResourceServerData (resource_server.go).
-var sharedServerReadWriterKeys = []string{"enabled_features", "confidential"}
+// serverReadWriterKeys are the keys the server state-writers (setResourceServerData for enterprise,
+// setResourceVCPUServerData for vcpu) call d.Set on unconditionally, i.e. not gated on the key
+// existing in the schema. Every server resource whose writer sets them MUST declare all of them, or
+// that resource crashes at plan/apply/refresh with "Invalid address to set". Keep this in sync with
+// the unconditional d.Set calls in both writers.
+var serverReadWriterKeys = []string{"enabled_features", "confidential"}
 
-// sharedServerReadResources are the resources that reuse resourceServerRead / setResourceServerData
-// as their read path. ionoscloud_cube_server is deliberately excluded: it has its own reader
-// (resourceCubeServerRead) that does not set these keys.
-var sharedServerReadResources = map[string]func() *schema.Resource{
+// serverConfidentialAwareResources are the resources whose state-writer sets serverReadWriterKeys.
+// As of the un-sharing, ionoscloud_server and ionoscloud_vcpu_server have SEPARATE writers, but both
+// still set these keys, so both must declare them. ionoscloud_cube_server / ionoscloud_gpu_server are
+// excluded: their reader (resourceCubeServerRead) sets neither key.
+var serverConfidentialAwareResources = map[string]func() *schema.Resource{
 	"ionoscloud_server":      resourceServer,
 	"ionoscloud_vcpu_server": resourceVCPUServer,
 }
 
 // Regression for the 6.7.36 crash (https://github.com/ionos-cloud/terraform-provider-ionoscloud):
-// ionoscloud_vcpu_server reads through the shared server state-writer (resourceServerRead ->
-// setResourceServerData), which unconditionally calls d.Set for enabled_features and confidential.
-// Both keys must exist in every schema wired to that reader or plan/apply/refresh fails with
+// the vcpu server crashed because its schema lacked enabled_features/confidential while the writer
+// set them unconditionally. Whether the writer is shared (pre-fix) or per-type (post un-sharing),
+// every server whose writer sets these keys must declare them, or plan/apply/refresh fails with
 // "error setting enabled_features Invalid address to set". This guards the whole class, not just
 // the one attribute/one resource that broke in 6.7.36.
 func TestSharedServerReadWriterKeysPresentInSchemas(t *testing.T) {
-	for name, ctor := range sharedServerReadResources {
+	for name, ctor := range serverConfidentialAwareResources {
 		s := ctor().Schema
-		for _, key := range sharedServerReadWriterKeys {
+		for _, key := range serverReadWriterKeys {
 			if _, ok := s[key]; !ok {
-				t.Errorf("%s schema missing %q; shared server state-writer sets it unconditionally and will crash at read", name, key)
+				t.Errorf("%s schema missing %q; its server state-writer sets it unconditionally and will crash at read", name, key)
 			}
 		}
 	}
 }
 
-// Reproduces the exact failing calls from setResourceServerData (resource_server.go:1566, 1576)
-// against every shared-reader schema: enabled_features as a []string and confidential as a bool.
-// Stronger than the presence check — it also catches a type mismatch (e.g. someone re-declaring
-// enabled_features as TypeString), which would still fail d.Set at runtime.
-func TestSharedServerReadWriterSetRoundTrip(t *testing.T) {
-	for name, ctor := range sharedServerReadResources {
+// Exercises the ACTUAL writer helper both server state-writers call (setServerConfidentialVisibility)
+// against every consuming schema, with a populated Server carrying SEV-SNP. This is the real drift
+// guard after un-sharing: it runs the writer path (not a bare d.Set), so it catches the vcpu writer
+// dropping/misspelling a key, a type mismatch, or confidential being derived wrong — the exact class
+// that broke in 6.7.36. Both writers delegate here, so testing the helper covers both.
+func TestSetServerConfidentialVisibilityAcrossSchemas(t *testing.T) {
+	server := &ionoscloud.Server{
+		Properties: &ionoscloud.ServerProperties{
+			EnabledFeatures: &[]string{"SEV-SNP"},
+		},
+	}
+
+	for name, ctor := range serverConfidentialAwareResources {
 		d := schema.TestResourceDataRaw(t, ctor().Schema, nil)
 
-		if err := d.Set("enabled_features", []string{"SEV-SNP"}); err != nil {
-			t.Errorf("%s: d.Set(enabled_features) = %v, want nil", name, err)
-		}
-		if err := d.Set("confidential", true); err != nil {
-			t.Errorf("%s: d.Set(confidential) = %v, want nil", name, err)
+		if err := setServerConfidentialVisibility(d, server); err != nil {
+			t.Errorf("%s: setServerConfidentialVisibility = %v, want nil", name, err)
+			continue
 		}
 
 		feats := d.Get("enabled_features").([]any)
@@ -109,7 +115,7 @@ func TestSharedServerReadWriterSetRoundTrip(t *testing.T) {
 			t.Errorf("%s: enabled_features = %v, want [SEV-SNP]", name, feats)
 		}
 		if d.Get("confidential").(bool) != true {
-			t.Errorf("%s: confidential = false, want true", name)
+			t.Errorf("%s: confidential = false, want true (SEV-SNP present)", name)
 		}
 	}
 }

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -743,7 +743,41 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 	}
 
+	return serverReadForType(ctx, d, meta)
+}
+
+// serverReadForType routes the post-create/update read-back to the state-writer that owns the
+// server's type. ionoscloud_vcpu_server has its own read path (resourceVCPUServerRead) that is not
+// shared with the enterprise writer, so its create/update must refresh state through it too.
+// Only called from the enterprise create/update handlers, which vcpu delegates to after setting
+// type=VCPU — so `type` is always populated here; anything non-VCPU (incl. the empty default for a
+// genuine ionoscloud_server) correctly reads via the enterprise writer.
+func serverReadForType(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	if strings.EqualFold(d.Get("type").(string), constant.VCPUType) {
+		return resourceVCPUServerRead(ctx, d, meta)
+	}
 	return resourceServerRead(ctx, d, meta)
+}
+
+// setServerConfidentialVisibility writes the two Confidential Computing visibility keys
+// (enabled_features, confidential) that every server state-writer must set. Centralised so the
+// enterprise (setResourceServerData) and vcpu (setResourceVCPUServerData) writers cannot drift on
+// these crash-prone keys — a missing/misspelled key here is exactly the 6.7.36 regression.
+func setServerConfidentialVisibility(d *schema.ResourceData, server *ionoscloud.Server) error {
+	if server.Properties != nil && server.Properties.EnabledFeatures != nil {
+		if err := d.Set("enabled_features", *server.Properties.EnabledFeatures); err != nil {
+			return fmt.Errorf("error setting enabled_features %w", err)
+		}
+	} else {
+		// Clear any stale value if the API no longer reports features.
+		d.Set("enabled_features", nil)
+	}
+	// Derive `confidential` from the API so imported/refreshed servers reflect their real state
+	// and don't trigger a spurious ForceNew replace.
+	if err := d.Set("confidential", serverIsConfidential(server)); err != nil {
+		return fmt.Errorf("error setting confidential %w", err)
+	}
+	return nil
 }
 
 func resourceServerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -1144,7 +1178,7 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 
 	}
-	return resourceServerRead(ctx, d, meta)
+	return serverReadForType(ctx, d, meta)
 }
 
 func deleteInlineVolumes(ctx context.Context, d *schema.ResourceData, meta any, client *ionoscloud.APIClient) diag.Diagnostics {
@@ -1562,19 +1596,8 @@ func setResourceServerData(ctx context.Context, client *ionoscloud.APIClient, d 
 			}
 		}
 
-		if server.Properties.EnabledFeatures != nil {
-			if err := d.Set("enabled_features", *server.Properties.EnabledFeatures); err != nil {
-				return fmt.Errorf("error setting enabled_features %w", err)
-			}
-		} else {
-			// Clear any stale value if the API no longer reports features.
-			d.Set("enabled_features", nil)
-		}
-
-		// Derive `confidential` from the API so imported/refreshed servers reflect their real state
-		// and don't trigger a spurious ForceNew replace.
-		if err := d.Set("confidential", serverIsConfidential(server)); err != nil {
-			return fmt.Errorf("error setting confidential %w", err)
+		if err := setServerConfidentialVisibility(d, server); err != nil {
+			return err
 		}
 
 		if server.Properties.BootCdrom != nil {

--- a/ionoscloud/resource_vcpu_server.go
+++ b/ionoscloud/resource_vcpu_server.go
@@ -76,6 +76,17 @@ func resourceVCPUServer() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+			"enabled_features": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Features enabled on the server, e.g. SEV-SNP for a Confidential Computing VM.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"confidential": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Computed on read from the server's enabled features. Always false for VCPU servers, which cannot be Confidential Computing VMs.",
+			},
 			"primary_nic": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/ionoscloud/resource_vcpu_server.go
+++ b/ionoscloud/resource_vcpu_server.go
@@ -16,11 +16,11 @@ import (
 func resourceVCPUServer() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceVCPUServerCreate,
-		ReadContext:   resourceServerRead,
+		ReadContext:   resourceVCPUServerRead,
 		UpdateContext: resourceServerUpdate,
 		DeleteContext: resourceServerDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceServerImport,
+			StateContext: resourceVCPUServerImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -85,7 +85,7 @@ func resourceVCPUServer() *schema.Resource {
 			"confidential": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Computed on read from the server's enabled features. Always false for VCPU servers, which cannot be Confidential Computing VMs.",
+				Description: "Whether the server is a Confidential Computing (SEV-SNP) VM. Derived on read from the server's enabled features; normally false for VCPU servers, which are not Confidential Computing VMs.",
 			},
 			"primary_nic": {
 				Type:        schema.TypeString,

--- a/ionoscloud/resource_vcpu_server_read.go
+++ b/ionoscloud/resource_vcpu_server_read.go
@@ -1,0 +1,380 @@
+package ionoscloud
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
+
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/bundleclient"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/cloudapi/cloudapifirewall"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/cloudapi/cloudapinic"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/cloudapi/nsg"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils"
+	diagutil "github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/diags"
+)
+
+// The ionoscloud_vcpu_server resource has its own read/import/state-writer, deliberately NOT shared
+// with ionoscloud_server. This keeps the two schemas decoupled: a change to the enterprise
+// server's state-writer can no longer set a key that is missing from the VCPU schema (the 6.7.36
+// enabled_features regression). Leaf helpers (SetVolumeProperties, cloudapinic/cloudapifirewall/nsg
+// services, LabelsService, serverIsConfidential) remain shared - only the top-level per-type
+// state-writer is duplicated.
+
+func resourceVCPUServerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	location := d.Get("location").(string)
+	client, err := meta.(bundleclient.SdkBundle).NewCloudAPIClient(ctx, location)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dcID := d.Get("datacenter_id").(string)
+	serverID := d.Id()
+
+	server, apiResponse, err := client.ServersApi.DatacentersServersFindById(ctx, dcID, serverID).Depth(4).Execute()
+	logApiRequestTime(apiResponse)
+	if err != nil {
+		if httpNotFound(apiResponse) {
+			tflog.Debug(ctx, "cannot find vcpu server by id", map[string]any{"server_id": serverID})
+			d.SetId("")
+			return nil
+		}
+		return diagutil.ToDiags(d, fmt.Errorf("error occurred while fetching a vcpu server: %w", err), nil)
+	}
+	if err := setResourceVCPUServerData(ctx, client, d, &server); err != nil {
+		return diagutil.ToDiags(d, err, nil)
+	}
+
+	return nil
+}
+
+func resourceVCPUServerImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	importID := d.Id()
+	location, parts := splitImportID(importID, "/")
+
+	if len(parts) < 2 {
+		return nil, diagutil.ToError(d, fmt.Errorf(
+			"invalid import identifier: expected one of <location>:<datacenter-id>/<server-id> "+
+				"or <datacenter-id>/<server-id>, got: %s", importID,
+		), nil)
+	}
+
+	if err := validateImportIDParts(parts); err != nil {
+		return nil, diagutil.ToError(d, fmt.Errorf("failed validating import identifier %q: %w", importID, err), nil)
+	}
+
+	datacenterID := parts[0]
+	serverID := parts[1]
+
+	client, err := meta.(bundleclient.SdkBundle).NewCloudAPIClient(ctx, location)
+	if err != nil {
+		return nil, err
+	}
+
+	server, apiResponse, err := client.ServersApi.DatacentersServersFindById(ctx, datacenterID, serverID).Depth(3).Execute()
+	logApiRequestTime(apiResponse)
+
+	if err != nil {
+		if httpNotFound(apiResponse) {
+			d.SetId("")
+			return nil, diagutil.ToError(d, fmt.Errorf("unable to find vcpu server %q", serverID), nil)
+		}
+		return nil, diagutil.ToError(d, fmt.Errorf("error occurred while fetching a vcpu server ID %s %w", importID, err), nil)
+	}
+	var primaryNic ionoscloud.Nic
+	d.SetId(*server.Id)
+	primaryNicID := ""
+	// first we try to get primary nic from parts, then if that fails, we get it from entities.
+	if len(parts) > 2 {
+		primaryNicID = parts[2]
+		if err := d.Set("primary_nic", primaryNicID); err != nil {
+			return nil, diagutil.ToError(d, fmt.Errorf("error setting primary_nic id %w", err), nil)
+		}
+	} else {
+		if server.Entities != nil && server.Entities.Nics != nil && len(*server.Entities.Nics.Items) > 0 {
+			primaryNic = (*server.Entities.Nics.Items)[0]
+		}
+	}
+	if primaryNicID != "" {
+		if server.Entities != nil && server.Entities.Nics != nil && server.Entities.Nics.Items != nil {
+			for _, nic := range *server.Entities.Nics.Items {
+				if *nic.Id == primaryNicID {
+					primaryNic = nic
+					if primaryNic.Properties != nil && *nic.Properties.Ips != nil && len(*nic.Properties.Ips) > 0 {
+						tflog.Debug(ctx, "setting primary_ip", map[string]any{"primary_ip": (*primaryNic.Properties.Ips)[0]})
+						if err := d.Set("primary_ip", (*primaryNic.Properties.Ips)[0]); err != nil {
+							return nil, diagutil.ToError(d, fmt.Errorf("error while setting primary ip: %w", err), nil)
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+
+	if err := d.Set("datacenter_id", datacenterID); err != nil {
+		return nil, diagutil.ToError(d, err, nil)
+	}
+	if err := d.Set("location", location); err != nil {
+		return nil, err
+	}
+
+	if len(parts) > 3 {
+		var rules []string
+		rules = append(rules, parts[3])
+		if err = cloudapifirewall.SetIdsInSchema(d, rules); err != nil {
+			return nil, diagutil.ToError(d, err, nil)
+		}
+
+	}
+
+	if err := setResourceVCPUServerData(ctx, client, d, &server); err != nil {
+		return nil, diagutil.ToError(d, err, nil)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+// setResourceVCPUServerData is the VCPU-specific state-writer. It mirrors setResourceServerData but
+// is intentionally independent so the two resource schemas cannot drift into each other. Unlike the
+// enterprise writer it never sets ssh_key_path (VCPU volumes do not expose it).
+func setResourceVCPUServerData(ctx context.Context, client *ionoscloud.APIClient, d *schema.ResourceData, server *ionoscloud.Server) error {
+	if server.Id != nil {
+		d.SetId(*server.Id)
+	}
+	// takes care of an upgrade from a version that does not have firewallrule_ids(pre 6.4.2)
+	// to one that has it(>=6.4.2)
+	if err := cloudapifirewall.SetFwRuleIdsInSchemaInCaseOfProviderUpdate(d); err != nil {
+		return err
+	}
+
+	// takes care of an upgrade from a version that does not have inline_volume_ids(pre 6.4.0)
+	// to one that has it(>6.4.0). GetOk cannot be used here since it also returns false when
+	// inline_volume_ids is present in the state as an empty list; checking the raw state directly
+	// ensures this only fires when the attribute is completely absent.
+	if rawState := d.GetRawState(); !rawState.IsNull() && rawState.GetAttr("inline_volume_ids").IsNull() {
+		if bootVolumeItf, ok := d.GetOk("boot_volume"); ok {
+			bootVolume := bootVolumeItf.(string)
+			var inlineVolumeIDs []string
+			inlineVolumeIDs = append(inlineVolumeIDs, bootVolume)
+			if err := d.Set("inline_volume_ids", inlineVolumeIDs); err != nil {
+				return utils.GenerateSetError("vcpu server", "inline_volume_ids", err)
+			}
+		}
+	}
+
+	datacenterID := d.Get("datacenter_id").(string)
+	if server.Properties != nil {
+		if server.Properties.Name != nil {
+			if err := d.Set("name", *server.Properties.Name); err != nil {
+				return fmt.Errorf("error setting name %w", err)
+			}
+		}
+		if server.Properties.Hostname != nil {
+			if err := d.Set("hostname", *server.Properties.Hostname); err != nil {
+				return fmt.Errorf("error setting hostname %w", err)
+			}
+		}
+		if server.Properties.Cores != nil {
+			if err := d.Set("cores", *server.Properties.Cores); err != nil {
+				return fmt.Errorf("error setting cores %w", err)
+			}
+		}
+
+		if server.Properties.Ram != nil {
+			if err := d.Set("ram", *server.Properties.Ram); err != nil {
+				return fmt.Errorf("error setting ram %w", err)
+			}
+		}
+
+		if server.Properties.AvailabilityZone != nil {
+			if err := d.Set("availability_zone", *server.Properties.AvailabilityZone); err != nil {
+				return fmt.Errorf("error setting availability_zone %w", err)
+			}
+		}
+
+		if server.Properties.CpuFamily != nil {
+			if err := d.Set("cpu_family", *server.Properties.CpuFamily); err != nil {
+				return fmt.Errorf("error setting cpu_family %w", err)
+			}
+		}
+
+		if server.Properties.Type != nil {
+			if err := d.Set("type", *server.Properties.Type); err != nil {
+				return fmt.Errorf("error setting type %w", err)
+			}
+		}
+
+		if server.Properties.VmState != nil {
+			if err := d.Set("vm_state", *server.Properties.VmState); err != nil {
+				return fmt.Errorf("error setting vm_state %w", err)
+			}
+		}
+
+		// Shared with the enterprise writer so these crash-prone keys can't drift between the two.
+		if err := setServerConfidentialVisibility(d, server); err != nil {
+			return err
+		}
+
+		if server.Properties.BootCdrom != nil {
+			if err := d.Set("boot_cdrom", *server.Properties.BootCdrom.Id); err != nil {
+				return fmt.Errorf("error setting boot_cdrom %w", err)
+			}
+		} else {
+			d.Set("boot_cdrom", nil)
+		}
+
+		if server.Properties.BootVolume != nil {
+			if err := d.Set("boot_volume", *server.Properties.BootVolume.Id); err != nil {
+				return fmt.Errorf("error setting bootVolume %w", err)
+			}
+		} else {
+			d.Set("boot_volume", nil)
+		}
+		if server.Entities != nil {
+			if server.Entities.Volumes != nil && server.Entities.Volumes.Items != nil && len(*server.Entities.Volumes.Items) > 0 &&
+				(*server.Entities.Volumes.Items)[0].Properties != nil && (*server.Entities.Volumes.Items)[0].Properties.Image != nil {
+				if err := d.Set("boot_image", *(*server.Entities.Volumes.Items)[0].Properties.Image); err != nil {
+					return fmt.Errorf("error setting boot_image %w", err)
+				}
+			}
+			if server.Entities.Securitygroups != nil && server.Entities.Securitygroups.Items != nil {
+				if err := nsg.SetNSGInResourceData(d, server.Entities.Securitygroups.Items); err != nil {
+					return err
+				}
+			}
+		}
+		if server.Properties.NicMultiQueue != nil {
+			if err := d.Set("nic_multi_queue", *server.Properties.NicMultiQueue); err != nil {
+				return fmt.Errorf("error setting nic_multi_queue: %w", err)
+			}
+		}
+	}
+
+	if server.Entities == nil {
+		return fmt.Errorf("vcpu server entities cannot be empty for %s", d.Id())
+	}
+
+	inlineVolumeIDs := d.Get("inline_volume_ids")
+	if inlineVolumeIDs != nil {
+		inlineVolumeIDs := inlineVolumeIDs.([]any)
+		var volumes []any
+		for i, volumeID := range inlineVolumeIDs {
+			volume, apiResponse, err := client.ServersApi.DatacentersServersVolumesFindById(ctx, datacenterID, d.Id(), volumeID.(string)).Execute()
+			logApiRequestTime(apiResponse)
+			if err != nil {
+				if apiResponse.HttpNotFound() {
+					tflog.Info(ctx, "inline volume not found", map[string]any{"volume_id": volumeID.(string), "datacenter_id": datacenterID, "server_id": d.Id()})
+					continue
+				}
+				return fmt.Errorf("error retrieving inline volume %w", err)
+			}
+			volumePath := fmt.Sprintf("volume.%d.", i)
+			entry := SetVolumeProperties(volume)
+			userData := d.Get(volumePath + "user_data")
+			entry["user_data"] = userData
+			backupUnit := d.Get(volumePath + "backup_unit_id")
+			entry["backup_unit_id"] = backupUnit
+			volumes = append(volumes, entry)
+		}
+		if err := d.Set("volume", volumes); err != nil {
+			return fmt.Errorf("error setting inline volumes %w", err)
+		}
+	}
+
+	// take nic and firewall from schema if set is used in resource read, else take it from entities
+	var nicID string
+	firewallRuleIDs := d.Get("firewallrule_ids").([]any)
+
+	if nicIntf, primaryNicOk := d.GetOk("primary_nic"); primaryNicOk {
+		nicID = nicIntf.(string)
+		ns := cloudapinic.Service{Client: client, Meta: nil, D: d}
+		nic, apiResponse, err := ns.Get(ctx, datacenterID, d.Id(), nicID, 2)
+		if err != nil {
+			// fixes #467
+			if apiResponse.HttpNotFound() {
+				tflog.Debug(ctx, "primary nic not found, clearing primary_nic/primary_ip/nic", map[string]any{"nic_id": nicID})
+				if err := d.Set("primary_nic", ""); err != nil {
+					return err
+				}
+				if err := d.Set("primary_ip", ""); err != nil {
+					return err
+				}
+				if err := d.Set("nic", nil); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+		var nicEntry map[string]any
+		var fwRulesEntries []map[string]any
+
+		if nic != nil && nic.Properties != nil {
+			// fixes #467
+			if nic.Properties.Ips != nil && len(*nic.Properties.Ips) > 0 {
+				if err := d.Set("primary_ip", (*nic.Properties.Ips)[0]); err != nil {
+					return err
+				}
+			}
+			nicEntry = cloudapinic.SetNetworkProperties(*nic)
+			nicEntry["id"] = *nic.Id
+			fs := cloudapifirewall.Service{Client: client, D: d}
+
+			for _, id := range firewallRuleIDs {
+				firewallEntry, err := fs.AddToMapIfRuleExists(ctx, datacenterID, d.Id(), nicID, id.(string))
+				if err != nil {
+					return err
+				}
+				if firewallEntry != nil && len(firewallEntry) != 0 {
+					fwRulesEntries = append(fwRulesEntries, firewallEntry)
+				}
+			}
+		}
+		if nic != nil && nic.Entities != nil && nic.Entities.Securitygroups != nil && nic.Entities.Securitygroups.Items != nil {
+			nsgIDs := make([]string, 0)
+			for _, group := range *nic.Entities.Securitygroups.Items {
+				if group.Id != nil {
+					id := *group.Id
+					nsgIDs = append(nsgIDs, id)
+				}
+			}
+			utils.SetPropWithNilCheck(nicEntry, "security_groups_ids", nsgIDs)
+		}
+		nics := []map[string]any{}
+		if fwRulesEntries != nil {
+			nicEntry["firewall"] = fwRulesEntries
+		}
+		if len(nicEntry) > 0 {
+			nics = []map[string]any{nicEntry}
+		}
+		if err := d.Set("nic", nics); err != nil {
+			return fmt.Errorf("error settings nics %w", err)
+		}
+	}
+	if len(firewallRuleIDs) == 0 {
+		if err := d.Set("firewallrule_id", ""); err != nil {
+			return err
+		}
+	}
+	if err := d.Set("firewallrule_ids", firewallRuleIDs); err != nil {
+		return err
+	}
+
+	// Labels logic
+	ls := LabelsService{ctx: ctx, client: client}
+	labels, err := ls.datacentersServersLabelsGet(datacenterID, d.Id(), false)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("label", labels); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/ionoscloud/resource_vcpu_server_read.go
+++ b/ionoscloud/resource_vcpu_server_read.go
@@ -23,8 +23,8 @@ import (
 // with ionoscloud_server. This keeps the two schemas decoupled: a change to the enterprise
 // server's state-writer can no longer set a key that is missing from the VCPU schema (the 6.7.36
 // enabled_features regression). Leaf helpers (SetVolumeProperties, cloudapinic/cloudapifirewall/nsg
-// services, LabelsService, serverIsConfidential) remain shared - only the top-level per-type
-// state-writer is duplicated.
+// services, LabelsService, serverIsConfidential, setServerConfidentialVisibility) remain shared -
+// only the top-level per-type state-writer is duplicated.
 
 func resourceVCPUServerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	location := d.Get("location").(string)
@@ -86,34 +86,15 @@ func resourceVCPUServerImport(ctx context.Context, d *schema.ResourceData, meta 
 		}
 		return nil, diagutil.ToError(d, fmt.Errorf("error occurred while fetching a vcpu server ID %s %w", importID, err), nil)
 	}
-	var primaryNic ionoscloud.Nic
 	d.SetId(*server.Id)
-	primaryNicID := ""
-	// first we try to get primary nic from parts, then if that fails, we get it from entities.
+
 	if len(parts) > 2 {
-		primaryNicID = parts[2]
+		primaryNicID := parts[2]
 		if err := d.Set("primary_nic", primaryNicID); err != nil {
 			return nil, diagutil.ToError(d, fmt.Errorf("error setting primary_nic id %w", err), nil)
 		}
-	} else {
-		if server.Entities != nil && server.Entities.Nics != nil && len(*server.Entities.Nics.Items) > 0 {
-			primaryNic = (*server.Entities.Nics.Items)[0]
-		}
-	}
-	if primaryNicID != "" {
-		if server.Entities != nil && server.Entities.Nics != nil && server.Entities.Nics.Items != nil {
-			for _, nic := range *server.Entities.Nics.Items {
-				if *nic.Id == primaryNicID {
-					primaryNic = nic
-					if primaryNic.Properties != nil && *nic.Properties.Ips != nil && len(*nic.Properties.Ips) > 0 {
-						tflog.Debug(ctx, "setting primary_ip", map[string]any{"primary_ip": (*primaryNic.Properties.Ips)[0]})
-						if err := d.Set("primary_ip", (*primaryNic.Properties.Ips)[0]); err != nil {
-							return nil, diagutil.ToError(d, fmt.Errorf("error while setting primary ip: %w", err), nil)
-						}
-					}
-					break
-				}
-			}
+		if err := setVCPUServerPrimaryIPFromNic(ctx, d, &server, primaryNicID); err != nil {
+			return nil, diagutil.ToError(d, err, nil)
 		}
 	}
 
@@ -125,12 +106,10 @@ func resourceVCPUServerImport(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if len(parts) > 3 {
-		var rules []string
-		rules = append(rules, parts[3])
+		rules := []string{parts[3]}
 		if err = cloudapifirewall.SetIdsInSchema(d, rules); err != nil {
 			return nil, diagutil.ToError(d, err, nil)
 		}
-
 	}
 
 	if err := setResourceVCPUServerData(ctx, client, d, &server); err != nil {
@@ -138,6 +117,26 @@ func resourceVCPUServerImport(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	return []*schema.ResourceData{d}, nil
+}
+
+// setVCPUServerPrimaryIPFromNic sets primary_ip from the entity matching the imported primary nic id.
+func setVCPUServerPrimaryIPFromNic(ctx context.Context, d *schema.ResourceData, server *ionoscloud.Server, primaryNicID string) error {
+	if server.Entities == nil || server.Entities.Nics == nil || server.Entities.Nics.Items == nil {
+		return nil
+	}
+	for _, nic := range *server.Entities.Nics.Items {
+		if nic.Id == nil || *nic.Id != primaryNicID {
+			continue
+		}
+		if nic.Properties != nil && nic.Properties.Ips != nil && len(*nic.Properties.Ips) > 0 {
+			tflog.Debug(ctx, "setting primary_ip", map[string]any{"primary_ip": (*nic.Properties.Ips)[0]})
+			if err := d.Set("primary_ip", (*nic.Properties.Ips)[0]); err != nil {
+				return fmt.Errorf("error while setting primary ip: %w", err)
+			}
+		}
+		break
+	}
+	return nil
 }
 
 // setResourceVCPUServerData is the VCPU-specific state-writer. It mirrors setResourceServerData but
@@ -152,147 +151,162 @@ func setResourceVCPUServerData(ctx context.Context, client *ionoscloud.APIClient
 	if err := cloudapifirewall.SetFwRuleIdsInSchemaInCaseOfProviderUpdate(d); err != nil {
 		return err
 	}
-
-	// takes care of an upgrade from a version that does not have inline_volume_ids(pre 6.4.0)
-	// to one that has it(>6.4.0). GetOk cannot be used here since it also returns false when
-	// inline_volume_ids is present in the state as an empty list; checking the raw state directly
-	// ensures this only fires when the attribute is completely absent.
-	if rawState := d.GetRawState(); !rawState.IsNull() && rawState.GetAttr("inline_volume_ids").IsNull() {
-		if bootVolumeItf, ok := d.GetOk("boot_volume"); ok {
-			bootVolume := bootVolumeItf.(string)
-			var inlineVolumeIDs []string
-			inlineVolumeIDs = append(inlineVolumeIDs, bootVolume)
-			if err := d.Set("inline_volume_ids", inlineVolumeIDs); err != nil {
-				return utils.GenerateSetError("vcpu server", "inline_volume_ids", err)
-			}
-		}
+	if err := vcpuServerInlineVolumeIDsUpgrade(d); err != nil {
+		return err
 	}
 
 	datacenterID := d.Get("datacenter_id").(string)
-	if server.Properties != nil {
-		if server.Properties.Name != nil {
-			if err := d.Set("name", *server.Properties.Name); err != nil {
-				return fmt.Errorf("error setting name %w", err)
-			}
-		}
-		if server.Properties.Hostname != nil {
-			if err := d.Set("hostname", *server.Properties.Hostname); err != nil {
-				return fmt.Errorf("error setting hostname %w", err)
-			}
-		}
-		if server.Properties.Cores != nil {
-			if err := d.Set("cores", *server.Properties.Cores); err != nil {
-				return fmt.Errorf("error setting cores %w", err)
-			}
-		}
-
-		if server.Properties.Ram != nil {
-			if err := d.Set("ram", *server.Properties.Ram); err != nil {
-				return fmt.Errorf("error setting ram %w", err)
-			}
-		}
-
-		if server.Properties.AvailabilityZone != nil {
-			if err := d.Set("availability_zone", *server.Properties.AvailabilityZone); err != nil {
-				return fmt.Errorf("error setting availability_zone %w", err)
-			}
-		}
-
-		if server.Properties.CpuFamily != nil {
-			if err := d.Set("cpu_family", *server.Properties.CpuFamily); err != nil {
-				return fmt.Errorf("error setting cpu_family %w", err)
-			}
-		}
-
-		if server.Properties.Type != nil {
-			if err := d.Set("type", *server.Properties.Type); err != nil {
-				return fmt.Errorf("error setting type %w", err)
-			}
-		}
-
-		if server.Properties.VmState != nil {
-			if err := d.Set("vm_state", *server.Properties.VmState); err != nil {
-				return fmt.Errorf("error setting vm_state %w", err)
-			}
-		}
-
-		// Shared with the enterprise writer so these crash-prone keys can't drift between the two.
-		if err := setServerConfidentialVisibility(d, server); err != nil {
-			return err
-		}
-
-		if server.Properties.BootCdrom != nil {
-			if err := d.Set("boot_cdrom", *server.Properties.BootCdrom.Id); err != nil {
-				return fmt.Errorf("error setting boot_cdrom %w", err)
-			}
-		} else {
-			d.Set("boot_cdrom", nil)
-		}
-
-		if server.Properties.BootVolume != nil {
-			if err := d.Set("boot_volume", *server.Properties.BootVolume.Id); err != nil {
-				return fmt.Errorf("error setting bootVolume %w", err)
-			}
-		} else {
-			d.Set("boot_volume", nil)
-		}
-		if server.Entities != nil {
-			if server.Entities.Volumes != nil && server.Entities.Volumes.Items != nil && len(*server.Entities.Volumes.Items) > 0 &&
-				(*server.Entities.Volumes.Items)[0].Properties != nil && (*server.Entities.Volumes.Items)[0].Properties.Image != nil {
-				if err := d.Set("boot_image", *(*server.Entities.Volumes.Items)[0].Properties.Image); err != nil {
-					return fmt.Errorf("error setting boot_image %w", err)
-				}
-			}
-			if server.Entities.Securitygroups != nil && server.Entities.Securitygroups.Items != nil {
-				if err := nsg.SetNSGInResourceData(d, server.Entities.Securitygroups.Items); err != nil {
-					return err
-				}
-			}
-		}
-		if server.Properties.NicMultiQueue != nil {
-			if err := d.Set("nic_multi_queue", *server.Properties.NicMultiQueue); err != nil {
-				return fmt.Errorf("error setting nic_multi_queue: %w", err)
-			}
-		}
+	if err := setVCPUServerProperties(d, server); err != nil {
+		return err
 	}
 
 	if server.Entities == nil {
 		return fmt.Errorf("vcpu server entities cannot be empty for %s", d.Id())
 	}
 
-	inlineVolumeIDs := d.Get("inline_volume_ids")
-	if inlineVolumeIDs != nil {
-		inlineVolumeIDs := inlineVolumeIDs.([]any)
-		var volumes []any
-		for i, volumeID := range inlineVolumeIDs {
-			volume, apiResponse, err := client.ServersApi.DatacentersServersVolumesFindById(ctx, datacenterID, d.Id(), volumeID.(string)).Execute()
-			logApiRequestTime(apiResponse)
-			if err != nil {
-				if apiResponse.HttpNotFound() {
-					tflog.Info(ctx, "inline volume not found", map[string]any{"volume_id": volumeID.(string), "datacenter_id": datacenterID, "server_id": d.Id()})
-					continue
-				}
-				return fmt.Errorf("error retrieving inline volume %w", err)
+	if err := setVCPUServerInlineVolumes(ctx, client, d, datacenterID); err != nil {
+		return err
+	}
+	if err := setVCPUServerPrimaryNic(ctx, client, d, datacenterID); err != nil {
+		return err
+	}
+	return setVCPUServerLabels(ctx, client, d, datacenterID)
+}
+
+// vcpuServerInlineVolumeIDsUpgrade seeds inline_volume_ids from boot_volume when upgrading from a
+// provider version (pre 6.4.0) that did not have the attribute. GetOk cannot be used since it also
+// returns false when inline_volume_ids is present as an empty list; the raw state is checked
+// directly so this only fires when the attribute is completely absent.
+func vcpuServerInlineVolumeIDsUpgrade(d *schema.ResourceData) error {
+	rawState := d.GetRawState()
+	if rawState.IsNull() || !rawState.GetAttr("inline_volume_ids").IsNull() {
+		return nil
+	}
+	bootVolumeItf, ok := d.GetOk("boot_volume")
+	if !ok {
+		return nil
+	}
+	inlineVolumeIDs := []string{bootVolumeItf.(string)}
+	if err := d.Set("inline_volume_ids", inlineVolumeIDs); err != nil {
+		return utils.GenerateSetError("vcpu server", "inline_volume_ids", err)
+	}
+	return nil
+}
+
+// setVCPUServerProperties writes the scalar server properties (name, sizing, boot references,
+// enabled_features/confidential, security groups) into state.
+func setVCPUServerProperties(d *schema.ResourceData, server *ionoscloud.Server) error {
+	if server.Properties == nil {
+		return nil
+	}
+	strProps := map[string]*string{
+		"name":              server.Properties.Name,
+		"hostname":          server.Properties.Hostname,
+		"availability_zone": server.Properties.AvailabilityZone,
+		"cpu_family":        server.Properties.CpuFamily,
+		"type":              server.Properties.Type,
+		"vm_state":          server.Properties.VmState,
+	}
+	for key, val := range strProps {
+		if val != nil {
+			if err := d.Set(key, *val); err != nil {
+				return fmt.Errorf("error setting %s %w", key, err)
 			}
-			volumePath := fmt.Sprintf("volume.%d.", i)
-			entry := SetVolumeProperties(volume)
-			userData := d.Get(volumePath + "user_data")
-			entry["user_data"] = userData
-			backupUnit := d.Get(volumePath + "backup_unit_id")
-			entry["backup_unit_id"] = backupUnit
-			volumes = append(volumes, entry)
 		}
-		if err := d.Set("volume", volumes); err != nil {
-			return fmt.Errorf("error setting inline volumes %w", err)
+	}
+	if server.Properties.Cores != nil {
+		if err := d.Set("cores", *server.Properties.Cores); err != nil {
+			return fmt.Errorf("error setting cores %w", err)
+		}
+	}
+	if server.Properties.Ram != nil {
+		if err := d.Set("ram", *server.Properties.Ram); err != nil {
+			return fmt.Errorf("error setting ram %w", err)
 		}
 	}
 
-	// take nic and firewall from schema if set is used in resource read, else take it from entities
-	var nicID string
+	// Shared with the enterprise writer so these crash-prone keys can't drift between the two.
+	if err := setServerConfidentialVisibility(d, server); err != nil {
+		return err
+	}
+	if server.Properties.NicMultiQueue != nil {
+		if err := d.Set("nic_multi_queue", *server.Properties.NicMultiQueue); err != nil {
+			return fmt.Errorf("error setting nic_multi_queue: %w", err)
+		}
+	}
+	return setVCPUServerBootAndSecurity(d, server)
+}
+
+// setVCPUServerBootAndSecurity writes the boot references (cdrom/volume/image) and security groups.
+func setVCPUServerBootAndSecurity(d *schema.ResourceData, server *ionoscloud.Server) error {
+	if server.Properties != nil && server.Properties.BootCdrom != nil {
+		if err := d.Set("boot_cdrom", *server.Properties.BootCdrom.Id); err != nil {
+			return fmt.Errorf("error setting boot_cdrom %w", err)
+		}
+	} else {
+		d.Set("boot_cdrom", nil)
+	}
+	if server.Properties != nil && server.Properties.BootVolume != nil {
+		if err := d.Set("boot_volume", *server.Properties.BootVolume.Id); err != nil {
+			return fmt.Errorf("error setting bootVolume %w", err)
+		}
+	} else {
+		d.Set("boot_volume", nil)
+	}
+	if server.Entities == nil {
+		return nil
+	}
+	if server.Entities.Volumes != nil && server.Entities.Volumes.Items != nil && len(*server.Entities.Volumes.Items) > 0 &&
+		(*server.Entities.Volumes.Items)[0].Properties != nil && (*server.Entities.Volumes.Items)[0].Properties.Image != nil {
+		if err := d.Set("boot_image", *(*server.Entities.Volumes.Items)[0].Properties.Image); err != nil {
+			return fmt.Errorf("error setting boot_image %w", err)
+		}
+	}
+	if server.Entities.Securitygroups != nil && server.Entities.Securitygroups.Items != nil {
+		if err := nsg.SetNSGInResourceData(d, server.Entities.Securitygroups.Items); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// setVCPUServerInlineVolumes refreshes the volume block from the inline_volume_ids the resource owns.
+func setVCPUServerInlineVolumes(ctx context.Context, client *ionoscloud.APIClient, d *schema.ResourceData, datacenterID string) error {
+	inlineVolumeIDsItf := d.Get("inline_volume_ids")
+	if inlineVolumeIDsItf == nil {
+		return nil
+	}
+	inlineVolumeIDs := inlineVolumeIDsItf.([]any)
+	var volumes []any
+	for i, volumeID := range inlineVolumeIDs {
+		volume, apiResponse, err := client.ServersApi.DatacentersServersVolumesFindById(ctx, datacenterID, d.Id(), volumeID.(string)).Execute()
+		logApiRequestTime(apiResponse)
+		if err != nil {
+			if apiResponse.HttpNotFound() {
+				tflog.Info(ctx, "inline volume not found", map[string]any{"volume_id": volumeID.(string), "datacenter_id": datacenterID, "server_id": d.Id()})
+				continue
+			}
+			return fmt.Errorf("error retrieving inline volume %w", err)
+		}
+		volumePath := fmt.Sprintf("volume.%d.", i)
+		entry := SetVolumeProperties(volume)
+		entry["user_data"] = d.Get(volumePath + "user_data")
+		entry["backup_unit_id"] = d.Get(volumePath + "backup_unit_id")
+		volumes = append(volumes, entry)
+	}
+	if err := d.Set("volume", volumes); err != nil {
+		return fmt.Errorf("error setting inline volumes %w", err)
+	}
+	return nil
+}
+
+// setVCPUServerPrimaryNic refreshes the primary nic (and its inline firewall rules and security
+// groups) from the API, using the primary_nic id already present in state.
+func setVCPUServerPrimaryNic(ctx context.Context, client *ionoscloud.APIClient, d *schema.ResourceData, datacenterID string) error {
 	firewallRuleIDs := d.Get("firewallrule_ids").([]any)
 
 	if nicIntf, primaryNicOk := d.GetOk("primary_nic"); primaryNicOk {
-		nicID = nicIntf.(string)
+		nicID := nicIntf.(string)
 		ns := cloudapinic.Service{Client: client, Meta: nil, D: d}
 		nic, apiResponse, err := ns.Get(ctx, datacenterID, d.Id(), nicID, 2)
 		if err != nil {
@@ -312,44 +326,11 @@ func setResourceVCPUServerData(ctx context.Context, client *ionoscloud.APIClient
 				return err
 			}
 		}
-		var nicEntry map[string]any
-		var fwRulesEntries []map[string]any
-
-		if nic != nil && nic.Properties != nil {
-			// fixes #467
-			if nic.Properties.Ips != nil && len(*nic.Properties.Ips) > 0 {
-				if err := d.Set("primary_ip", (*nic.Properties.Ips)[0]); err != nil {
-					return err
-				}
-			}
-			nicEntry = cloudapinic.SetNetworkProperties(*nic)
-			nicEntry["id"] = *nic.Id
-			fs := cloudapifirewall.Service{Client: client, D: d}
-
-			for _, id := range firewallRuleIDs {
-				firewallEntry, err := fs.AddToMapIfRuleExists(ctx, datacenterID, d.Id(), nicID, id.(string))
-				if err != nil {
-					return err
-				}
-				if firewallEntry != nil && len(firewallEntry) != 0 {
-					fwRulesEntries = append(fwRulesEntries, firewallEntry)
-				}
-			}
-		}
-		if nic != nil && nic.Entities != nil && nic.Entities.Securitygroups != nil && nic.Entities.Securitygroups.Items != nil {
-			nsgIDs := make([]string, 0)
-			for _, group := range *nic.Entities.Securitygroups.Items {
-				if group.Id != nil {
-					id := *group.Id
-					nsgIDs = append(nsgIDs, id)
-				}
-			}
-			utils.SetPropWithNilCheck(nicEntry, "security_groups_ids", nsgIDs)
+		nicEntry, err := vcpuServerNicEntry(ctx, client, d, datacenterID, nicID, nic, firewallRuleIDs)
+		if err != nil {
+			return err
 		}
 		nics := []map[string]any{}
-		if fwRulesEntries != nil {
-			nicEntry["firewall"] = fwRulesEntries
-		}
 		if len(nicEntry) > 0 {
 			nics = []map[string]any{nicEntry}
 		}
@@ -365,8 +346,53 @@ func setResourceVCPUServerData(ctx context.Context, client *ionoscloud.APIClient
 	if err := d.Set("firewallrule_ids", firewallRuleIDs); err != nil {
 		return err
 	}
+	return nil
+}
 
-	// Labels logic
+// vcpuServerNicEntry builds the schema map for the primary nic, including its firewall rules and
+// attached security groups.
+func vcpuServerNicEntry(ctx context.Context, client *ionoscloud.APIClient, d *schema.ResourceData, datacenterID, nicID string, nic *ionoscloud.Nic, firewallRuleIDs []any) (map[string]any, error) {
+	var nicEntry map[string]any
+	var fwRulesEntries []map[string]any
+
+	if nic != nil && nic.Properties != nil {
+		// fixes #467
+		if nic.Properties.Ips != nil && len(*nic.Properties.Ips) > 0 {
+			if err := d.Set("primary_ip", (*nic.Properties.Ips)[0]); err != nil {
+				return nil, err
+			}
+		}
+		nicEntry = cloudapinic.SetNetworkProperties(*nic)
+		nicEntry["id"] = *nic.Id
+		fs := cloudapifirewall.Service{Client: client, D: d}
+
+		for _, id := range firewallRuleIDs {
+			firewallEntry, err := fs.AddToMapIfRuleExists(ctx, datacenterID, d.Id(), nicID, id.(string))
+			if err != nil {
+				return nil, err
+			}
+			if len(firewallEntry) != 0 {
+				fwRulesEntries = append(fwRulesEntries, firewallEntry)
+			}
+		}
+	}
+	if nic != nil && nic.Entities != nil && nic.Entities.Securitygroups != nil && nic.Entities.Securitygroups.Items != nil {
+		nsgIDs := make([]string, 0)
+		for _, group := range *nic.Entities.Securitygroups.Items {
+			if group.Id != nil {
+				nsgIDs = append(nsgIDs, *group.Id)
+			}
+		}
+		utils.SetPropWithNilCheck(nicEntry, "security_groups_ids", nsgIDs)
+	}
+	if fwRulesEntries != nil {
+		nicEntry["firewall"] = fwRulesEntries
+	}
+	return nicEntry, nil
+}
+
+// setVCPUServerLabels refreshes the label block from the API.
+func setVCPUServerLabels(ctx context.Context, client *ionoscloud.APIClient, d *schema.ResourceData, datacenterID string) error {
 	ls := LabelsService{ctx: ctx, client: client}
 	labels, err := ls.datacentersServersLabelsGet(datacenterID, d.Id(), false)
 	if err != nil {
@@ -375,6 +401,5 @@ func setResourceVCPUServerData(ctx context.Context, client *ionoscloud.APIClient
 	if err := d.Set("label", labels); err != nil {
 		return err
 	}
-
 	return nil
 }


### PR DESCRIPTION
fix #1033: `error setting enabled_features` on `vcpu_server` by adding the missing `enabled_features` (Computed) attribute to the resource schema, introduced in 6.7.36 by the Confidential Computing change.
