### PR TITLE
fix: nsg firewallrule protocol field marked with forceNew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.7.37
 
 ### Fixes
+- `ionoscloud_nsg_firewallrule`: Changing `protocol` now re-creates the rule instead of planning an in-place update that can never succeed. The API disallows `protocol` in update requests, and it is omitted from the PATCH body on update, so the request returned 200 without changing anything and the same diff was re-planned indefinitely. Marked `protocol` as `ForceNew`.
 - `ionoscloud_server`: Deleting a Confidential Computing server no longer destroys volumes owned by separate `ionoscloud_volume` resources; they are detached first.
 - `ionoscloud_vcpu_server`: Fix `error setting enabled_features` on every plan/apply/refresh (introduced in 6.7.36 by the Confidential Computing change). Adds the missing `enabled_features` and `confidential` (both Computed) attributes to the resource schema, and gives `ionoscloud_vcpu_server` its own read/import/state-writer decoupled from `ionoscloud_server` so the two schemas can no longer break each other; create/update read-back now dispatches by server type.
 

--- a/docs/resources/nsg_firewallrule.md
+++ b/docs/resources/nsg_firewallrule.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `nsg_id` - (Required)[string] The ID of a Network Security Group.
 * `datacenter_id` - (Required)[string] The ID of a Virtual Data Center.
 * `name` - (Optional)[string] The name of the Network Security Group.
-* `protocol` - (Required)[string] The protocol for the rule: TCP, UDP, ICMP, ANY. Property cannot be modified after creation (disallowed in update requests).
+* `protocol` - (Required)[string] The protocol for the rule: TCP, UDP, ICMP, ANY. Property cannot be modified after creation (disallowed in update requests); changing it forces a new resource to be created.
 * `name` - (Optional)[string] The name of the firewall rule.
 * `source_mac` - (Optional)[string] Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff. Value null allows all source MAC address. Valid format: aa:bb:cc:dd:ee:ff.
 * `source_ip` -  (Optional)(computed)[string] Only traffic originating from the respective IPv4 address is allowed. Value null allows all source IPs.

--- a/ionoscloud/resource_nsg_firewallrule.go
+++ b/ionoscloud/resource_nsg_firewallrule.go
@@ -30,6 +30,7 @@ func resourceNSGFirewallRule() *schema.Resource {
 			},
 			"protocol": {
 				Type:             schema.TypeString,
+				ForceNew:         true,
 				Required:         true,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(constant.FirewallProtocolEnum, false)),
 			},


### PR DESCRIPTION
## Fix: `protocol` on `ionoscloud_nsg_firewallrule` is immutable but was not `ForceNew`

### Problem

`protocol` cannot be modified after creation — the API disallows it in update requests. But the schema did not mark it `ForceNew`, so Terraform planned an in-place update that can never take effect.

`resourceNSGFirewallUpdate` calls it with `update=true`, so the PATCH goes out **without** `protocol`. The API has nothing to validate, returns `200`, and changes nothing. Terraform's state keeps the old value while the config wants the new one, so the same diff is re-planned indefinitely.

This is most visible through Crossplane (`provider-upjet-ionoscloud`), where it becomes an endless reconcile loop at ~7 requests/min while reporting `Synced=True` — a false assurance that a firewall rule's protocol changed when it did not:

### Fix

Mark `protocol` as `ForceNew`. This routes the change through delete + create instead of update — and the create path already sends `protocol` correctly (`getFirewallData(..., false)`). `resourceNSGFirewallUpdate` is simply never invoked for a protocol change, so `getFirewallData` needed no modification.

### Testing

Manual verification against the real API  with a datacenter + NSG + rule.

Baseline created with `protocol = "TCP"`:

```
Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

rule_id = "059be33d-dc66-4d99-854b-9592fd9d91b1"
```

`terraform plan -var rule_protocol=UDP`:

```
Terraform will perform the following actions:

  # ionoscloud_nsg_firewallrule.example must be replaced
-/+ resource "ionoscloud_nsg_firewallrule" "example" {
      ~ id               = "059be33d-dc66-4d99-854b-9592fd9d91b1" -> (known after apply)
        name             = "protocol-forcenew"
      ~ protocol         = "TCP" -> "UDP" # forces replacement
      + source_ip        = (known after apply)
      + target_ip        = (known after apply)
        # (5 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  ~ rule_id = "059be33d-dc66-4d99-854b-9592fd9d91b1" -> (known after apply)
```

`terraform apply -var rule_protocol=UDP`:

```
Apply complete! Resources: 1 added, 0 changed, 1 destroyed.

Outputs:

rule_id = "e100adeb-965f-4ebd-bd46-6cdc607496c1"
```