### PR TITLE
fix:Confidential server destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.7.37
 
 ### Fixes
+- `ionoscloud_server`: Deleting a Confidential Computing server no longer destroys volumes owned by separate `ionoscloud_volume` resources; they are detached first.
 - `ionoscloud_vcpu_server`: Fix `error setting enabled_features` on every plan/apply/refresh (introduced in 6.7.36 by the Confidential Computing change). Adds the missing `enabled_features` and `confidential` (both Computed) attributes to the resource schema, and gives `ionoscloud_vcpu_server` its own read/import/state-writer decoupled from `ionoscloud_server` so the two schemas can no longer break each other; create/update read-back now dispatches by server type.
 
 ## 6.7.36

--- a/ionoscloud/data_source_vcpu_server.go
+++ b/ionoscloud/data_source_vcpu_server.go
@@ -59,9 +59,9 @@ func dataSourceVCPUServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			// Always empty for VCPU (only ENTERPRISE can be confidential), but kept because the
-			// shared setServerData reader (used by both this and the server data source) sets it
-			// whenever the API returns features, and would error if the field were absent here.
+			// Always empty for VCPU (only ENTERPRISE can be confidential), but kept because this
+			// data source reads through dataSourceServerRead, whose writer sets the field whenever
+			// the API returns features and would error if it were absent here.
 			"enabled_features": {
 				Type:        schema.TypeList,
 				Computed:    true,

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -1206,6 +1206,43 @@ func deleteInlineVolumes(ctx context.Context, d *schema.ResourceData, meta any, 
 	return nil
 }
 
+// detachableVolumeIDs returns the volumes attached to the server that Terraform does not own,
+// i.e. everything that is not one of the server's inline volume blocks. Those belong to separate
+// ionoscloud_volume resources with their own lifecycle, so a server delete must not take them
+// down with it.
+func detachableVolumeIDs(server *ionoscloud.Server, inlineVolumeIDs []any) []string {
+	if server == nil || server.Entities == nil || server.Entities.Volumes == nil || server.Entities.Volumes.Items == nil {
+		return nil
+	}
+
+	inline := make(map[string]struct{}, len(inlineVolumeIDs))
+	for _, id := range inlineVolumeIDs {
+		if idStr, ok := id.(string); ok {
+			inline[idStr] = struct{}{}
+		}
+	}
+
+	var detachable []string
+	for _, volume := range *server.Entities.Volumes.Items {
+		if volume.Id == nil {
+			continue
+		}
+		if _, owned := inline[*volume.Id]; !owned {
+			detachable = append(detachable, *volume.Id)
+		}
+	}
+	return detachable
+}
+
+// deleteServerRequest builds the server DELETE request. A Confidential Computing server must be
+// deleted together with its volumes: its boot volume carries a confidential image, which the API
+// refuses to leave behind on its own (VDC-5-2060), and which cannot be detached while attached.
+// Non-confidential servers keep the previous behaviour, where inline volumes are deleted first in
+// their own requests.
+func deleteServerRequest(ctx context.Context, client *ionoscloud.APIClient, dcID, serverID string, confidential bool) ionoscloud.ApiDatacentersServersDeleteRequest {
+	return client.ServersApi.DatacentersServersDelete(ctx, dcID, serverID).DeleteVolumes(confidential)
+}
+
 // serverIsConfidential reports whether the server the API returned is a Confidential Computing
 // (SEV-SNP) VM, based on its enabled features. Derived from the API rather than the user-supplied
 // confidential flag so it stays correct for imported servers and config drift.
@@ -1237,10 +1274,13 @@ func resourceServerDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		return diagutil.ToDiags(d, fmt.Errorf("error occurred while fetching a server: %w", err), &diagutil.ErrorContext{RequestID: diagutil.ExtractRequestID(requestLocation), StatusCode: apiResponse.SafeStatusCode()})
 	}
 
-	// A confidential boot volume cannot be detached while attached, so it must be deleted after
-	// the server is gone rather than before it.
-	//   Normal server: volume, then server.
-	//   Confidential:  server, then volume.
+	// A confidential boot volume cannot exist on its own: the API refuses to delete a confidential
+	// server that would leave its volume behind (VDC-5-2060), and the volume cannot be deleted
+	// while attached either (VDC-5-2058). So the server delete has to take the volume with it via
+	// deleteVolumes.
+	//   Normal server: inline volumes, then server.
+	//   Confidential:  detach everything Terraform does not own, then server together with the
+	//                  volumes it does own, in one request.
 	// Confidentiality is derived from the server the API returned (not the user flag) so this stays
 	// correct for imported servers and config drift.
 	confidential := serverIsConfidential(&server)
@@ -1255,7 +1295,29 @@ func resourceServerDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 	}
 
-	apiResponse, err = client.ServersApi.DatacentersServersDelete(ctx, dcID, d.Id()).Execute()
+	// deleteVolumes takes down every volume still attached, so volumes owned by a separate
+	// ionoscloud_volume resource have to be detached first or they would be destroyed along with
+	// the server - silent data loss, plus a dangling ID in Terraform state.
+	if confidential {
+		for _, volumeID := range detachableVolumeIDs(&server, d.Get("inline_volume_ids").([]any)) {
+			apiResponse, err := client.ServersApi.DatacentersServersVolumesDelete(ctx, dcID, d.Id(), volumeID).Execute()
+			logApiRequestTime(apiResponse)
+			if err != nil {
+				if apiResponse.HttpNotFound() {
+					tflog.Info(ctx, "volume not found while detaching it from a confidential server", map[string]any{"volume_id": volumeID, "datacenter_id": dcID, "server_id": d.Id()})
+					continue
+				}
+				requestLocation, _ := apiResponse.SafeLocation()
+				return diagutil.ToDiags(d, fmt.Errorf("error occurred while detaching volume with ID: %s %w", volumeID, err), &diagutil.ErrorContext{RequestID: diagutil.ExtractRequestID(requestLocation), StatusCode: apiResponse.SafeStatusCode()})
+			}
+			if errState := bundleclient.WaitForStateChange(ctx, meta, d, apiResponse, schema.TimeoutDelete); errState != nil {
+				requestLocation, _ := apiResponse.SafeLocation()
+				return diagutil.ToDiags(d, fmt.Errorf("error getting state change for volume detach %w", errState), &diagutil.ErrorContext{Timeout: d.Timeout(schema.TimeoutDelete).String(), RequestID: diagutil.ExtractRequestID(requestLocation)})
+			}
+		}
+	}
+
+	apiResponse, err = deleteServerRequest(ctx, client, dcID, d.Id(), confidential).Execute()
 	logApiRequestTime(apiResponse)
 	if err != nil {
 		requestLocation, _ := apiResponse.SafeLocation()
@@ -1265,14 +1327,7 @@ func resourceServerDelete(ctx context.Context, d *schema.ResourceData, meta any)
 
 	if errState := bundleclient.WaitForStateChange(ctx, meta, d, apiResponse, schema.TimeoutDelete); errState != nil {
 		requestLocation, _ := apiResponse.SafeLocation()
-		return diagutil.ToDiags(d, fmt.Errorf("error getting state change for datacenter delete %w", errState), &diagutil.ErrorContext{Timeout: d.Timeout(schema.TimeoutDelete).String(), RequestID: diagutil.ExtractRequestID(requestLocation)})
-	}
-
-	if confidential {
-		diags := deleteInlineVolumes(ctx, d, meta, client)
-		if diags != nil {
-			return diags
-		}
+		return diagutil.ToDiags(d, fmt.Errorf("error getting state change for server delete %w", errState), &diagutil.ErrorContext{Timeout: d.Timeout(schema.TimeoutDelete).String(), RequestID: diagutil.ExtractRequestID(requestLocation)})
 	}
 
 	d.SetId("")

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -1210,16 +1210,25 @@ func deleteInlineVolumes(ctx context.Context, d *schema.ResourceData, meta any, 
 // i.e. everything that is not one of the server's inline volume blocks. Those belong to separate
 // ionoscloud_volume resources with their own lifecycle, so a server delete must not take them
 // down with it.
+//
+// The boot volume the API reports is never detachable, whatever the ownership list says. A
+// confidential boot volume cannot be detached at all (VDC-5-2058), so treating it as foreign
+// would make the server undeletable; it also has to stay attached for the server delete to take
+// it down. Ownership normally covers it - inline_volume_ids is populated on create, and on import
+// it is filled in from boot_volume - but this does not depend on that holding.
 func detachableVolumeIDs(server *ionoscloud.Server, inlineVolumeIDs []any) []string {
 	if server == nil || server.Entities == nil || server.Entities.Volumes == nil || server.Entities.Volumes.Items == nil {
 		return nil
 	}
 
-	inline := make(map[string]struct{}, len(inlineVolumeIDs))
+	inline := make(map[string]struct{}, len(inlineVolumeIDs)+1)
 	for _, id := range inlineVolumeIDs {
 		if idStr, ok := id.(string); ok {
 			inline[idStr] = struct{}{}
 		}
+	}
+	if server.Properties != nil && server.Properties.BootVolume != nil && server.Properties.BootVolume.Id != nil {
+		inline[*server.Properties.BootVolume.Id] = struct{}{}
 	}
 
 	var detachable []string

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -1271,15 +1271,6 @@ func detachableVolumeIDs(server *ionoscloud.Server, inlineVolumeIDs []any) []str
 	return detachable
 }
 
-// deleteServerRequest builds the server DELETE request. A Confidential Computing server must be
-// deleted together with its volumes: its boot volume carries a confidential image, which the API
-// refuses to leave behind on its own (VDC-5-2060), and which cannot be detached while attached.
-// Non-confidential servers keep the previous behaviour, where inline volumes are deleted first in
-// their own requests.
-func deleteServerRequest(ctx context.Context, client *ionoscloud.APIClient, dcID, serverID string, confidential bool) ionoscloud.ApiDatacentersServersDeleteRequest {
-	return client.ServersApi.DatacentersServersDelete(ctx, dcID, serverID).DeleteVolumes(confidential)
-}
-
 // serverIsConfidential reports whether the server the API returned is a Confidential Computing
 // (SEV-SNP) VM, based on its enabled features. Derived from the API rather than the user-supplied
 // confidential flag so it stays correct for imported servers and config drift.
@@ -1354,7 +1345,11 @@ func resourceServerDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 	}
 
-	apiResponse, err = deleteServerRequest(ctx, client, dcID, d.Id(), confidential).Execute()
+	// A confidential server has to be deleted together with its volumes: its boot volume carries a
+	// confidential image, which the API refuses to leave behind on its own (VDC-5-2060) and which
+	// cannot be deleted while attached (VDC-5-2058). Non-confidential servers keep the previous
+	// behaviour, where inline volumes are deleted first, in their own requests.
+	apiResponse, err = client.ServersApi.DatacentersServersDelete(ctx, dcID, d.Id()).DeleteVolumes(confidential).Execute()
 	logApiRequestTime(apiResponse)
 	if err != nil {
 		requestLocation, _ := apiResponse.SafeLocation()

--- a/ionoscloud/resource_server.go
+++ b/ionoscloud/resource_server.go
@@ -768,9 +768,9 @@ func setServerConfidentialVisibility(d *schema.ResourceData, server *ionoscloud.
 		if err := d.Set("enabled_features", *server.Properties.EnabledFeatures); err != nil {
 			return fmt.Errorf("error setting enabled_features %w", err)
 		}
-	} else {
+	} else if err := d.Set("enabled_features", nil); err != nil {
 		// Clear any stale value if the API no longer reports features.
-		d.Set("enabled_features", nil)
+		return fmt.Errorf("error clearing enabled_features %w", err)
 	}
 	// Derive `confidential` from the API so imported/refreshed servers reflect their real state
 	// and don't trigger a spurious ForceNew replace.
@@ -1206,6 +1206,34 @@ func deleteInlineVolumes(ctx context.Context, d *schema.ResourceData, meta any, 
 	return nil
 }
 
+// shouldSeedInlineVolumeIDs reports whether inline_volume_ids has to be seeded from the boot
+// volume. Two states need it:
+//
+//   - the attribute is absent entirely: state written before 6.4.0, which predates it.
+//   - the attribute is an empty list while an inline volume block is still declared. That
+//     combination is inconsistent, and leaving it alone is not harmless: the volume block is
+//     refreshed from the ownership list, so it blanks out, and every later plan then fails with
+//     "volume.0.disk_type attribute is immutable" - which also blocks destroy, leaving the server
+//     unmanageable. Seeding from the boot volume restores the invariant instead.
+//
+// An empty list is legitimate when no inline volume block is declared - every disk then belongs to
+// a separate ionoscloud_volume resource, and claiming the boot volume as inline would make a server
+// delete destroy a disk Terraform does not own. That is why emptiness alone does not seed.
+func shouldSeedInlineVolumeIDs(d *schema.ResourceData) bool {
+	rawState := d.GetRawState()
+	if rawState.IsNull() {
+		return false
+	}
+	if rawState.GetAttr("inline_volume_ids").IsNull() {
+		return true
+	}
+	if inline, ok := d.Get("inline_volume_ids").([]any); !ok || len(inline) > 0 {
+		return false
+	}
+	volumes, ok := d.Get("volume").([]any)
+	return ok && len(volumes) > 0
+}
+
 // detachableVolumeIDs returns the volumes attached to the server that Terraform does not own,
 // i.e. everything that is not one of the server's inline volume blocks. Those belong to separate
 // ionoscloud_volume resources with their own lifecycle, so a server delete must not take them
@@ -1598,10 +1626,9 @@ func setResourceServerData(ctx context.Context, client *ionoscloud.APIClient, d 
 	}
 
 	// takes care of an upgrade from a version that does not have inline_volume_ids(pre 6.4.0)
-	// to one that has it(>6.4.0). GetOk cannot be used here since it also returns false when
-	// inline_volume_ids is present in the state as an empty list; checking the raw state directly
-	// ensures this only fires when the attribute is completely absent.
-	if rawState := d.GetRawState(); !rawState.IsNull() && rawState.GetAttr("inline_volume_ids").IsNull() {
+	// to one that has it(>6.4.0), and of a state whose ownership list went empty while an inline
+	// volume block is still declared. See shouldSeedInlineVolumeIDs.
+	if shouldSeedInlineVolumeIDs(d) {
 		if bootVolumeItf, ok := d.GetOk("boot_volume"); ok {
 			bootVolume := bootVolumeItf.(string)
 			var inlineVolumeIDs []string

--- a/ionoscloud/resource_server_confidential_test.go
+++ b/ionoscloud/resource_server_confidential_test.go
@@ -1,10 +1,14 @@
 package ionoscloud
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 )
 
 // initializeCreateRequests is the pure request-builder shared by the create path. These unit
@@ -121,4 +125,116 @@ func int32PtrEqual(a, b *int32) bool {
 		return a == b
 	}
 	return *a == *b
+}
+
+// A Confidential Computing server must be deleted together with its volumes: the API refuses to
+// delete one that would leave its confidential boot volume behind (VDC-5-2060), and the volume
+// cannot be detached while attached. This drives the request through a stub API so the actual
+// deleteVolumes query parameter on the wire is asserted, not just the builder call.
+func TestDeleteServerRequestDeleteVolumes(t *testing.T) {
+	tests := []struct {
+		name         string
+		confidential bool
+		want         string
+	}{
+		{name: "confidential deletes its volumes with the server", confidential: true, want: "true"},
+		{name: "normal server keeps its volumes", confidential: false, want: "false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotDeleteVolumes string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.Method + " " + r.URL.Path
+				gotDeleteVolumes = r.URL.Query().Get("deleteVolumes")
+				w.WriteHeader(http.StatusAccepted)
+			}))
+			defer srv.Close()
+
+			cfg := ionoscloud.NewConfiguration("", "", "token", srv.URL)
+			client := ionoscloud.NewAPIClient(cfg)
+
+			_, err := deleteServerRequest(context.Background(), client, "dc-id", "server-id", tt.confidential).Execute()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if want := "DELETE /cloudapi/v6/datacenters/dc-id/servers/server-id"; gotPath != want {
+				t.Errorf("request = %q, want %q", gotPath, want)
+			}
+			if gotDeleteVolumes != tt.want {
+				t.Errorf("deleteVolumes = %q, want %q", gotDeleteVolumes, tt.want)
+			}
+		})
+	}
+}
+
+// deleteVolumes on the server delete takes down every volume still attached, so the confidential
+// delete path has to detach the ones Terraform does not own first. Only inline volume blocks are
+// owned; anything else belongs to a separate ionoscloud_volume resource and must survive.
+func TestDetachableVolumeIDs(t *testing.T) {
+	volumes := func(ids ...string) *ionoscloud.Server {
+		items := make([]ionoscloud.Volume, 0, len(ids))
+		for _, id := range ids {
+			items = append(items, ionoscloud.Volume{Id: new(id)})
+		}
+		return &ionoscloud.Server{Entities: &ionoscloud.ServerEntities{Volumes: &ionoscloud.AttachedVolumes{Items: &items}}}
+	}
+
+	tests := []struct {
+		name   string
+		server *ionoscloud.Server
+		inline []any
+		want   []string
+	}{
+		{
+			name:   "boot volume only is owned, nothing to detach",
+			server: volumes("boot"),
+			inline: []any{"boot"},
+			want:   nil,
+		},
+		{
+			name:   "separately managed data disk is detached",
+			server: volumes("boot", "data"),
+			inline: []any{"boot"},
+			want:   []string{"data"},
+		},
+		{
+			name:   "several foreign volumes are all detached",
+			server: volumes("boot", "data", "backup"),
+			inline: []any{"boot"},
+			want:   []string{"data", "backup"},
+		},
+		{
+			name:   "no inline volumes means nothing is owned",
+			server: volumes("data"),
+			inline: nil,
+			want:   []string{"data"},
+		},
+		{
+			name:   "nil server",
+			server: nil,
+			inline: []any{"boot"},
+			want:   nil,
+		},
+		{
+			name:   "server without volumes",
+			server: &ionoscloud.Server{},
+			inline: []any{"boot"},
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detachableVolumeIDs(tt.server, tt.inline)
+			if len(got) != len(tt.want) {
+				t.Fatalf("detachableVolumeIDs = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("detachableVolumeIDs = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
 }

--- a/ionoscloud/resource_server_confidential_test.go
+++ b/ionoscloud/resource_server_confidential_test.go
@@ -179,6 +179,10 @@ func TestDetachableVolumeIDs(t *testing.T) {
 		}
 		return &ionoscloud.Server{Entities: &ionoscloud.ServerEntities{Volumes: &ionoscloud.AttachedVolumes{Items: &items}}}
 	}
+	withBootVolume := func(server *ionoscloud.Server, bootID string) *ionoscloud.Server {
+		server.Properties = &ionoscloud.ServerProperties{BootVolume: &ionoscloud.ResourceReference{Id: new(bootID)}}
+		return server
+	}
 
 	tests := []struct {
 		name   string
@@ -209,6 +213,21 @@ func TestDetachableVolumeIDs(t *testing.T) {
 			server: volumes("data"),
 			inline: nil,
 			want:   []string{"data"},
+		},
+		{
+			// The API-reported boot volume is never detachable, even when the ownership list is
+			// empty: a confidential boot volume cannot be detached (VDC-5-2058), so classifying it
+			// as foreign would leave the server undeletable.
+			name:   "boot volume excluded even with an empty ownership list",
+			server: withBootVolume(volumes("boot", "data"), "boot"),
+			inline: nil,
+			want:   []string{"data"},
+		},
+		{
+			name:   "boot volume excluded when ownership list disagrees",
+			server: withBootVolume(volumes("boot", "data"), "boot"),
+			inline: []any{"data"},
+			want:   nil,
 		},
 		{
 			name:   "nil server",

--- a/ionoscloud/resource_server_confidential_test.go
+++ b/ionoscloud/resource_server_confidential_test.go
@@ -1,9 +1,6 @@
 package ionoscloud
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -125,47 +122,6 @@ func int32PtrEqual(a, b *int32) bool {
 		return a == b
 	}
 	return *a == *b
-}
-
-// A Confidential Computing server must be deleted together with its volumes: the API refuses to
-// delete one that would leave its confidential boot volume behind (VDC-5-2060), and the volume
-// cannot be detached while attached. This drives the request through a stub API so the actual
-// deleteVolumes query parameter on the wire is asserted, not just the builder call.
-func TestDeleteServerRequestDeleteVolumes(t *testing.T) {
-	tests := []struct {
-		name         string
-		confidential bool
-		want         string
-	}{
-		{name: "confidential deletes its volumes with the server", confidential: true, want: "true"},
-		{name: "normal server keeps its volumes", confidential: false, want: "false"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var gotPath, gotDeleteVolumes string
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				gotPath = r.Method + " " + r.URL.Path
-				gotDeleteVolumes = r.URL.Query().Get("deleteVolumes")
-				w.WriteHeader(http.StatusAccepted)
-			}))
-			defer srv.Close()
-
-			cfg := ionoscloud.NewConfiguration("", "", "token", srv.URL)
-			client := ionoscloud.NewAPIClient(cfg)
-
-			_, err := deleteServerRequest(context.Background(), client, "dc-id", "server-id", tt.confidential).Execute()
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if want := "DELETE /cloudapi/v6/datacenters/dc-id/servers/server-id"; gotPath != want {
-				t.Errorf("request = %q, want %q", gotPath, want)
-			}
-			if gotDeleteVolumes != tt.want {
-				t.Errorf("deleteVolumes = %q, want %q", gotDeleteVolumes, tt.want)
-			}
-		})
-	}
 }
 
 // deleteVolumes on the server delete takes down every volume still attached, so the confidential

--- a/ionoscloud/resource_server_inline_volumes_test.go
+++ b/ionoscloud/resource_server_inline_volumes_test.go
@@ -1,0 +1,94 @@
+package ionoscloud
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// inline_volume_ids drives both the volume-block refresh and the delete path, so a state carrying
+// an empty list while an inline volume block is still declared has to be repaired: left alone the
+// volume block blanks out and every later plan fails with "volume.0.disk_type attribute is
+// immutable", which blocks destroy too. An empty list with no volume block is legitimate - every
+// disk then belongs to a separate ionoscloud_volume resource - and must not be seeded, or a server
+// delete would destroy a disk Terraform does not own.
+func TestShouldSeedInlineVolumeIDs(t *testing.T) {
+	tests := []struct {
+		name  string
+		state map[string]any // nil means no prior state at all
+		want  bool
+	}{
+		{
+			name:  "no prior state does not seed",
+			state: nil,
+			want:  false,
+		},
+		{
+			name:  "attribute absent seeds (state predates 6.4.0)",
+			state: map[string]any{"volume": []any{map[string]any{"name": "system"}}},
+			want:  true,
+		},
+		{
+			name: "empty list with an inline volume block seeds",
+			state: map[string]any{
+				"inline_volume_ids": []any{},
+				"volume":            []any{map[string]any{"name": "system"}},
+			},
+			want: true,
+		},
+		{
+			name: "empty list with no volume block does not seed",
+			state: map[string]any{
+				"inline_volume_ids": []any{},
+			},
+			want: false,
+		},
+		{
+			name: "populated list does not seed",
+			state: map[string]any{
+				"inline_volume_ids": []any{"vol-1"},
+				"volume":            []any{map[string]any{"name": "system"}},
+			},
+			want: false,
+		},
+	}
+
+	res := resourceServer()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := seedingStateData(t, res, tt.state)
+			if got := shouldSeedInlineVolumeIDs(d); got != tt.want {
+				t.Errorf("shouldSeedInlineVolumeIDs = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// seedingStateData builds ResourceData backed by a raw state holding exactly the given attributes,
+// which is what lets GetRawState tell "attribute absent" apart from "present but empty" - the
+// distinction the seeding decision turns on.
+func seedingStateData(t *testing.T, res *schema.Resource, attrs map[string]any) *schema.ResourceData {
+	t.Helper()
+
+	if attrs == nil {
+		return res.Data(&terraform.InstanceState{ID: "srv-1"})
+	}
+
+	jsonMap := map[string]any{"id": "srv-1"}
+	maps.Copy(jsonMap, attrs)
+
+	raw, err := schema.JSONMapToStateValue(jsonMap, res.CoreConfigSchema())
+	if err != nil {
+		t.Fatalf("building raw state: %v", err)
+	}
+	state, err := res.ShimInstanceStateFromValue(raw)
+	if err != nil {
+		t.Fatalf("shimming instance state: %v", err)
+	}
+	state.ID = "srv-1"
+	state.RawState = raw
+
+	return res.Data(state)
+}

--- a/ionoscloud/resource_server_schema_compat_test.go
+++ b/ionoscloud/resource_server_schema_compat_test.go
@@ -1,0 +1,85 @@
+package ionoscloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ionoscloud_server and ionoscloud_vcpu_server share writers in both directions: an
+// ionoscloud_server with type = "VCPU" is read back by the vcpu writer (serverReadForType), and
+// both go through the same leaf helpers. A key one writer sets but the other's schema lacks fails
+// the apply with "Invalid address to set" - that is the shape of the 6.7.36 enabled_features
+// regression. These tests lock the compatibility down so the two schemas cannot drift apart again.
+func TestVCPUServerSchemaCompatibleWithServer(t *testing.T) {
+	srv := resourceServer().Schema
+	vcpu := resourceVCPUServer().Schema
+
+	for name, vcpuAttr := range vcpu {
+		srvAttr, ok := srv[name]
+		if !ok {
+			t.Errorf("ionoscloud_vcpu_server has %q but ionoscloud_server does not; the shared writers would fail to set it", name)
+			continue
+		}
+		if srvAttr.Type != vcpuAttr.Type {
+			t.Errorf("attribute %q: ionoscloud_server type %s, ionoscloud_vcpu_server type %s", name, srvAttr.Type, vcpuAttr.Type)
+		}
+	}
+
+	// The nested volume block is written by the shared SetVolumeProperties helper, so vcpu's keys
+	// must be a subset of the enterprise ones too.
+	srvVolume := nestedResource(t, srv, "volume")
+	vcpuVolume := nestedResource(t, vcpu, "volume")
+	for name := range vcpuVolume.Schema {
+		if _, ok := srvVolume.Schema[name]; !ok {
+			t.Errorf("volume.%s exists on ionoscloud_vcpu_server but not on ionoscloud_server", name)
+		}
+	}
+}
+
+// The 6.7.36 regression was a state-writer setting enabled_features on a resource whose schema did
+// not declare it. Every resource whose read goes through setServerConfidentialVisibility must
+// declare both keys it writes.
+func TestConfidentialVisibilityKeysDeclared(t *testing.T) {
+	resources := map[string]map[string]*schema.Schema{
+		"ionoscloud_server":      resourceServer().Schema,
+		"ionoscloud_vcpu_server": resourceVCPUServer().Schema,
+	}
+
+	for name, s := range resources {
+		for _, key := range []string{"enabled_features", "confidential"} {
+			if _, ok := s[key]; !ok {
+				t.Errorf("%s is missing %q, which its state-writer sets", name, key)
+			}
+		}
+	}
+}
+
+// Data sources reading through dataSourceServerRead share the same writer, and it sets
+// enabled_features whenever the API reports features.
+func TestServerDataSourcesDeclareEnabledFeatures(t *testing.T) {
+	resources := map[string]map[string]*schema.Schema{
+		"ionoscloud_server data source":      dataSourceServer().Schema,
+		"ionoscloud_vcpu_server data source": dataSourceVCPUServer().Schema,
+	}
+
+	for name, s := range resources {
+		if _, ok := s["enabled_features"]; !ok {
+			t.Errorf("%s is missing enabled_features, which its shared reader sets", name)
+		}
+	}
+}
+
+func nestedResource(t *testing.T, s map[string]*schema.Schema, key string) *schema.Resource {
+	t.Helper()
+
+	attr, ok := s[key]
+	if !ok {
+		t.Fatalf("attribute %q missing", key)
+	}
+	nested, ok := attr.Elem.(*schema.Resource)
+	if !ok {
+		t.Fatalf("attribute %q is not a nested block", key)
+	}
+	return nested
+}

--- a/ionoscloud/resource_vcpu_server_read.go
+++ b/ionoscloud/resource_vcpu_server_read.go
@@ -173,13 +173,11 @@ func setResourceVCPUServerData(ctx context.Context, client *ionoscloud.APIClient
 	return setVCPUServerLabels(ctx, client, d, datacenterID)
 }
 
-// vcpuServerInlineVolumeIDsUpgrade seeds inline_volume_ids from boot_volume when upgrading from a
-// provider version (pre 6.4.0) that did not have the attribute. GetOk cannot be used since it also
-// returns false when inline_volume_ids is present as an empty list; the raw state is checked
-// directly so this only fires when the attribute is completely absent.
+// vcpuServerInlineVolumeIDsUpgrade seeds inline_volume_ids from boot_volume when the attribute is
+// missing (state written before 6.4.0) or empty while an inline volume block is still declared.
+// The decision is shared with the enterprise writer - see shouldSeedInlineVolumeIDs.
 func vcpuServerInlineVolumeIDsUpgrade(d *schema.ResourceData) error {
-	rawState := d.GetRawState()
-	if rawState.IsNull() || !rawState.GetAttr("inline_volume_ids").IsNull() {
+	if !shouldSeedInlineVolumeIDs(d) {
 		return nil
 	}
 	bootVolumeItf, ok := d.GetOk("boot_volume")


### PR DESCRIPTION
Deleting a Confidential Computing server no longer destroys volumes owned by separate `ionoscloud_volume` resources; they are detached first.

Also fixes a situation where manually setting `inline_volume_ids = []` in state while the config still has a volume {} block would make the resource stuck