### PR TITLE
feat: add ionoscloud_ipblock list resource and resource identity

### DIFF
--- a/.claude/skills/add-list-resource/SKILL.md
+++ b/.claude/skills/add-list-resource/SKILL.md
@@ -20,16 +20,29 @@ deliverable is the whole arc, not just the Go file:
 5. a query step on the resource's tagged acceptance test (written, not run)
 6. `docs/list-resources/<x>.md` + an identity/query section on `docs/resources/<x>.md`
 7. `CHANGELOG.md`
-8. verification — **then stop and report**
+8. verification — **then stop, report what changed, and ask**
 
 A list resource without an identity, or with a test that passes when the mapper is wrong,
 is not done. Both were real findings on #1034.
 
-**Where the arc ends.** Deliver the files and the verification results, then stop.
-`git commit`, `git push`, `gh pr create` and replying to a review comment are writes the
-maintainer makes, or explicitly asks you to make — never a step you take because the
-checklist has one line left. `references/verify-and-pr.md` documents *how*, for when
-you are asked; it is not permission.
+**Where the arc ends.** The run ends with the work sitting **uncommitted in the working
+tree** — modified and new files, nothing staged, no branch created, no commit, no push, no
+`gh` write. Report what changed (a `git status --short` listing and the verification results),
+then **ask the user what else, if anything, to do**. Name the candidates, so the question is
+answerable rather than an open-ended nudge:
+
+- commit the change — and with what subject;
+- push the branch, open the PR;
+- run rung 5's expensive `go vet -tags=all ./...`, if you offered to leave that to CI;
+- run the tagged acceptance test, or a live `terraform query` check — both spend real IONOS
+  credentials and create real cloud resources, so neither is ever yours to start;
+- carry on to another resource.
+
+Then stop and wait for the answer. `git commit`, `git push`, `gh pr create` and replying to a
+review comment are writes the maintainer makes, or explicitly asks you to make — never a step
+you take because the checklist has one line left, and never one the closing question talks you
+into. `references/verify-and-pr.md` documents *how*, for when you are asked; it is not
+permission.
 
 ---
 
@@ -235,7 +248,7 @@ grep -rn 'func AvailableLocations' --include=*.go services/   # no hit for your 
 | 3 | The unit test, then the mutation check | `references/test-harness.md` |
 | 4 | Docs + CHANGELOG | `references/docs-and-changelog.md` |
 | 5 | Verification ladder | below |
-| 6 | **Stop and report.** Commit / PR / review replies only when the user asks | `references/verify-and-pr.md` |
+| 6 | **Stop, report, ask.** Files left uncommitted; commit / PR / review replies only when the user asks | `references/verify-and-pr.md` |
 
 Do them in that order. Step 1 is a hard prerequisite for step 2: a resource with no
 `Identity` cannot be listed at all — `identity.SetRawV6Schemas` gives up, and
@@ -379,7 +392,8 @@ go mod vendor && git status --porcelain vendor/
 `vendor/modules.txt` and adds vendored sources while leaving `go.mod`/`go.sum` untouched.
 That is exactly what happened on #1034 with `terraform-plugin-mux/tf5to6server/translate`.
 Run the vendor half even when the tidy half is clean, and **report `vendor/` as part of the
-change** so it goes in the same commit — do not run `git commit` yourself.
+change** so it lands in whatever commit the maintainer makes — do not run `git commit`
+yourself.
 
 **Rung 5 — expensive, exactly once, at the very end:**
 ```bash
@@ -442,7 +456,11 @@ the hazard in `references/docs-and-changelog.md` §2b.
 - [ ] Ladder rungs 0–5 clean, **2b included**
 - [ ] The pagination decision is written down somewhere a reviewer will find it, with this
       endpoint's real default limit
-- [ ] Reported, not committed: no `git commit`, `git push` or `gh` write unless the user asked
+- [ ] Left uncommitted: every file modified or created sits in the working tree, nothing
+      staged, nothing committed — no `git commit`, `git push` or `gh` write unless the user
+      asked for it in so many words
+- [ ] Reported what changed, then **asked what to do next** — the run ends on that question,
+      not on a silent stop and not on a next step you chose yourself
 
 ## Reference files
 

--- a/.claude/skills/add-list-resource/SKILL.md
+++ b/.claude/skills/add-list-resource/SKILL.md
@@ -78,8 +78,8 @@ framework-native?** Determine it before writing anything.
 grep -n '= "<ionoscloud_type>"' utils/constant/constants.go
 
 # 2. Is it in the SDKv2 ResourcesMap?  Match on the FACTORY, not the constant: ResourcesMap
-#    (provider.go:93) and DataSourcesMap (:153) frequently key off the SAME constant — a bare
-#    `grep -n 'constant.DatacenterResource:'` returns :94 AND :154 — and some types have only
+#    (provider.go:96) and DataSourcesMap (:156) frequently key off the SAME constant — a bare
+#    `grep -n 'constant.DatacenterResource:'` returns :97 AND :157 — and some types have only
 #    a *DataSource constant, so the constant's own suffix does not settle it either.
 #    (The [Rr]/[Dd] classes are for the three exported autoscaling factories.)
 grep -nE 'constant.<Const>: *[Rr]esource'   ionoscloud/provider.go   # ResourcesMap   -> listable
@@ -181,7 +181,9 @@ Two checks before you settle the list:
   value is a filter that always matches everything — noise in the allow-list and a
   meaningless doc example. `ionoscloud_target_group`'s `protocol` is the case in point:
   `StringInSlice([]string{"HTTP"}, true)`, and the API model says "Only the value 'HTTP' is
-  allowed". It was proposed, then dropped. Read the `ValidateDiagFunc` of every candidate.
+  allowed". It was proposed as a filter field on a `target_group` list resource and dropped for
+  exactly this reason; that list resource was never merged, so only the managed resource's own
+  schema is in the tree to look at. Read the `ValidateDiagFunc` of every candidate.
 - **`MatchesFilters` is an exact, case-sensitive compare** (`filter.go:57-60`) against the
   value the API returned, but an SDKv2 `StringInSlice(..., true)` validator lets the *resource*
   accept any case. So a filterable enum is case-sensitive in a `list` block and
@@ -202,6 +204,16 @@ selects an endpoint override (`bundleclient.go:393-417`), it does not partition 
   says "intended for resources that do not have a location attribute", but datacenter has one
   and uses it anyway — for a *collection read* that is correct. Fanning out here re-reads the
   same global collection N times and returns every item N times.
+
+  *Known limitation of the pattern, not something you have to solve.*
+  `NewCloudAPIClientWithFailover` resolves its endpoint from **global** cloud overrides only
+  (`FilterGlobalOverrides` keeps the entries whose `location` is empty), so a file config that
+  overrides the cloud product with per-location endpoints and no global one makes it hard-error
+  with `no global failover endpoints configured for "cloud"` — on a configuration where the
+  managed resource's own `NewCloudAPIClient(ctx, location)` is fine, because that one falls back
+  the other way (location override first, global second). The shipped `ionoscloud_datacenter`
+  list resource has the same hole. Follow the pattern anyway; just have the answer ready if
+  review raises it.
 - **Regional = an sdk-go-bundle DBaaS product that exposes `AvailableLocations()`** in
   `services/dbaas/<product>/client.go` — today exactly `pgsqlv2`, `mariadbv2`, `inmemorydbv2`.
   Only then fan out; copy `internal/framework/services/pgsqlv2/resource_pg_cluster_list.go`.
@@ -232,12 +244,17 @@ Do them in that order. Step 1 is a hard prerequisite for step 2: a resource with
 ### The files
 
 On the SDKv2 branch every line you write is in **package `ionoscloud`, next to the resource
-being listed**. It has to be: the list resource calls that resource's own unexported
-`resource<X>()`, `set<X>Data()` and `set<X>Identity()`, and no package under
+being listed**. It has to be: the list resource calls that resource's own package-level
+`resource<X>()`, state writer and `set<X>Identity()`, and no package under
 `internal/framework` can import package `ionoscloud` — `ionoscloud/provider_test.go` is an
 in-package test that imports `internal/framework/provider`, so the reverse import is a cycle
 in the test build. Framework code in `ionoscloud/` looks wrong and is not; a list resource can
 only be written with terraform-plugin-framework, whichever half of the mux its resource is on.
+
+The state writer's name is **not** uniform, so read the resource file instead of assuming:
+`resource_datacenter.go` has the unexported `setDatacenterData`, `resource_ipblock.go` the
+exported `IpBlockSetData`. `set<X>Data` everywhere in this skill is a placeholder for whatever
+that resource calls its writer, not a name to grep for.
 
 | SDKv2-backed | framework-native |
 |---|---|
@@ -307,6 +324,13 @@ than at runtime. On the framework-native branch it is not — `./internal/framew
 does not reach `internal/framework/provider`, so a slip in the wiring line you were just told
 to add is invisible until rung 5 unless you run the second command.
 
+**Rung 1 can fail for a reason only rung 4 fixes — the one permitted jump in the ladder.** The
+repo vendors its dependencies (`vendor/modules.txt` exists, so `-mod=vendor` is the default) and
+the compiler sees only packages already under `vendor/`. An import of a not-yet-vendored
+subpackage therefore breaks *this* rung, as a cannot-find-module / missing-package error naming
+that import path — it does not wait for rung 4. When that is the failure, go run rung 4, then
+come back and re-run rung 1.
+
 **Rung 2 — the untagged unit test. Main iteration loop. No credentials, no network:**
 ```bash
 # SDKv2 branch (the test is ionoscloud/resource_<resource>_list_test.go, package ionoscloud_test):
@@ -361,7 +385,7 @@ change** so it goes in the same commit — do not run `git commit` yourself.
 ```bash
 go vet -tags=all ./...
 ```
-136 of the repo's 158 `_test.go` files sit behind build tags and are invisible to a plain
+136 of the repo's 157 `_test.go` files sit behind build tags and are invisible to a plain
 `go vet ./...`. That includes the `Query: true` step you wrote — the resource's acceptance
 test file is tagged (`ionoscloud/resource_datacenter_test.go` is
 `//go:build compute || all || datacenter`), so this rung is the only thing that compiles it.
@@ -411,7 +435,10 @@ the hazard in `references/docs-and-changelog.md` §2b.
 - [ ] A `Query: true` step on the resource's tagged acceptance test (written; **not run**),
       plus a non-ForceNew update step whenever Update writes the identity itself
 - [ ] `docs/list-resources/<resource>.md` + the pointer section on `docs/resources/<resource>.md`
-- [ ] CHANGELOG entry appended under the existing open version heading (do not create a new one)
+- [ ] CHANGELOG entry under the correct `## X.Y.Z` heading — decided by the **git tag, not the
+      heading**: append under the topmost heading only while no `v<that version>` tag exists; once
+      that version is tagged, create a new `## X.Y.Z+1` heading above it. The check and the #1034
+      counter-example are in `references/docs-and-changelog.md` §4 — re-run it just before merge
 - [ ] Ladder rungs 0–5 clean, **2b included**
 - [ ] The pagination decision is written down somewhere a reviewer will find it, with this
       endpoint's real default limit

--- a/.claude/skills/add-list-resource/SKILL.md
+++ b/.claude/skills/add-list-resource/SKILL.md
@@ -1,0 +1,429 @@
+---
+name: add-list-resource
+description: "Add a `terraform query` list resource, plus the resource identity it requires, to a resource in terraform-provider-ionoscloud — code, unit test, docs, CHANGELOG, verification and PR review. Use when asked to make a resource queryable, add a list resource, add a resource identity, support `terraform query` for an `ionoscloud_*` type, or repeat what PR 1034 did for `ionoscloud_datacenter`."
+user-invocable: true
+argument-hint: <ionoscloud_type>, e.g. ionoscloud_ipblock
+---
+
+# Add a list resource + resource identity
+
+Target resource: **$ARGUMENTS** (if empty, ask which `ionoscloud_*` type before doing anything else).
+
+This skill reproduces the work done for `ionoscloud_datacenter` in PR #1034 — the reference
+example, `ionoscloud/resource_datacenter_list.go` — for another resource. The
+deliverable is the whole arc, not just the Go file:
+
+1. resource identity on the managed resource
+2. the list resource
+3. registration — one name in a `ListResources()` slice
+4. a unit test that actually asserts something
+5. a query step on the resource's tagged acceptance test (written, not run)
+6. `docs/list-resources/<x>.md` + an identity/query section on `docs/resources/<x>.md`
+7. `CHANGELOG.md`
+8. verification — **then stop and report**
+
+A list resource without an identity, or with a test that passes when the mapper is wrong,
+is not done. Both were real findings on #1034.
+
+**Where the arc ends.** Deliver the files and the verification results, then stop.
+`git commit`, `git push`, `gh pr create` and replying to a review comment are writes the
+maintainer makes, or explicitly asks you to make — never a step you take because the
+checklist has one line left. `references/verify-and-pr.md` documents *how*, for when
+you are asked; it is not permission.
+
+---
+
+## Machine limits — read before running anything
+
+The maintainer works on a 12-core laptop while you work, with an IDE, gopls and often a kind
+cluster running. A previous agent fan-out drove it to load average 55 and made it unusable.
+
+- **Do not fan out to subagents for this task.** It is sequential work, and the expensive part
+  is compilation — N agents × ~10 Go compile threads swamps 12 cores. One agent, one build at
+  a time.
+- **Never** `make testacc`, or any `go test` with a build tag. `GNUmakefile:22-23` sets
+  `TF_ACC=1` and `-tags`; the tagged suites run against real IONOS credentials and create live
+  cloud resources (CI budgets them at 240m–6h — `.github/workflows/compute-test-run.yml:32`,
+  `e2e.yaml:65`).
+- **Avoid** `go build ./...`, `go test ./...` and `make test` — not because they reach the cloud
+  (`make test` sets no `TF_ACC` and no tag, `GNUmakefile:17-20`, so no acceptance suite is even
+  compiled) but because `TEST?=$$(go list ./... |grep -v 'vendor')` expands to all 60 non-vendor
+  packages and `-parallel=4` saturates the maintainer's cores. Getting the reason right matters:
+  an **untagged, package-scoped `go test` is always safe** and the ladder below depends on it.
+- Scope every build and test to a package path. Follow the verification ladder at the bottom.
+- Never run commands in parallel or in the background.
+- If the user reports slowness, check `uptime` and stop what you are running.
+
+---
+
+## Placeholders used throughout
+
+| Placeholder | Meaning | Datacenter example |
+|---|---|---|
+| `<ionoscloud_type>` | terraform type name | `ionoscloud_datacenter` |
+| `<Resource>` | Go-exported name | `Datacenter` |
+| `<resource>` | lower-case name / doc filename stem | `datacenter` |
+| `<service>` | framework service package — **framework-native branch only**; an SDKv2-backed list resource lives in package `ionoscloud`, beside the resource it lists | `pgsqlv2` |
+
+---
+
+## Step 0 — Discovery
+
+Everything downstream depends on one branch: **is the managed resource SDKv2 or
+framework-native?** Determine it before writing anything.
+
+```bash
+# 1. Resolve the type-name constant (ResourcesMap is keyed by constants, never by
+#    string literals — a naive grep of provider.go finds nothing).
+grep -n '= "<ionoscloud_type>"' utils/constant/constants.go
+
+# 2. Is it in the SDKv2 ResourcesMap?  Match on the FACTORY, not the constant: ResourcesMap
+#    (provider.go:93) and DataSourcesMap (:153) frequently key off the SAME constant — a bare
+#    `grep -n 'constant.DatacenterResource:'` returns :94 AND :154 — and some types have only
+#    a *DataSource constant, so the constant's own suffix does not settle it either.
+#    (The [Rr]/[Dd] classes are for the three exported autoscaling factories.)
+grep -nE 'constant.<Const>: *[Rr]esource'   ionoscloud/provider.go   # ResourcesMap   -> listable
+grep -nE 'constant.<Const>: *[Dd]ataSource' ionoscloud/provider.go   # DataSourcesMap -> not, on its own
+
+# 3. Is it framework-native?  Most hits here are data sources (and one ephemeral resource),
+#    so check the FILE the hit is in: only a `resource_*.go` hit means framework-native.
+grep -rn 'ProviderTypeName + "_<suffix>"' internal/framework/services/ --include=*.go | grep -v _test.go
+
+# 4. Does it already declare an identity?
+grep -rn 'Identity: &schema.ResourceIdentity' ionoscloud/resource_<resource>.go
+grep -rn 'IdentitySchema' internal/framework/services/<service>/
+
+# 5. Does a list resource already exist?  The SDKv2-backed ones live in ionoscloud/,
+#    the framework-native ones under internal/framework/services/.
+ls docs/list-resources/
+find ionoscloud internal/framework/services -name '*_list.go'
+cat ionoscloud/list_resources.go
+```
+
+- Hit in (2), not (3) → **SDKv2-backed**. Read `references/sdkv2-branch.md`. This is the
+  harder path and the one this skill is mostly about.
+- Hit in (3) from a `resource_*.go`, not (2) → **framework-native**. Read
+  `references/framework-native-branch.md`. Much less work: the list resource is more methods
+  on the *same* struct as the managed resource, in the same package, so there is no
+  `RawV6Schemas` and no SDKv2 bridge at all.
+- Only a `[Dd]ataSource` hit in (2), or only `data_source_*.go` / `ephemeral_*.go` hits in
+  (3) → there is **no managed resource** of that type. It cannot be listed; say so and stop.
+- Hits in both (2) and (3) → no type in the tree does this today, so treat it as a genuine
+  ambiguity rather than picking: report both hits and ask.
+- Hits in neither → the type does not exist. Stop and say so.
+
+Then find the API call that lists them — **if there isn't one, stop**:
+
+```bash
+# every parentless collection GET in the vendored SDKs.
+# note [A-Za-z0-9]+ — without the digits this silently misses K8sGet.
+grep -rhoE "func \(a \*[A-Za-z0-9]+\) [A-Za-z0-9]+(Get|List)\(ctx _?context\.Context\) Api[A-Za-z0-9]+Request" \
+  vendor/github.com/ionos-cloud/ | sed 's/^func (a \*//' | sort -u
+```
+
+A resource whose collection GET needs a parent ID (`DatacentersLansGet(ctx, datacenterId)`,
+`K8sNodepoolsGet(ctx, clusterId)`, …) is a **bad candidate**: listing it means enumerating
+every parent first, an unbounded N+1 with no precedent in this repo. So are
+association-only resources with no API object of their own (`ionoscloud_ipfailover`,
+`ionoscloud_server_boot_device_selection`, `ionoscloud_datacenter_nsg_selection`). Say so
+and stop rather than inventing a fan-out.
+
+---
+
+## Step 0.5 — Four decisions to settle with the user, before writing code
+
+The maintainer wants these agreed up front, not discovered in review. Present them together,
+briefly, with your recommendation — then wait.
+
+**1. Pagination.** Decide explicitly; do not default silently. The provider-wide state:
+there is exactly **one** offset/limit loop in the whole provider
+(`services/dbaas/pgsqlv2/cluster.go` — it stops on a short page and deliberately does *not*
+use `Links.HasNext()`, which stays populated past the last page and spins forever). The S3
+paths use continuation tokens. Everything else is unpaginated. On #1034 the user **declined**
+pagination for the datacenter list resource and documented the limitation instead, because
+fixing only the list resource would leave it inconsistent with the identical unpaginated call
+in `ionoscloud/data_source_datacenter.go`. That precedent is defensible and reusable — but if
+you follow it, **the docs must say so** (wording in `references/docs-and-changelog.md`), and
+Copilot will raise pagination on the PR, so have the answer ready.
+
+Before deciding, look up **this endpoint's** default limit and what the sibling data source
+already does. The default is *not* uniform — it is 1000 for most Cloud API collections but
+**100** for `/ipblocks`, `/targetgroups` and user management, and nothing in the provider sets
+`DefaultQueryParams`:
+
+```bash
+grep -n 'parameterToString(1\?0*, "")' vendor/github.com/ionos-cloud/sdk-go/v6/api_<x>.go
+grep -n 'Limit(' ionoscloud/data_source_<resource>.go
+```
+
+If the data source sets an explicit `Limit(...)` — `data_source_ipblock.go:146` passes
+`constant.IPBlockLimit` (1000) — then a bare `.Depth(1)` fetch caps the *list resource* below
+its own data source, which is the exact inconsistency the decline argument rests on. Match the
+data source's `Limit()`, and name that endpoint's real number in the docs note.
+
+**2. Identity attributes.** Read them off the resource's existing import ID — that tuple is
+already exactly what an importer needs. `splitImportID` (in `ionoscloud/utils.go`) parses
+`"<location>:<id-1><del><id-2>…"`, so the identity is `location` (optional, when the resource
+has one) plus one string attribute per parsed part, the resource's own being `id`. A child
+resource carries its parent IDs, named exactly as its own schema names them
+(`datacenter_id`, `server_id`), all `RequiredForImport`. Never put a mutable attribute such
+as `name` in an identity — Terraform fails refresh if any identity attribute changes.
+
+**3. Filter fields.** The allow-list passed to `identity.FilterAttribute(...)` must be
+exactly the key set of the map handed to `identity.MatchesFilters(...)` in the mapper.
+Nothing enforces this; a mismatch means a filter silently matches nothing. Default to
+`name` plus the regional key under whatever name *the resource's own schema* uses
+(`location` vs `region`).
+
+Two checks before you settle the list:
+
+- **Drop any field that cannot narrow.** A field whose schema validator admits exactly one
+  value is a filter that always matches everything — noise in the allow-list and a
+  meaningless doc example. `ionoscloud_target_group`'s `protocol` is the case in point:
+  `StringInSlice([]string{"HTTP"}, true)`, and the API model says "Only the value 'HTTP' is
+  allowed". It was proposed, then dropped. Read the `ValidateDiagFunc` of every candidate.
+- **`MatchesFilters` is an exact, case-sensitive compare** (`filter.go:57-60`) against the
+  value the API returned, but an SDKv2 `StringInSlice(..., true)` validator lets the *resource*
+  accept any case. So a filterable enum is case-sensitive in a `list` block and
+  case-insensitive in the resource. A bad `field_name` is a loud plan-time error; a
+  wrongly-cased `field_value` is silent. Say so in the docs whenever a filterable field is a
+  case-insensitively-validated enum.
+
+**4. Regional or global.** Decide from the **shape of the collection endpoint**, not from the
+managed resource's client constructor. The constructor is a red herring: `resource_datacenter.go`
+calls `NewCloudAPIClient(ctx, location)` on every CRUD path, yet the datacenter *list* resource
+uses `NewCloudAPIClientWithFailover(ctx)` and makes one call — because `location` there only
+selects an endpoint override (`bundleclient.go:393-417`), it does not partition the collection.
+
+- **Cloud API (`sdk-go/v6`) — always global.** `/datacenters`, `/ipblocks` and the rest are
+  single un-partitioned collections that return objects from every location in one response.
+  Use `NewCloudAPIClientWithFailover(ctx)` and one call; copy the client construction inside
+  `datacenterListResource.List` (`ionoscloud/resource_datacenter_list.go`). Its doc comment
+  says "intended for resources that do not have a location attribute", but datacenter has one
+  and uses it anyway — for a *collection read* that is correct. Fanning out here re-reads the
+  same global collection N times and returns every item N times.
+- **Regional = an sdk-go-bundle DBaaS product that exposes `AvailableLocations()`** in
+  `services/dbaas/<product>/client.go` — today exactly `pgsqlv2`, `mariadbv2`, `inmemorydbv2`.
+  Only then fan out; copy `internal/framework/services/pgsqlv2/resource_pg_cluster_list.go`.
+  There is **no `AvailableLocations()` for the Cloud API**, so the fan-out snippet in
+  `sdkv2-branch.md` §2c cannot even be filled in for one.
+
+```bash
+grep -rn 'func AvailableLocations' --include=*.go services/   # no hit for your product -> global
+```
+
+---
+
+## The plan
+
+| Step | What | Reference |
+|---|---|---|
+| 1 | Resource identity on the managed resource | `references/sdkv2-branch.md` §1 (or `framework-native-branch.md` §1) |
+| 2 | The list resource + its one registration line | `references/sdkv2-branch.md` §2–3 (or `framework-native-branch.md` §2–3) |
+| 3 | The unit test, then the mutation check | `references/test-harness.md` |
+| 4 | Docs + CHANGELOG | `references/docs-and-changelog.md` |
+| 5 | Verification ladder | below |
+| 6 | **Stop and report.** Commit / PR / review replies only when the user asks | `references/verify-and-pr.md` |
+
+Do them in that order. Step 1 is a hard prerequisite for step 2: a resource with no
+`Identity` cannot be listed at all — `identity.SetRawV6Schemas` gives up, and
+`RawV6Schemas` has no diagnostics channel, so the only trace is a `tflog.Error` line.
+
+### The files
+
+On the SDKv2 branch every line you write is in **package `ionoscloud`, next to the resource
+being listed**. It has to be: the list resource calls that resource's own unexported
+`resource<X>()`, `set<X>Data()` and `set<X>Identity()`, and no package under
+`internal/framework` can import package `ionoscloud` — `ionoscloud/provider_test.go` is an
+in-package test that imports `internal/framework/provider`, so the reverse import is a cycle
+in the test build. Framework code in `ionoscloud/` looks wrong and is not; a list resource can
+only be written with terraform-plugin-framework, whichever half of the mux its resource is on.
+
+| SDKv2-backed | framework-native |
+|---|---|
+| `ionoscloud/resource_<resource>.go` — the `Identity` block, `set<X>Identity`, its call sites, the dual-mode importer | `internal/framework/services/<service>/resource_<resource>.go` — `IdentitySchema` + `Identity.Set` on every state-producing path |
+| **new** `ionoscloud/resource_<resource>_list.go` | **new** `internal/framework/services/<service>/resource_<resource>_list.go` |
+| **new** `ionoscloud/resource_<resource>_list_test.go` (package `ionoscloud_test`) — the shared helpers (`muxedProviderServer`, `listResults`, `decode`, `goValue`, …) are already in `ionoscloud/resource_datacenter_list_test.go`; reuse them, do not re-copy | **new** `internal/framework/services/<service>/resource_<resource>_list_test.go` |
+| one name in `ionoscloud/list_resources.go`'s `ListResources()` | one name in the service package's `ListResources()`, and — only for a **new** service package — one `<service>.ListResources(),` line in `internal/framework/provider/provider.go` |
+| `ionoscloud/resource_<resource>_test.go` — the `Query: true` acceptance step | same |
+| docs + CHANGELOG | same |
+
+`internal/framework/provider/provider.go` is **not** touched on the SDKv2 branch.
+`provider.New(sdkv2ListResources ...func() list.ListResource)` takes the whole slice, and every
+call site (`main.go`, `xpprovider/provider.go`, `internal/acctest/acctest.go`,
+`internal/framework/provider/provider_test.go`, `ionoscloud/provider_test.go`, and the test
+harness itself) passes `ionoscloud.ListResources()...` and never names an individual resource.
+
+### Shared plumbing that already exists — do not rewrite it
+
+`internal/framework/identity/`:
+
+| Symbol | File | What it does |
+|---|---|---|
+| `FiltersKey` | `filter.go` | `"filters"`, the config attribute name |
+| `Filter` | `filter.go` | `{FieldName, FieldValue types.String}` |
+| `FilterAttribute(allowed...)` | `filter.go` | the `filters` list attribute; attaches `stringvalidator.OneOf` |
+| `FilterValue(filters, name)` | `filter.go` | pull one filter value out, to push down to the API |
+| `MatchesFilters(fields, filters)` | `filter.go` | client-side AND match, exact string compare |
+| `StreamList[T](ctx, stream, req, fetch, mapper)` | `list.go` | the whole List body |
+| `MappedItem` | `identity.go` | `{DisplayName string; Identity, Resource any}` |
+| `Model` | `identity.go` | reusable identity model for a lone `id` (framework-native branch — the SDKv2 branch takes its identity out of the `ResourceData`) |
+| `SetRawV6Schemas(...)` | `sdkv2.go` | SDKv2 → protocol-v6 schema bridge (SDKv2 branch only) |
+| `MappedItemFromResourceData(name, rd, incl)` | `sdkv2.go` | turns a `ResourceData` the resource's own writers have filled into a `MappedItem` — identity and resource as `tftypes.Value`, `timeouts` nulled back out (SDKv2 branch only) |
+
+Nothing new belongs in that package for an ordinary resource.
+
+---
+
+## Verification ladder
+
+Cheapest first. Substitute `<service>` and `<Resource>`. Strictly sequential.
+
+**Rung 0 — after every edit, free:**
+```bash
+gofmt -l -d ./ionoscloud ./internal ./utils
+```
+**Never let `gofmt` run with an empty argument list — it silently reads stdin and exits
+clean.** That is what `gofmt -l -d $(git diff --name-only master...HEAD ...)` does here:
+`master...HEAD` is a *commit* range, your work is uncommitted (you are not committing it,
+see "Where the arc ends"), so the substitution expands to nothing and the rung reports green
+having inspected none of your new files. Formatting then fails in CI instead
+(`.github/workflows/build.yml`, `Run gofmt check`, `-l -d` over `.`).
+
+**Rung 1 — type-check the packages you touched. Main iteration loop:**
+```bash
+# SDKv2 branch — the identity, the list resource and its registration are all in here:
+go build ./ionoscloud/
+
+# framework-native branch:
+go build ./internal/framework/services/<service>/
+# additionally, ONLY if the list resource went in a NEW service package (i.e. you added a
+# `<service>.ListResources(),` line to internal/framework/provider/provider.go):
+go build ./internal/framework/provider/
+```
+On the SDKv2 branch this really is one command: `ionoscloud/list_resources.go` is compiled by
+the same build as the list resource, so a typo in the registration line fails here rather
+than at runtime. On the framework-native branch it is not — `./internal/framework/services/<service>/`
+does not reach `internal/framework/provider`, so a slip in the wiring line you were just told
+to add is invisible until rung 5 unless you run the second command.
+
+**Rung 2 — the untagged unit test. Main iteration loop. No credentials, no network:**
+```bash
+# SDKv2 branch (the test is ionoscloud/resource_<resource>_list_test.go, package ionoscloud_test):
+go test ./ionoscloud/ -run 'Test<Resource>ListResource' -count=1
+
+# framework-native branch:
+go test ./internal/framework/services/<service>/ -run 'Test<Resource>ListResource' -count=1
+```
+
+**Rung 2b — validate the identity schema (SDKv2 branch). No credentials, no network:**
+```bash
+go test ./ionoscloud/ -run 'TestProvider$' -count=1
+```
+This is the **only** thing that executes `Provider().InternalValidate()` →
+`InternalIdentityValidate()` on your new `Identity`
+(`vendor/.../helper/schema/provider.go:220-225`), which is what turns a malformed identity
+into a unit-test failure instead of a runtime one. The skill elsewhere calls that check
+"free" — it is free only because you run this rung. Nothing in CI runs it, rung 1 compiles no
+test file, and rung 2's `GetResourceIdentitySchemas` assertion passes for a malformed identity.
+On the SDKv2 branch rung 2 has already built this package's test binary, so this is one more
+`-run` over it; on the framework-native branch rung 2 was scoped to another package and this
+is the one small compile you pay for.
+
+**Rung 3 — lint only your own lines, once the code compiles and the test is green:**
+```bash
+# SDKv2 branch:
+golangci-lint run --new-from-rev $(git merge-base origin/master HEAD) ./ionoscloud/...
+
+# framework-native branch:
+golangci-lint run --new-from-rev $(git merge-base origin/master HEAD) \
+  ./internal/framework/services/<service>/... ./internal/framework/provider/...
+```
+`--new-from-rev` narrows the *report*, not the work: `make lint` (`GNUmakefile:14-15`) is the
+same flags with **no path argument**, so golangci-lint loads and analyses all 60 non-vendor
+packages under ~45 linters. On this machine that is the rung most likely to reproduce the
+load-55 incident, so pass paths in the loop and save `make lint` for a single run at the end.
+Never drop `--new-from-rev` — the whole-package baseline in these packages runs to a couple of
+hundred pre-existing issues that are not yours and not actionable, and CI lints only the diff.
+
+**Rung 4 — only if you added or removed an import:**
+```bash
+go mod tidy && git diff --exit-code -- go.mod go.sum
+go mod vendor && git status --porcelain vendor/
+```
+**The trap:** importing a *new subpackage of a module already in `go.mod`* changes
+`vendor/modules.txt` and adds vendored sources while leaving `go.mod`/`go.sum` untouched.
+That is exactly what happened on #1034 with `terraform-plugin-mux/tf5to6server/translate`.
+Run the vendor half even when the tidy half is clean, and **report `vendor/` as part of the
+change** so it goes in the same commit — do not run `git commit` yourself.
+
+**Rung 5 — expensive, exactly once, at the very end:**
+```bash
+go vet -tags=all ./...
+```
+136 of the repo's 158 `_test.go` files sit behind build tags and are invisible to a plain
+`go vet ./...`. That includes the `Query: true` step you wrote — the resource's acceptance
+test file is tagged (`ionoscloud/resource_datacenter_test.go` is
+`//go:build compute || all || datacenter`), so this rung is the only thing that compiles it.
+It also catches a signature change reaching test files in packages you never opened.
+
+This compiles all 60 non-vendor packages **and their test variants**, so it is strictly heavier
+than the `go build ./...` the machine-limits section tells you to avoid. **Tell the user before
+you start it**, and offer to leave it to CI (`.github/workflows/build.yml`, `Run go vet with all
+build tags`) and run only the scoped form:
+```bash
+go vet -tags=all ./ionoscloud/ ./internal/framework/provider/ ./internal/acctest/
+# framework-native branch: add ./internal/framework/services/<service>/
+```
+
+Note: **no test job runs on PRs.** Green CI does not mean the tests pass. Rungs 2 and 2b are
+on you.
+
+Note also what the ladder does **not** prove: it exercises the ListResource *RPC*, never the
+`terraform query` command. There is no repo tooling for that — no `dev_overrides` example
+anywhere in the tree, no make target. A manual check needs a `~/.terraformrc` `dev_overrides`
+block pointing at a locally built binary plus a `.tfquery.hcl` file, and it runs against real
+credentials. **Only on explicit request**, and only with a throwaway `list` block label — see
+the hazard in `references/docs-and-changelog.md` §2b.
+
+---
+
+## Definition of done
+
+- [ ] `Identity` on the managed resource, every attribute set on **every** read path
+- [ ] `d.SetId(...)` right after parsing the import parts (SDKv2 branch)
+- [ ] Legacy string import still works, byte-for-byte unchanged
+- [ ] List resource registered — one name in `ionoscloud/list_resources.go`'s `ListResources()`
+      (SDKv2 branch); or one name in the service package's `ListResources()`, plus the
+      `<service>.ListResources(),` line in the framework provider **only** when that service
+      package is new (framework-native branch)
+- [ ] **No model, and no attribute mapping of your own** (SDKv2 branch): your `map<X>`
+      does the filter check and nothing else — every result is
+      `r.resourceSchema.Data(&terraform.InstanceState{})` → `set<X>Data` → `set<X>Identity`
+      (in that order — the identity setter reads values back out) →
+      `identity.MappedItemFromResourceData`. If you wrote a `tfsdk`-tagged struct, delete it
+- [ ] Unit test asserts every mapped attribute, every stub result, and the null-vs-zero
+      distinction (an omitted nested **block** can decode to `[]any{}` rather than nil —
+      `test-harness.md`) — and **the mutation check was run and failed**
+- [ ] One filter subtest **per field** in the `FilterAttribute(...)` allow-list, plus an AND
+      case; and the stub asserts the query params the fetch closure sets (`depth`, and `limit`
+      when an explicit one is passed)
+- [ ] A `Query: true` step on the resource's tagged acceptance test (written; **not run**),
+      plus a non-ForceNew update step whenever Update writes the identity itself
+- [ ] `docs/list-resources/<resource>.md` + the pointer section on `docs/resources/<resource>.md`
+- [ ] CHANGELOG entry appended under the existing open version heading (do not create a new one)
+- [ ] Ladder rungs 0–5 clean, **2b included**
+- [ ] The pagination decision is written down somewhere a reviewer will find it, with this
+      endpoint's real default limit
+- [ ] Reported, not committed: no `git commit`, `git push` or `gh` write unless the user asked
+
+## Reference files
+
+- `references/sdkv2-branch.md` — the SDKv2 path: identity on the resource, the list resource
+  in package `ionoscloud`, registration. **The traps live here.**
+- `references/framework-native-branch.md` — the shorter path, and what *not* to copy from
+  the five existing examples.
+- `references/test-harness.md` — the test file, the verbatim-copy helpers, the mutation check.
+- `references/docs-and-changelog.md` — doc template, reusable prose, CHANGELOG rules.
+- `references/verify-and-pr.md` — CI checks, `gh` commands, what the bot review looks like
+  and how the #1034 replies were written.

--- a/.claude/skills/add-list-resource/references/docs-and-changelog.md
+++ b/.claude/skills/add-list-resource/references/docs-and-changelog.md
@@ -1,0 +1,391 @@
+# Docs and CHANGELOG
+
+Docs here are **hand-written**. There is no `tfplugindocs`, no `templates/`, no `.web-docs/`,
+no `go:generate`. Nothing verifies that docs match the schema.
+
+**No index file needs updating.** `docs/list-resources/` is discovered by folder name.
+`gitbook_docs/summary.md` indexes only `docs/resources/` and `docs/data-sources/` and has never
+contained a list resource; `docs/index.md` is a landing page with no per-page index; `README.md`
+does not mention list resources. `website/profitbricks.erb` is dead legacy — do not touch it.
+
+**Links are checked on the PR.** `.github/workflows/broken-link-checker.yml` runs
+`markdown-link-check` on modified files under `docs/` plus `CHANGELOG.md` and `README.md`. So
+every `docs.ionos.com` URL and the `../list-resources/<resource>.md` back-link must resolve.
+There is a pre-existing broken one to not copy: `docs/resources/pg_cluster_v2.md` links to
+`../list-resources/psql_cluster_v2.md`, but the file is `pg_cluster_v2.md`.
+
+---
+
+## 1. New page: `docs/list-resources/<resource>.md`
+
+Frontmatter conventions:
+
+- `subcategory` — copied **verbatim** from `docs/resources/<resource>.md`.
+- `layout` — always `"ionoscloud"`.
+- `page_title` — `"IONOS CLOUD: <resource>"`, the **bare type stem**, no `ionoscloud_` prefix.
+  All eight existing list pages use this form. Do **not** copy the resource page's title: about a
+  third of `docs/resources/` prefixes the type (`docs/resources/pg_cluster_v2.md` has
+  `IONOS CLOUD: ionoscloud_pg_cluster_v2` while `docs/list-resources/pg_cluster_v2.md` has
+  `IONOS CLOUD: pg_cluster_v2`). The list page does not disambiguate itself in the title; only
+  the H1 says "List Resource:".
+- `description` — `Lists IONOS CLOUD <Plural Thing>.`
+
+````markdown
+---
+subcategory: "<Subcategory>"
+layout: "ionoscloud"
+page_title: "IONOS CLOUD: <resource>"
+description: |-
+  Lists IONOS CLOUD <Things>.
+---
+
+# List Resource: <ionoscloud_type>
+
+⚠️ **Note:** List Resources require HashiCorp Terraform version 1.14 or later and are queried using `terraform query`.
+
+Lists [<Things>](<docs_url>) on IONOS CLOUD.
+
+## Example Usage
+
+⚠️ **Note:** `list` blocks must be placed in a dedicated query file, whose name ends in `.tfquery.hcl` (for example `queries.tfquery.hcl`), separate from your main Terraform configuration.
+
+### List all <things>
+
+```hcl
+list "<ionoscloud_type>" "all" {
+  provider         = ionoscloud
+  include_resource = true
+}
+```
+
+### Filter <things> by <field>
+
+```hcl
+list "<ionoscloud_type>" "<label>" {
+  provider         = ionoscloud
+  include_resource = true
+  config {
+    filters = [{
+      field_name  = "<field>"
+      field_value = "<value>"
+    }]
+  }
+}
+```
+
+### Filter <things> by <field_a> and <field_b>
+
+```hcl
+list "<ionoscloud_type>" "prod" {
+  provider         = ionoscloud
+  include_resource = true
+  config {
+    filters = [
+      { field_name = "<field_a>", field_value = "<value_a>" },
+      { field_name = "<field_b>", field_value = "<value_b>" },
+    ]
+  }
+}
+```
+
+### Generate resource configuration from existing <things>
+
+Use `terraform query` with `-generate-config-out` to produce ready-to-use `<ionoscloud_type>` resource blocks for the <things> the query returns:
+
+```shell
+terraform query -generate-config-out=imported.tf
+```
+
+Terraform will write an `<ionoscloud_type>` resource block for each discovered <thing> into `imported.tf`, which can then be used directly in your configuration.
+
+<!-- pagination caveat here, if the implementation makes a single unpaginated call — §2a -->
+
+<!-- label-collision warning here — §2b -->
+
+## Argument Reference
+
+The `config` block supports the following arguments:
+
+- `filters` - (Optional) List of filters to apply. All filters must match (AND logic). Each filter supports:
+  - `field_name` - (Required) The field to filter on. Supported values: <filter_fields>.
+  - `field_value` - (Required) The exact value to match against.
+
+<!-- regional services only: the supported-locations line and the performance note — §2c -->
+
+## Identity Attributes
+
+Each result exposes the following identity attributes, usable for import:
+
+| Attribute  | Description                        |
+|------------|------------------------------------|
+| `id`       | The UUID of the <thing>.           |
+| `<extra>`  | <description>.                     |
+
+## Attributes Reference
+
+Each result exposes the following attributes when `include_resource = true`, matching the `<ionoscloud_type>` resource schema:
+
+- `id` - ...
+- `<attr>` - ...
+- `<block>` - <Block description>:
+  - `<sub_attr>` - ...
+- `timeouts` - Always null; timeouts are configuration-only and are not returned by a query.
+
+> **Note:** `<attr>` is not available via the list resource as <reason>.
+````
+
+The `timeouts` bullet applies to the **SDKv2 branch** — the SDKv2 schema carries a `timeouts`
+block that surfaces in the result as null. The framework-native pages do not have it.
+
+Two things the two oldest pages (`s3_bucket.md`, `object_storage_accesskey.md`) lack: the
+two-filter example, and the `## Identity Attributes` section. Follow the newer form instead —
+`ipblock.md` and `target_group.md` are the closest models for an SDKv2-backed resource
+(`target_group.md` for one with no `location`), then `datacenter.md` and `pg_cluster_v2.md`.
+
+The supported-locations line and the performance note appear only on the three regional cluster
+pages — `datacenter.md` has neither, because the Cloud API is not regional. Omit them for a
+non-regional resource; the template marks them "regional services only" for that reason.
+
+---
+
+## 2. Reusable prose — copy near-verbatim rather than rewriting
+
+### 2a. Pagination caveat — for any single-unpaginated-call implementation
+
+Two variants — pick by whether the fetch passes an explicit `.Limit(n)`.
+
+*No explicit limit (the SDK's own fallback applies):*
+
+```markdown
+> **Note:** The <things> are read with a single <API name> request, so the results are
+> bounded by the page limit the IONOS SDK requests by default. A contract holding more
+> <things> than that limit is truncated silently — no error is raised and the missing
+> <things> simply do not appear. Check that the number of generated resource blocks matches
+> the number of <things> you expect before treating `imported.tf` as complete.
+```
+
+*Explicit `.Limit(n)` (decision 1 said to match the data source):*
+
+```markdown
+> **Note:** The <things> are read with a single <API name> request, which asks for up to
+> **<n>** items — the same limit the `<ionoscloud_type>` data source requests, and <k> times
+> the <sdk-fallback> the IONOS SDK falls back to when no limit is asked for. Whether the
+> server honours the requested limit in full is not verified. A contract holding more
+> <things> than one response returns is truncated silently — no error is raised and the
+> missing <things> simply do not appear. Check that the number of generated resource blocks
+> matches the number of <things> you expect before treating `imported.tf` as complete.
+```
+
+**Never write "the API's default page limit".** The fallback is sent by the *SDK client*, not
+applied by the endpoint (`sdk-go/v6/api_<x>.go`, the `DefaultQueryParams.Get("limit")` branch),
+and when the fetch passes an explicit `.Limit(n)` the endpoint default is not what bounds the
+result at all. Name the real number and say where it comes from. Keep the "not verified" hedge:
+nothing in the repo confirms the server honours a requested limit in full.
+
+Its companion under `## Argument Reference`, when the API returns everything in one response
+so filtering saves no calls:
+
+```markdown
+> **Note:** The Cloud API returns <things> from every location in a single response, so filtering by `location` does not reduce the number of API calls; it only narrows the results. Filtering happens after that response is read, so it cannot recover a <thing> left out by the page limit described above.
+```
+
+If the resource has **no** location — `ionoscloud_target_group` does not — drop the first
+clause rather than inventing a location: "Filtering happens after the single API response above
+is read, so it narrows the results but does not reduce the number of API calls, and it cannot
+recover a <thing> left out by the <n>-item limit."'
+
+**Look the limit up per endpoint, and name the number you found.** There is no module-wide
+default: the generated code sends `limit=1000` for most Cloud API collections but **100** for
+`/ipblocks`, `/targetgroups` and user management, and the vendored doc comments say "Default
+limit is the first 100 items" throughout regardless.
+
+```bash
+grep -n 'parameterToString(1\?0*, "")' vendor/github.com/ionos-cloud/sdk-go/v6/api_<x>.go
+grep -n 'Limit(' ionoscloud/data_source_<resource>.go
+```
+
+If the fetch passes an explicit `.Limit(n)` — match whatever the sibling data source already
+does — say `n`. If it does not, say the endpoint's default. Note which of the two it is, and
+that whether the server honours the request is unverified. What you must not do is copy
+datacenter's "1000" onto an endpoint that defaults to 100.
+
+### 2b. Label-collision warning — recommended on every page
+
+This documents a real near-miss: a smoke test renamed the maintainer's live datacenter and
+nearly destroyed it. Only `<ionoscloud_type>` and `<thing>` change — but the section has two
+halves and the second is conditional.
+
+**First check whether the resource has a force-new attribute at all:**
+
+```bash
+grep -n 'ForceNew' ionoscloud/resource_<resource>.go
+grep -n 'CustomizeDiff' ionoscloud/resource_<resource>.go
+```
+
+Many good list candidates have none — backup units, target groups, users, groups, CDN
+distributions, certificates, DNS reverse records and autoscaling groups all return zero — and a
+`CustomizeDiff` is usually not a substitute: an immutable-field check like
+`resource_certificate_manager_certificate.go:64` *errors out* rather than planning a
+replacement. If there is no force-new attribute, drop the destroy paragraph and its HCL block — but do not
+just stop, or the section trails off having described a hazard without saying what it costs.
+Replace them with one paragraph naming the in-place-update damage for *this* resource, e.g. for
+`ionoscloud_target_group`: "Target groups have no force-new attributes, so the result is an
+in-place update rather than a destroy — but it is still an update applied to the **wrong**
+target group: the name, algorithm, protocol, targets and health checks of the one you queried
+are written over the one in state, and the ALB forwarding rules pointing at it start balancing
+across the new target list." Then trim the closing plan-reading advice to match — with nothing
+force-new there is no `must be replaced` line to look for. The silent-wrong-target risk is real for every resource; the destroy-and-recreate
+risk is not, and describing a destroy that cannot happen costs the whole warning its
+credibility.
+
+````markdown
+Terraform names each generated resource after the `list` block label plus an index — a `list "<ionoscloud_type>" "smoke"` block produces `<ionoscloud_type>.smoke_0`, `smoke_1`, and so on.
+
+### ⚠️ Do not reuse a `list` block label across separate imports
+
+Because the generated names are derived from the `list` block label, running a second query with the **same** label produces the **same** resource addresses. If a previous address is still in state, the generated configuration is silently applied to the <thing> already recorded at that address — not to the one you just queried.
+
+This happens because an `import` block is idempotent: Terraform skips it when the target address is already in state, so the identity in the generated `import` block is never consulted. Deleting the generated `.tf` file does **not** remove the state entry.
+
+The consequences are not limited to a harmless diff. `<force_new_attr>` is a force-new attribute, so if the two <things> differ in it, the plan **destroys the <thing> already in state** and creates a replacement — the <thing> you meant to import is never touched:
+
+```hcl
+# generated for a <thing> with <force_new_attr> = "<b>", but smoke_0 in state points at one with "<a>"
+resource "<ionoscloud_type>" "smoke_0" {
+  <force_new_attr> = "<b>"     # forces replacement of the "<a>" <thing>
+  name             = "<example-name>"
+}
+```
+
+To avoid this:
+
+- Use a distinct `list` block label for each query you intend to import from, or
+- Clear the address deliberately: run `terraform state show <ionoscloud_type>.smoke_0` first
+  and confirm it is the leftover import and not a <thing> you still manage, then
+  `terraform state rm <ionoscloud_type>.smoke_0`. Removing the address does not delete the
+  <thing> — it stops Terraform managing it, and it has to be re-imported to come back under
+  management.
+
+Always read the plan before applying. A clean import reports:
+
+```
+Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
+```
+
+Anything reporting changes, and especially `must be replaced` with `<force_new_attr> = "..." -> "..." # forces replacement`, means the address is bound to a different <thing> — stop and clear the state entry first.
+````
+
+### 2c. Regional services
+
+```markdown
+Supported `location` values: `de/fra`, `de/fra/1`, ...
+
+> **Performance note:** When no `location` filter is set, the provider queries every regional endpoint in sequence. Adding a `location` filter reduces the query to a single endpoint call.
+```
+
+---
+
+## 3. Append to `docs/resources/<resource>.md`
+
+At the end of the file, after the existing `## Import` section:
+
+````markdown
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can also be used with the `identity` attribute:
+
+```hcl
+import {
+  to = <ionoscloud_type>.example
+  identity = {
+    id = "<thing> uuid"
+  }
+}
+
+resource "<ionoscloud_type>" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `id` (String) The UUID of the <thing>.
+
+#### Optional
+
+* `<extra>` (String) <description>.
+
+## Query (List Resource)
+
+<Things> can be listed using `terraform query` (requires Terraform 1.14+). List blocks must be placed in a dedicated query file, whose name ends in `.tfquery.hcl` (for example `queries.tfquery.hcl`).
+
+```hcl
+list "<ionoscloud_type>" "all" {
+  provider         = ionoscloud
+  include_resource = true
+}
+```
+
+See the [`<ionoscloud_type>` list resource documentation](../list-resources/<resource>.md) for filters and the full attribute reference.
+````
+
+Identity attributes that are `RequiredForImport` go under `#### Required`; drop the
+`#### Optional` heading entirely if there are none.
+
+`mariadb_cluster_v2.md` and `inmemorydb_cluster_v2.md` have neither section despite having
+list resources and identity imports. That is drift, not a rule — follow the
+datacenter/pg/s3/accesskey form.
+
+---
+
+## 4. CHANGELOG.md
+
+Two entries, under `### Features`:
+
+```markdown
+- `<ionoscloud_type>`: New list resource, queryable with `terraform query` (requires Terraform 1.14+).
+- `<ionoscloud_type>`: Add a resource identity (`id`, `<extra>`), which also enables `import` blocks with an `identity` attribute.
+```
+
+### The version-heading rule — the common mistake
+
+The PR checklist says "Changelog updated **and version incremented**", but the observed rule is
+subtler:
+
+- There is **no version string anywhere in the source**. `main.go`, `GNUmakefile` and
+  `.goreleaser.yml` carry none. The `CHANGELOG.md` heading *is* the version; releases are cut
+  by pushing a `v*` tag.
+- **The `## X.Y.Z` heading is created once per release cycle, by the first PR after a release.
+  Every later PR appends under it.** `## 6.7.36` was created by #1025; #1029, #1030 and #1031
+  all added bullets under it without bumping.
+
+So: **read the top of `CHANGELOG.md` first.** If the topmost `## X.Y.Z` heading has no
+corresponding git tag yet, append under the right `###` section (creating the section if
+missing). Only create a new `## X.Y.Z+1` heading if the topmost one is already released.
+Adding a duplicate heading is the mistake to avoid.
+
+**#1034 is the counter-example, so check the tag and not just the heading.** It appended its two
+`ionoscloud_datacenter` bullets under `## 6.7.36`, which was correct when the PR was opened and
+wrong by the time it merged: `v6.7.36` had been tagged in between, at a commit that is not an
+ancestor of the merge. The result advertised an unreleased feature under a released version, and a
+later PR had to move both bullets into `## 6.7.37`. The heading being un-bumped is not evidence
+that it is unreleased — the tag is:
+
+```bash
+top=$(sed -n 's/^## //p' CHANGELOG.md | head -1)
+if git rev-parse -q --verify "refs/tags/v$top" >/dev/null; then
+  echo "v$top is ALREADY TAGGED - add a new '## <next>' heading above it"
+else
+  echo "v$top is unreleased - append under it"
+fi
+```
+
+Re-check this immediately before merge, not only when you write the entry.
+
+Format: `## <semver>` (no date, no link), then `### Features` / `### Fixes` / `### Testing` /
+`### Refactor` / `### Documentation` / `### Chore`. Resource-scoped entries lead with the
+backticked type name and a colon; provider-wide entries have no prefix. There is no
+`Unreleased` section, no `.changelog/` directory, and no changelog tooling.
+
+Issue links use the full form: `(fixes [#1021](https://github.com/ionos-cloud/terraform-provider-ionoscloud/issues/1021))`.
+Any URL in a new bullet is link-checked.

--- a/.claude/skills/add-list-resource/references/docs-and-changelog.md
+++ b/.claude/skills/add-list-resource/references/docs-and-changelog.md
@@ -23,7 +23,7 @@ Frontmatter conventions:
 - `subcategory` — copied **verbatim** from `docs/resources/<resource>.md`.
 - `layout` — always `"ionoscloud"`.
 - `page_title` — `"IONOS CLOUD: <resource>"`, the **bare type stem**, no `ionoscloud_` prefix.
-  All eight existing list pages use this form. Do **not** copy the resource page's title: about a
+  Every existing list page uses this form. Do **not** copy the resource page's title: about a
   third of `docs/resources/` prefixes the type (`docs/resources/pg_cluster_v2.md` has
   `IONOS CLOUD: ionoscloud_pg_cluster_v2` while `docs/list-resources/pg_cluster_v2.md` has
   `IONOS CLOUD: pg_cluster_v2`). The list page does not disambiguate itself in the title; only
@@ -139,8 +139,10 @@ block that surfaces in the result as null. The framework-native pages do not hav
 
 Two things the two oldest pages (`s3_bucket.md`, `object_storage_accesskey.md`) lack: the
 two-filter example, and the `## Identity Attributes` section. Follow the newer form instead —
-`ipblock.md` and `target_group.md` are the closest models for an SDKv2-backed resource
-(`target_group.md` for one with no `location`), then `datacenter.md` and `pg_cluster_v2.md`.
+`ipblock.md` and `datacenter.md` are the closest models for an SDKv2-backed resource, then
+`pg_cluster_v2.md`. Both SDKv2 models carry a `location`; no existing page covers an
+SDKv2-backed resource without one, so for such a resource start from `ipblock.md` and apply the
+no-location wording in §2a instead of hunting for a page to imitate.
 
 The supported-locations line and the performance note appear only on the three regional cluster
 pages — `datacenter.md` has neither, because the Cloud API is not regional. Omit them for a
@@ -169,8 +171,8 @@ Two variants — pick by whether the fetch passes an explicit `.Limit(n)`.
 ```markdown
 > **Note:** The <things> are read with a single <API name> request, which asks for up to
 > **<n>** items — the same limit the `<ionoscloud_type>` data source requests, and <k> times
-> the <sdk-fallback> the IONOS SDK falls back to when no limit is asked for. Whether the
-> server honours the requested limit in full is not verified. A contract holding more
+> the <sdk-fallback> the IONOS SDK sends for `<endpoint>` when no limit is asked for. Whether
+> the server honours the requested limit in full is not verified. A contract holding more
 > <things> than one response returns is truncated silently — no error is raised and the
 > missing <things> simply do not appear. Check that the number of generated resource blocks
 > matches the number of <things> you expect before treating `imported.tf` as complete.
@@ -192,15 +194,18 @@ so filtering saves no calls:
 If the resource has **no** location — `ionoscloud_target_group` does not — drop the first
 clause rather than inventing a location: "Filtering happens after the single API response above
 is read, so it narrows the results but does not reduce the number of API calls, and it cannot
-recover a <thing> left out by the <n>-item limit."'
+recover a <thing> left out by the <n>-item limit."
 
 **Look the limit up per endpoint, and name the number you found.** There is no module-wide
 default: the generated code sends `limit=1000` for most Cloud API collections but **100** for
-`/ipblocks`, `/targetgroups` and user management, and the vendored doc comments say "Default
-limit is the first 100 items" throughout regardless.
+`/ipblocks`, `/targetgroups` and user management. Do not trust the vendored doc comments: the
+only comment in `sdk-go/v6` that names a default says "Default limit is the first 100 items",
+and it sits on `DatacentersGet`, whose client actually sends 1000. Read the `parameterToString`
+literal, never the comment.
 
 ```bash
-grep -n 'parameterToString(1\?0*, "")' vendor/github.com/ionos-cloud/sdk-go/v6/api_<x>.go
+# the vendored file names are snake_cased: api_ip_blocks.go, api_target_groups.go
+grep -n 'Add("limit", parameterToString(' vendor/github.com/ionos-cloud/sdk-go/v6/api_<x>.go
 grep -n 'Limit(' ionoscloud/data_source_<resource>.go
 ```
 
@@ -225,7 +230,8 @@ grep -n 'CustomizeDiff' ionoscloud/resource_<resource>.go
 Many good list candidates have none — backup units, target groups, users, groups, CDN
 distributions, certificates, DNS reverse records and autoscaling groups all return zero — and a
 `CustomizeDiff` is usually not a substitute: an immutable-field check like
-`resource_certificate_manager_certificate.go:64` *errors out* rather than planning a
+`checkCertImmutableFields` in `ionoscloud/resource_certificate_manager_certificate.go`
+*errors out* rather than planning a
 replacement. If there is no force-new attribute, drop the destroy paragraph and its HCL block — but do not
 just stop, or the section trails off having described a hazard without saying what it costs.
 Replace them with one paragraph naming the in-place-update damage for *this* resource, e.g. for
@@ -381,6 +387,12 @@ fi
 ```
 
 Re-check this immediately before merge, not only when you write the entry.
+
+**This tag check is the authority for the version heading.** Run the snippet and do what it
+prints; never decide from the heading alone, in either direction. The `ionoscloud_ipblock` run got
+it right *because of* the snippet — the topmost heading's version was already tagged at master's
+own tip, so opening the next heading was correct there. That outcome is an instance of the rule,
+not a standing instruction to always bump.
 
 Format: `## <semver>` (no date, no link), then `### Features` / `### Fixes` / `### Testing` /
 `### Refactor` / `### Documentation` / `### Chore`. Resource-scoped entries lead with the

--- a/.claude/skills/add-list-resource/references/framework-native-branch.md
+++ b/.claude/skills/add-list-resource/references/framework-native-branch.md
@@ -171,9 +171,10 @@ takes — nothing there is per-resource.
 3. **Bucket does a per-item extra API call inside the mapper**, before the filter check —
    N+1 (or 2N) requests. Unavoidable for the S3 API, a bad default for a Cloud API resource
    where one `Depth(1)` call returns everything.
-4. **mariadbv2 and inmemorydbv2 have their doc comments stripped.** Don't teach the
-   stripped-down form.
-5. **Filter-field vocabulary drifts** — four use `("name","location")`, bucket
+4. **mariadbv2 and inmemorydbv2 keep only pgsqlv2's `New<X>ListResource` and `List` comments** —
+   the ones on the `clusterWithLocation` type, on `ListResourceConfigSchema`, on the mapper, and
+   the inline early-filter-read note were dropped. Don't teach the stripped-down form.
+5. **Filter-field vocabulary drifts** — three use `("name","location")`, bucket
    `("name","region")`, accesskey `("id","description","accesskey")`. Filtering on `id` is
    redundant with the identity. Match the *resource's own attribute names*, not a house style.
 6. **None of the five has a test.** That is a gap, not a convention — write one. The harness in

--- a/.claude/skills/add-list-resource/references/framework-native-branch.md
+++ b/.claude/skills/add-list-resource/references/framework-native-branch.md
@@ -1,0 +1,182 @@
+# Framework-native branch
+
+For a managed resource already implemented with terraform-plugin-framework (anything under
+`internal/framework/services/<service>/resource_*.go` with a `Metadata` method building its
+name from `req.ProviderTypeName`).
+
+This is substantially less work than the SDKv2 branch: **no `RawV6Schemas`, no protocol-schema
+bridge, and no second package.** The list resource is just more methods on the *same* struct as
+the managed resource, which already supplies `Metadata`, `Schema`, `IdentitySchema` and
+`Configure`.
+
+Best template: `internal/framework/services/pgsqlv2/resource_pg_cluster_list.go`. It is the
+only one of the five with doc comments on every non-obvious part, it shows the
+two-attribute identity + regional fan-out + timeouts-nulling triad, and it reuses the
+resource's existing mapper instead of writing a second one. Use
+`objectstoragemanagement/resource_object_storage_accesskey_list.go` as the secondary template
+for the single-`id`-identity, non-regional case.
+
+---
+
+## §1 — Resource identity on the managed resource
+
+On the **managed** resource, never on the list resource. Add the interface assertion and the
+`IdentitySchema` method:
+
+```go
+var (
+	_ resource.ResourceWithImportState = (*<x>Resource)(nil)
+	_ resource.ResourceWithConfigure   = (*<x>Resource)(nil)
+	_ resource.ResourceWithIdentity    = (*<x>Resource)(nil)
+)
+
+type <x>IdentityModel struct {
+	ID       types.String `tfsdk:"id"`
+	Location types.String `tfsdk:"location"`
+}
+
+func (r *<x>Resource) IdentitySchema(_ context.Context, _ resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+	resp.IdentitySchema = identityschema.Schema{
+		Attributes: map[string]identityschema.Attribute{
+			"id":       identityschema.StringAttribute{RequiredForImport: true},
+			"location": identityschema.StringAttribute{RequiredForImport: true},
+		},
+	}
+}
+```
+
+Import `"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"`.
+
+For a lone `id`, reuse the shared `identity.Model` instead of declaring a package-local
+struct — that is what the accesskey resource does.
+
+**Write the identity on every state-producing path** — Create, Read, Update (Delete needs
+none), and read it in ImportState:
+
+```go
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, &<x>IdentityModel{ID: plan.ID, Location: plan.Location})...)
+```
+
+```go
+func (r *<x>Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if req.Identity != nil {
+		// ... resp.Diagnostics.Append(req.Identity.Get(ctx, &id)...)
+	}
+	// ... existing string-import path unchanged
+}
+```
+
+Where the identity model lives: next to the `IdentitySchema` that defines it, in the managed
+resource file. (The SDKv2 branch has no identity model at all — its identity is a block on the
+`*schema.Resource` and a `set<X>Identity(d *schema.ResourceData)` writer.)
+
+---
+
+## §2 — The list resource
+
+```go
+var (
+	_ list.ListResource              = (*<x>Resource)(nil)
+	_ list.ListResourceWithConfigure = (*<x>Resource)(nil)
+)
+
+// New<X>ListResource creates a new list resource for <ionoscloud_type>.
+func New<X>ListResource() list.ListResource {
+	return &<x>Resource{}
+}
+```
+
+No `Metadata`, no `Configure`, no `RawV6Schemas`, no constructor argument — all inherited
+from the managed resource. `list.ListResource.Metadata` is declared with
+`resource.MetadataRequest` and `list.ListResourceWithConfigure.Configure` with
+`resource.ConfigureRequest` precisely so one method satisfies both interfaces.
+
+`ListResourceConfigSchema`, `List` and the mapper are **identical in shape to the SDKv2
+branch** — see `sdkv2-branch.md` §2b/§2c, including the `StreamList` fatal-vs-skip table and
+the regional fan-out pattern. What the mapper *builds* is the difference: the SDKv2 branch has
+no model and writes each result through the managed resource's own `ResourceData`, while here
+you fill a real framework model. Two consequences:
+
+**Resource model — reuse the existing one.** The managed resource already has a model struct
+with `types.String` / `types.Int32` / `timeouts.Value` fields and a
+`map<X>ResponseToModel` function. Use both. Do not write a second model or a second mapper.
+`pgsqlv2` is the worked example: `resource_pg_cluster_list.go:105-115` fills the very
+`clusterResourceModel` declared at `resource_pg_cluster_v2.go:41` and calls the same
+`mapClusterResponseToModel` the managed resource's Create, Read and Update call.
+
+That reuse is also why this branch never had the drift failure the SDKv2 one did. There, the
+list resource sat in a different package from the schema and mirrored it in a hand-written
+struct; an unrelated PR added an attribute to the schema, the mirror did not follow, and every
+`terraform query` result failed at runtime with "Object defines fields not found in struct".
+Here the schema, the model and the mapper are the same three things the managed resource
+itself uses, in the same file — a model that no longer covers the schema breaks the managed
+resource's own `State.Set` first, in its own acceptance test, long before anyone queries it.
+So there is nothing to keep in sync: **reusing the model is the correctness argument, not a
+convenience.**
+
+**Timeouts must be explicitly nulled**, and the attribute-type map must match the resource's
+own `timeouts.Opts` **exactly**:
+
+```go
+	Timeouts: timeouts.Value{Object: types.ObjectNull(map[string]attr.Type{
+		"create": types.StringType,
+		"update": types.StringType,
+		"delete": types.StringType,
+	})},
+```
+
+There are three different key sets among the five existing list resources
+(`create/update/delete`, `create/read/update/delete`, `create/read/delete`). Read the target
+resource's `timeouts.Block(ctx, timeouts.Opts{...})` and mirror those keys. Copying the wrong
+map is a runtime type mismatch, not a compile error.
+
+---
+
+## §3 — Registration
+
+```go
+// ListResources returns the list of list resources for the package.
+func ListResources() []func() list.ListResource {
+	return []func() list.ListResource{
+		New<X>ListResource,
+	}
+}
+```
+
+Then, **only if the service package is not in `ListResources` yet**, one line in
+`internal/framework/provider/provider.go`'s `ListResources`:
+
+```go
+		<service>.ListResources(),
+```
+
+This is the only branch that touches the framework provider at all. An SDKv2-backed list
+resource registers itself in `ionoscloud/list_resources.go` instead, and reaches the provider
+through the `sdkv2ListResources ...func() list.ListResource` variadic that `New` already
+takes — nothing there is per-resource.
+
+---
+
+## Inconsistencies among the five existing examples — do not propagate these
+
+1. **pgsqlv2 (`:53`) and inmemorydbv2 (`:49`) carry a bare `//nolint:errcheck`** on the
+   deliberate `req.Config.GetAttribute` discard. Both are wrong twice over: `GetAttribute`
+   returns `diag.Diagnostics`, not an `error`, so `errcheck` has nothing to report; and a bare
+   directive fails `nolintlint`'s `require-explanation` (`.golangci.yml:82-84`). They survive
+   only because CI lints the diff (`--new-from-rev`) and they predate it. **Use the mariadbv2
+   form — no directive at all.**
+2. **objectstorage bucket returns `(mapped, diags-with-error)`** on a per-item failure, which
+   makes one bad bucket truncate the whole listing. The contract is `return nil, diags` to
+   skip, `return mapped, nil` to include.
+3. **Bucket does a per-item extra API call inside the mapper**, before the filter check —
+   N+1 (or 2N) requests. Unavoidable for the S3 API, a bad default for a Cloud API resource
+   where one `Depth(1)` call returns everything.
+4. **mariadbv2 and inmemorydbv2 have their doc comments stripped.** Don't teach the
+   stripped-down form.
+5. **Filter-field vocabulary drifts** — four use `("name","location")`, bucket
+   `("name","region")`, accesskey `("id","description","accesskey")`. Filtering on `id` is
+   redundant with the identity. Match the *resource's own attribute names*, not a house style.
+6. **None of the five has a test.** That is a gap, not a convention — write one. The harness in
+   `test-harness.md` works for this branch too; drop the `ListResourceSchemas` /
+   `GetResourceIdentitySchemas` assertions that exist specifically to prove `RawV6Schemas`
+   worked.

--- a/.claude/skills/add-list-resource/references/sdkv2-branch.md
+++ b/.claude/skills/add-list-resource/references/sdkv2-branch.md
@@ -8,9 +8,16 @@ For a managed resource still implemented with `terraform-plugin-sdk/v2` (anythin
 - `ionoscloud/list_resources.go` — registration
 - `internal/framework/identity/sdkv2.go` — the two shared helpers everything above leans on
 
-`ionoscloud/resource_ipblock_list.go` (optional `name`, explicit `Limit`) and
-`ionoscloud/resource_target_group_list.go` (lone-`id` identity, nested blocks) are the
-second and third worked examples.
+`ionoscloud/resource_ipblock_list.go` is the second — and, today, the last — worked example:
+an optional `name` (so a `DisplayName` fallback, §2c), an explicit `Limit`, and a state writer
+that is *exported* (`IpBlockSetData`, §2d).
+
+Those two are the whole set. `ionoscloud_datacenter` and `ionoscloud_ipblock` are the only
+SDKv2 resources that declare an `Identity` at all
+(`grep -l 'ResourceIdentity{' ionoscloud/*.go`), and `ionoscloud/list_resources.go` registers
+only their two list resources. Anything below about a lone-`id` identity, a child resource, or
+`MaxItems: 1` nested blocks is extrapolation from the existing schemas, not code you can go
+read.
 
 ## Why this is not just "a framework list resource"
 
@@ -20,8 +27,10 @@ until you know why.
 
 - **The list resource lives in package `ionoscloud`, beside the SDKv2 resource — not
   under `internal/framework/services/`.** It has to. A result is produced by calling the
-  managed resource's own `resource<Resource>()`, `set<Resource>Data()` and
-  `set<Resource>Identity()`, all unexported, and the import cannot be turned around:
+  managed resource's own `resource<Resource>()`, its state writer and
+  `set<Resource>Identity()` — the constructor and the identity setter are always unexported, and
+  the writer usually is, though `IpBlockSetData` is exported — and the import cannot be turned
+  around:
   `ionoscloud/provider_test.go` is an *in-package* test (`package ionoscloud`) that
   imports `internal/framework/provider`, so any `internal/framework/...` → `ionoscloud`
   import is a cycle in the test build. Exporting the setters does not help. Other providers
@@ -115,11 +124,13 @@ cannot proceed without it. Datacenter's `location` is Optional because
 to the global endpoint. A product whose client cannot be built without a location makes it
 Required — that is what the framework-native clusters do.
 
-**Only declare what addresses the resource.** `ionoscloud_target_group` has no `location`
-attribute at all — the collection is global — so its identity is a lone `id`
-(`ionoscloud/resource_target_group.go:34-45`). Do not add a `location` for symmetry with
-datacenter and ipblock; every identity attribute has to be set on every read (1b), and one
-that is always empty is one more thing to keep stable.
+**Only declare what addresses the resource.** Both shipped identities are `id` + `location`,
+but that is not a template. `ionoscloud_target_group`, for instance, has no `location`
+attribute at all — the collection is global — so its identity would be a lone `id`. It
+declares no identity yet, so there is no file to copy that from; treat it as the reasoning,
+not as a worked example. Do not add a `location` for symmetry with datacenter and ipblock;
+every identity attribute has to be set on every read (1b), and one that is always empty is one
+more thing to keep stable.
 
 **Child resource** — one attribute per parent ID, named as the resource's own schema names
 them, all Required:
@@ -317,7 +328,11 @@ Three things worth knowing:
   rejects `""` — the fall-through returns `d.Id()` verbatim and the API is called with an
   empty ID. If your resolver does not go through `splitImportID`, add the guard yourself:
   `if d.Id() == "" { return "", fmt.Errorf("invalid import identifier: expected a <resource> UUID, got an empty string") }`.
-  See `targetGroupImportID` in `ionoscloud/resource_target_group.go:405-418`.
+  No resource in the repo carries that guard yet, because no plain-import-ID resource has been
+  given an identity. `resourceTargetGroupImport` in `ionoscloud/resource_target_group.go` is the
+  unguarded shape to recognise: it takes `groupIp := d.Id()` and calls
+  `TargetgroupsFindByTargetGroupId` with it, with nothing in between. Adding an identity to a
+  resource shaped like that is exactly what makes the guard load-bearing.
 - `d.Identity()` returns an *error*, not nil, when the resource declares no identity schema —
   which is why the resolver treats a non-nil `identityErr` as "fall back to the string import"
   rather than a failure.
@@ -413,6 +428,14 @@ func New<Resource>ListResource() list.ListResource {
   literals have to keep. This file is in `package ionoscloud`, so the constant is one import away
   (`utils/constant`); the list resources in `internal/framework/services/` predate that and use
   literals because they were written in a package that did not import it.
+- **The reference implementation does not follow that rule — this is a known divergence, not a
+  precedent.** `ionoscloud/resource_datacenter_list.go` declares
+  `const datacenterResourceType = "ionoscloud_datacenter"` and passes it to both
+  `SetRawV6Schemas` and `Metadata`, even though `constant.DatacenterResource` exists and is what
+  keys `ResourcesMap`. It predates the rule and has not been migrated.
+  `ionoscloud/resource_ipblock_list.go` is the one that gets this right
+  (`constant.IpBlockResource` in both places). Copy ipblock here, not datacenter, and do not
+  read datacenter's local const as sanctioning a new one.
 
 ### 2b. The four boilerplate methods
 
@@ -464,7 +487,7 @@ func (r *<resource>ListResource) ListResourceConfigSchema(_ context.Context, _ l
   and that `set<Resource>Identity` operates on (`ionoscloud/resource_datacenter.go:341`), so an
   unaliased import would make `identity.` mean two unrelated things a few lines apart. Go imports
   are file-scoped and the two never collide in one file today, so this is **readability, not a
-  compiler requirement** — but all three list resources do it, and the SDKv2 identity is the
+  compiler requirement** — but both SDKv2 list resources do it, and the SDKv2 identity is the
   reading a maintainer of this package expects. Keep the alias.
 - `Metadata` sets the **full** type name; it does not prepend `req.ProviderTypeName` the way
   framework-native resources do.
@@ -655,6 +678,45 @@ The three statements at the end of the mapper are the whole mapping:
 **Do not add a Go struct mirroring the SDKv2 schema.** `MappedItem.Identity` and
 `MappedItem.Resource` are `any`, so one compiles; it is the shape this design replaced.
 
+#### What the design requires of the state writer
+
+The templates spell the writer `set<Resource>Data` because that is the majority name in
+`package ionoscloud`, but **the name is not the contract, the signature is.** Grep before you
+write the mapper:
+
+```bash
+grep -n 'func .*SetData\|func set.*Data' ionoscloud/resource_<resource>.go
+```
+
+The mapper can call any writer shaped `func(d *schema.ResourceData, obj *<sdk>.<X>) error` — one
+`ResourceData`, one object of the element type the collection endpoint returns, an `error`.
+Spelling varies and does not matter: `setDatacenterData` is unexported, `IpBlockSetData` is
+exported, and the ipblock list resource calls the exported name directly with no adapter.
+
+**A writer that needs arguments the mapper cannot supply is telling you something about the
+resource.** Several writers in this package take more than that pair: `setBackupUnitData` also
+wants an `*ionoscloud.Contracts`, `setApplicationLoadBalancerData` an `*ionoscloud.FlowLog`, and
+`setResourceServerData`, `setResourceVCPUServerData` and `setGroupData` want a `context.Context`
+plus an `*ionoscloud.APIClient` so they can fetch more. The mapper is handed only
+`(ctx, includeResource, filters, item)` — one already-fetched element of the collection
+(`internal/framework/identity/list.go`, the `mapper(ctx, req.IncludeResource, filters, item)`
+call). It has no `Contracts` and no `FlowLog`, and although it can reach a client, because it is
+a method and `r.bundle` is right there, every use of one costs an extra request per item.
+
+So: **a resource is listable under this design when its full state is derivable from one element
+of the collection response at `Depth(1)`.** When it is not, pick deliberately rather than
+discovering it when the mapper will not compile:
+
+1. list it anyway and accept that the writer's extra inputs are absent — defensible only if the
+   attributes they fill are genuinely optional, which for `server` and `group` they are not;
+2. do the extra per-item fetch inside the mapper, and own the N+1 request cost a listing over
+   hundreds of items then pays;
+3. do not list this resource yet — usually the right answer, and a finding to report back rather
+   than a problem to code around.
+
+This is a constraint on the *resource*, and it is invisible until you read the writer's
+signature. Read it in step 0, not after the mapper fails to compile.
+
 #### Why no model is possible
 
 Both halves of a list result are rendered from **one** `configschema.Block`:
@@ -753,7 +815,8 @@ datacenter's `cpu_architecture`), while one that is `Optional` (± `Computed`) b
 `MaxItems: 1` changes nothing here: `core_schema.go:201-205` sets `Nesting = NestingList` from
 `s.Type` before it ever looks at `MaxItems`, so such a block is still a list, is reified when
 absent, and decodes as a **one-element list** when present — assert `[]any{map[string]any{...}}`.
-`resource_target_group_list.go` has two of them (`health_check`, `http_health_check`). The
+No shipped list resource has a `MaxItems: 1` block yet; `ionoscloud_target_group`'s
+`health_check` and `http_health_check` are the shape to expect if you are the one to list it. The
 injected `timeouts` is `NestingSingle`, so it is not reified and stays null, which is what
 `nullTimeouts` leaves behind.
 
@@ -790,7 +853,6 @@ func ListResources() []func() list.ListResource {
 	return []func() list.ListResource{
 		NewDatacenterListResource,
 		NewIPBlockListResource,
-		NewTargetGroupListResource,
 	}
 }
 ```

--- a/.claude/skills/add-list-resource/references/sdkv2-branch.md
+++ b/.claude/skills/add-list-resource/references/sdkv2-branch.md
@@ -1,0 +1,876 @@
+# SDKv2-backed branch
+
+For a managed resource still implemented with `terraform-plugin-sdk/v2` (anything in
+`ionoscloud/resource_*.go`). Reference implementation, read it before writing anything:
+
+- `ionoscloud/resource_datacenter.go` — the identity side
+- `ionoscloud/resource_datacenter_list.go` — the list resource, 170 lines end to end
+- `ionoscloud/list_resources.go` — registration
+- `internal/framework/identity/sdkv2.go` — the two shared helpers everything above leans on
+
+`ionoscloud/resource_ipblock_list.go` (optional `name`, explicit `Limit`) and
+`ionoscloud/resource_target_group_list.go` (lone-`id` identity, nested blocks) are the
+second and third worked examples.
+
+## Why this is not just "a framework list resource"
+
+List resources cannot be implemented in SDKv2, so the list resource is framework code
+even when the resource it lists is not. Two things follow, and both look like mistakes
+until you know why.
+
+- **The list resource lives in package `ionoscloud`, beside the SDKv2 resource — not
+  under `internal/framework/services/`.** It has to. A result is produced by calling the
+  managed resource's own `resource<Resource>()`, `set<Resource>Data()` and
+  `set<Resource>Identity()`, all unexported, and the import cannot be turned around:
+  `ionoscloud/provider_test.go` is an *in-package* test (`package ionoscloud`) that
+  imports `internal/framework/provider`, so any `internal/framework/...` → `ionoscloud`
+  import is a cycle in the test build. Exporting the setters does not help. Other providers
+  colocate for the same reason: terraform-provider-aws puts
+  `internal/service/batch/job_definition_list.go` in `package batch` beside
+  `job_definition.go` and calls `resourceJobDefinitionFlatten`, the function
+  `resourceJobDefinitionRead` calls; terraform-provider-scaleway puts
+  `internal/services/vpc/vpc_list.go` in `package vpc` and calls `ResourceVPC()` and
+  `setVPCState`. If someone proposes moving it "where the framework code lives", this is
+  the answer.
+- **The framework has to be handed the managed resource's protocol schemas by hand.**
+  That is the `list.ListResourceWithRawV6Schemas` interface, and `identity.SetRawV6Schemas`
+  fills it from the SDKv2 `*schema.Resource` via `ProtoSchema` / `ProtoIdentitySchema`
+  plus `terraform-plugin-mux/tf5to6server/translate`
+  (`internal/framework/identity/sdkv2.go:24-42`).
+
+Two dead ends, both already walked:
+
+- **Do not obtain the schemas via `tf5to6server.UpgradeServer` + `GetProviderSchema`.** It
+  works, but it stands up a second gRPC server and builds protocol schemas for every
+  resource and data source to keep one. The original #1034 did this and it was replaced.
+  Do not copy terraform-provider-aws's `ListResourceWithSDKv2Resource` *struct* either —
+  that base exists to carry registry-injected state and to mutate the schema; with none of
+  that, a plain function is enough.
+- **Do not write a Go struct mirroring the SDKv2 schema.** That was the original shape and
+  it shipped broken; §2d has the story and the mechanism that replaced it.
+
+---
+
+## §1 — Resource identity on the SDKv2 resource
+
+**Hard prerequisite.** A resource with no `Identity` cannot be listed:
+`resourceSchema.ProtoIdentitySchema(ctx)` returns a **nil func** (not a func returning nil,
+`core_schema.go:419-423`), `SetRawV6Schemas` gives up, and `RawV6Schemas` has no
+diagnostics channel — the only trace is a `tflog.Error` line. Debugging that from the
+terraform side is miserable, and the failure is not local: see the end of §3.
+
+### 1a. The `Identity` block
+
+```go
+func resource<Resource>() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resource<Resource>Create,
+		ReadContext:   resource<Resource>Read,
+		UpdateContext: resource<Resource>Update,
+		DeleteContext: resource<Resource>Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resource<Resource>Import,
+		},
+		// The identity is what a `list "<ionoscloud_type>"` block streams back for
+		// each <resource> it finds, and what an import block can be written against.
+		// Terraform requires every read of a resource that declares an identity to
+		// return one, see set<Resource>Identity.
+		Identity: &schema.ResourceIdentity{
+			Version: 0,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+						Description:       "The UUID of the <resource>.",
+					},
+					"location": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+						Description:       "The location the <resource> lives in. Only needed when the Cloud API endpoint is overridden per location.",
+					},
+				}
+			},
+		},
+		Schema:   map[string]*schema.Schema{ /* unchanged */ },
+		Timeouts: &resourceDefaultTimeouts,
+	}
+}
+```
+
+Constraints enforced by `(*ResourceIdentity).InternalIdentityValidate()` — and already
+checked by `ionoscloud/provider_test.go`'s `Provider().InternalValidate()`, so a malformed
+identity fails a *unit* test, not an acceptance run:
+
+- exactly one of `RequiredForImport` / `OptionalForImport` per attribute — never both, never
+  neither;
+- only `TypeBool`, `TypeFloat`, `TypeInt`, `TypeString`, and `TypeList` of those.
+  `TypeMap` and `TypeSet` are rejected;
+- no `ForceNew`, `Required`, `Optional`, `Computed`, `Sensitive`, validators or defaults.
+  `Description` is allowed.
+
+`RequiredForImport` vs `OptionalForImport`: mark it Required only if the import genuinely
+cannot proceed without it. Datacenter's `location` is Optional because
+`bundleclient.SdkBundle.NewCloudAPIClient(ctx, "")` tolerates an empty location and falls back
+to the global endpoint. A product whose client cannot be built without a location makes it
+Required — that is what the framework-native clusters do.
+
+**Only declare what addresses the resource.** `ionoscloud_target_group` has no `location`
+attribute at all — the collection is global — so its identity is a lone `id`
+(`ionoscloud/resource_target_group.go:34-45`). Do not add a `location` for symmetry with
+datacenter and ipblock; every identity attribute has to be set on every read (1b), and one
+that is always empty is one more thing to keep stable.
+
+**Child resource** — one attribute per parent ID, named as the resource's own schema names
+them, all Required:
+
+```go
+			Identity: &schema.ResourceIdentity{
+				Version: 0,
+				SchemaFunc: func() map[string]*schema.Schema {
+					return map[string]*schema.Schema{
+						"datacenter_id": {Type: schema.TypeString, RequiredForImport: true, Description: "..."},
+						"server_id":     {Type: schema.TypeString, RequiredForImport: true, Description: "..."},
+						"id":            {Type: schema.TypeString, RequiredForImport: true, Description: "..."},
+						"location":      {Type: schema.TypeString, OptionalForImport: true, Description: "..."},
+					}
+				},
+			},
+```
+
+No child resource in the repo declares an identity yet — this is the extrapolation from the
+existing composite import IDs, not shipped code. Say so if you build one.
+
+### 1b. The identity setter
+
+```go
+// set<Resource>Identity writes the resource identity from the <resource> already in
+// state. Terraform errors out with "Missing Resource Identity After Read" if a
+// resource that declares an identity finishes a read without returning one.
+func set<Resource>Identity(d *schema.ResourceData) error {
+	identity, err := d.Identity()
+	if err != nil {
+		return err
+	}
+
+	if err := identity.Set("id", d.Id()); err != nil {
+		return fmt.Errorf("error while setting id identity attribute for <resource> %s: %w", d.Id(), err)
+	}
+
+	if err := identity.Set("location", d.Get("location")); err != nil {
+		return fmt.Errorf("error while setting location identity attribute for <resource> %s: %w", d.Id(), err)
+	}
+
+	return nil
+}
+```
+
+**Set every attribute, on every read, forever.** SDKv2's `ReadResource` compares the whole
+identity object with `RawEquals` against the previous one and fails with "Unexpected Identity
+Change" on any difference. Setting only some attributes avoids the "missing identity" error
+(the check is "null or *every* attribute null") but walks into the stability check instead.
+
+**This function is also the list resource's identity mapper**, verbatim — the list resource
+calls it on a `ResourceData` it built itself (§2c). It reads out of state (`d.Id()`,
+`d.Get(...)`) and never touches an API response, which is what makes that reuse work.
+
+### 1c. Call sites
+
+```go
+func resource<Resource>Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// ... build client, GET the object
+
+	if err != nil {
+		if httpNotFound(apiResponse) {
+			d.SetId("")   // drift: no identity needed, terraform short-circuits on an empty ID
+			return nil
+		}
+		return diagutil.ToDiags(d, err, nil)
+	}
+
+	if err := set<Resource>Data(d, &<resource>); err != nil {
+		return diagutil.ToDiags(d, err, nil)
+	}
+
+	// must run AFTER set<Resource>Data: the identity reads attributes that only the
+	// data setter fills in (this matters most on an identity-based import).
+	if err := set<Resource>Identity(d); err != nil {
+		return diagutil.ToDiags(d, err, nil)
+	}
+
+	return nil
+}
+```
+
+- The 404 branch correctly returns **before** setting an identity: `grpc_provider.go` returns
+  a null state early when the ID is empty, before any identity handling.
+- **Create** always needs the same call unless it ends with
+  `return resource<Resource>Read(ctx, d, meta)`. There is no prior identity to inherit
+  (`create == true`, `grpc_provider.go:1571-1573`), so without it `ApplyResourceChange` fails
+  with "Missing Resource Identity After Create".
+- **Update is different, and the reason is easy to get wrong.** (The comment that got it wrong
+  was on `resourceIPBlockUpdate` and has since been corrected — read
+  `ionoscloud/resource_ipblock.go:216-228` for the right wording; datacenter's Update delegates
+  to Read and carries no such comment.) The SDK carries the prior identity into the apply on its
+  own — `grpc_provider.go:1425` → `:1461` → `resource_data.go:856-857` → `:521-544` — so an
+  update that never touches the identity still returns one and "Missing Resource Identity After
+  Update" does *not* fire. The call is a safety net for state written before the resource
+  declared an identity (e.g. `-refresh=false` on an old state file), not the everyday path. Say
+  that in the comment; do not copy the Create rationale onto Update.
+- **Whatever Update writes must equal the prior identity byte for byte.**
+  `grpc_provider.go:1585` compares the returned identity against the planned one with
+  `RawEquals` and fails with "Unexpected Identity Change" unless `ResourceBehavior`
+  sets `MutableIdentity`. Derive from state (`d.Get(...)`), never from an API response.
+- **Prefer ending Update with `return resource<Resource>Read(ctx, d, meta)`** where the
+  resource has computed attributes to refresh — it solves both points at once and is what
+  datacenter does. Only add the explicit write when the update genuinely cannot delegate,
+  as `resourceIPBlockUpdate` cannot.
+- If Update does *not* delegate to read, the acceptance test needs an update step that changes
+  a **non-ForceNew** attribute only, or `resource<Resource>Update` is never entered at all.
+  Check the resource's existing `*ConfigUpdate` fixture first: `ionoscloud/resource_ipblock_test.go`
+  flips `size`, which is `ForceNew`, so that step is a destroy-and-create and covers nothing.
+- Delete needs nothing.
+
+### 1d. The importer — dual mode, and the `d.SetId` that is easy to miss
+
+Terraform sends an **empty `req.ID`** for an identity-based import; the real identifier is
+only in `d.Identity()`. So the importer must look at the identity first, and must set the ID
+itself before anything that reports on the resource.
+
+```go
+func resource<Resource>Import(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	<resource>ID, location, err := <resource>ImportParts(d)
+	if err != nil {
+		return nil, err
+	}
+
+	// Terraform sends an empty ID for an identity-based import, so the ID has to be
+	// set here for the error diagnostics and the log line below to name the resource.
+	d.SetId(<resource>ID)
+
+	client, err := meta.(bundleclient.SdkBundle).NewCloudAPIClient(ctx, location)
+	if err != nil {
+		return nil, err
+	}
+
+	<resource>, apiResponse, err := client.<Api>.<FindById>(ctx, <resource>ID).Execute()
+	logApiRequestTime(apiResponse)
+	if err != nil {
+		if httpNotFound(apiResponse) {
+			d.SetId("")
+			return nil, diagutil.ToError(d, fmt.Errorf("unable to find <resource> %q", <resource>ID), nil)
+		}
+		return nil, diagutil.ToError(d, fmt.Errorf("an error occurred while retrieving the <resource>: %w", err), nil)
+	}
+
+	tflog.Info(ctx, "<resource> imported", map[string]any{"resource_id": d.Id()})
+
+	if err := set<Resource>Data(d, &<resource>); err != nil {
+		return nil, diagutil.ToError(d, err, nil)
+	}
+
+	if err := set<Resource>Identity(d); err != nil {
+		return nil, diagutil.ToError(d, err, nil)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+// <resource>ImportParts resolves the <resource> to import, either from the resource
+// identity - which is how an import block with an `identity` argument, and the
+// import config that `terraform query` generates, address a <resource> - or from the
+// "<location>:<<resource>-id>" import string.
+func <resource>ImportParts(d *schema.ResourceData) (<resource>ID, location string, err error) {
+	if identity, identityErr := d.Identity(); identityErr == nil {
+		if id, ok := identity.GetOk("id"); ok {
+			loc, _ := identity.Get("location").(string)
+			<resource>ID, _ = id.(string)
+			return <resource>ID, loc, nil
+		}
+	}
+
+	// unchanged legacy string path: keep the delimiter, the part count and the error
+	// message the resource already used.
+	importID := d.Id()
+	location, parts := splitImportID(importID, ":")
+	if len(parts) != 1 {
+		return "", "", fmt.Errorf("invalid import identifier: expected one of <location>:<<resource>-id> or <<resource>-id>, got: %s", importID)
+	}
+
+	if err := validateImportIDParts(parts); err != nil {
+		return "", "", fmt.Errorf("failed validating import identifier %q: %w", importID, err)
+	}
+
+	return parts[0], location, nil
+}
+```
+
+Three things worth knowing:
+
+- `identity.GetOk("id")` returns `exists=false` for the schema type's **zero value**, so an
+  empty identity `id` does not take the identity branch — it falls through to the legacy
+  path, where `splitImportID` yields `[""]` and `validateImportIDParts` rejects it. No API
+  call with an empty ID is reachable. **Copilot will flag this as a missing validation. It is
+  a false positive** — this exact exchange happened on #1034.
+  **But that invariant is `splitImportID`'s, not the resolver's.** A resource with a plain
+  (non-composite) import ID has no reason to call `splitImportID` at all, and then nothing
+  rejects `""` — the fall-through returns `d.Id()` verbatim and the API is called with an
+  empty ID. If your resolver does not go through `splitImportID`, add the guard yourself:
+  `if d.Id() == "" { return "", fmt.Errorf("invalid import identifier: expected a <resource> UUID, got an empty string") }`.
+  See `targetGroupImportID` in `ionoscloud/resource_target_group.go:405-418`.
+- `d.Identity()` returns an *error*, not nil, when the resource declares no identity schema —
+  which is why the resolver treats a non-nil `identityErr` as "fall back to the string import"
+  rather than a failure.
+- The legacy string path must be preserved unchanged. This is a pure prepend.
+- Child resources: `d.SetId(parts[n])` **plus** `d.Set("datacenter_id", …)` etc. before
+  `set<Resource>Identity` runs, since the setter reads the parent IDs back out of state.
+
+`splitImportID` and `validateImportIDParts` live in `ionoscloud/utils.go` and are used by most
+SDKv2 resources (`grep -l 'splitImportID(' ionoscloud/*.go`). Note the unrelated `splitImportID` in
+`internal/framework/services/objectstorage/resource_object.go` — different package, different
+contract.
+
+---
+
+## §2 — The list resource
+
+File: `ionoscloud/resource_<resource>_list.go`, package `ionoscloud`.
+
+**There is no package decision to make.** The file goes next to the resource it lists, always,
+for the reason at the top of this document. `internal/framework/services/compute` is data
+sources only — nothing on this branch belongs there. A **framework-native** list resource still
+goes in its product's `internal/framework/services/<product>/` package; that branch is
+unaffected (`framework-native-branch.md`).
+
+### 2a. Header, assertions, struct, constructor
+
+```go
+// A list resource for <ionoscloud_type>, whose managed resource is still
+// implemented with terraform-plugin-sdk/v2 and therefore lives on the other half of
+// the mux. The protocol schemas the framework needs come from that resource via
+// identity.SetRawV6Schemas.
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
+
+	fwidentity "github.com/ionos-cloud/terraform-provider-ionoscloud/v6/internal/framework/identity"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/bundleclient"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
+)
+
+//
+// It lives in this package, next to the resource it lists, so it can call
+// resource<Resource>, set<Resource>Data and set<Resource>Identity directly. That is
+// the whole design: results are produced by the resource's own state writer, so this
+// file declares no model of the <resource> schema and there is nothing here to keep
+// in sync when that schema changes.
+
+var (
+	_ list.ListResource                 = (*<resource>ListResource)(nil)
+	_ list.ListResourceWithConfigure    = (*<resource>ListResource)(nil)
+	_ list.ListResourceWithRawV6Schemas = (*<resource>ListResource)(nil)
+)
+
+// <resource>ListResource lists <ionoscloud_type> instances.
+type <resource>ListResource struct {
+	bundle *bundleclient.SdkBundle
+
+	// resourceSchema is the SDKv2 managed resource being listed: the source of the
+	// protocol schemas returned by RawV6Schemas, and of the ResourceData every
+	// result is written into.
+	resourceSchema *schema.Resource
+}
+
+// New<Resource>ListResource creates a new list resource for <ionoscloud_type>.
+func New<Resource>ListResource() list.ListResource {
+	return &<resource>ListResource{resourceSchema: resource<Resource>()}
+}
+```
+
+- **The constructor takes no arguments.** It calls `resource<Resource>()` itself, so it *is* a
+  `func() list.ListResource` and registration needs no wrapper closure (§3). Do not add a
+  `*schema.Resource` parameter back; there is nothing to inject and nothing to fail.
+- `resource<Resource>()` is called **once**, at construction, and the resulting `*schema.Resource`
+  is kept for the life of the list resource. It is used for two things and never mutated:
+  `RawV6Schemas` reads the protocol schemas off it, and every mapped item gets a fresh
+  `ResourceData` from it (§2c). Do not call it per item — one `*schema.Resource` serves any
+  number of `Data()` calls.
+- **Use `constant.<Resource>Resource`, do not declare a local type-name const.** The type name
+  must exactly match the `ResourcesMap` key in `ionoscloud/provider.go`, or terraform has no
+  managed resource to attach the results to — and `provider.go:97,98,136` keys that map with
+  `constant.DatacenterResource`, `constant.IpBlockResource`, `constant.TargetGroupResource`.
+  Referencing the same constant makes the match structural instead of a convention two string
+  literals have to keep. This file is in `package ionoscloud`, so the constant is one import away
+  (`utils/constant`); the list resources in `internal/framework/services/` predate that and use
+  literals because they were written in a package that did not import it.
+
+### 2b. The four boilerplate methods
+
+```go
+// RawV6Schemas hands the framework the protocol schemas of the SDKv2 managed
+// resource. A framework-native list resource inherits them from the resource
+// itself; this is only needed because <ionoscloud_type> lives on the SDKv2 side.
+func (r *<resource>ListResource) RawV6Schemas(ctx context.Context, _ list.RawV6SchemaRequest, resp *list.RawV6SchemaResponse) {
+	fwidentity.SetRawV6Schemas(ctx, resp, constant.<Resource>Resource, r.resourceSchema)
+}
+
+// Metadata returns the type name of the managed resource being listed. It must match
+// the SDKv2 resource exactly, otherwise terraform has no resource to attach the
+// results to.
+func (r *<resource>ListResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = constant.<Resource>Resource
+}
+
+// Configure stores the client bundle shared by the provider.
+func (r *<resource>ListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	clientBundle, ok := req.ProviderData.(*bundleclient.SdkBundle)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected List Resource Configure Type",
+			fmt.Sprintf("Expected *bundleclient.SdkBundle, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.bundle = clientBundle
+}
+
+// ListResourceConfigSchema returns the schema for the list resource config block.
+func (r *<resource>ListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+	resp.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			fwidentity.FiltersKey: fwidentity.FilterAttribute("<field1>", "<field2>"),
+		},
+	}
+}
+```
+
+- **`internal/framework/identity` is imported as `fwidentity` here.** In package `ionoscloud`,
+  `identity` is already the name of the SDKv2 `*schema.IdentityData` that `d.Identity()` returns
+  and that `set<Resource>Identity` operates on (`ionoscloud/resource_datacenter.go:341`), so an
+  unaliased import would make `identity.` mean two unrelated things a few lines apart. Go imports
+  are file-scoped and the two never collide in one file today, so this is **readability, not a
+  compiler requirement** — but all three list resources do it, and the SDKv2 identity is the
+  reading a maintainer of this package expects. Keep the alias.
+- `Metadata` sets the **full** type name; it does not prepend `req.ProviderTypeName` the way
+  framework-native resources do.
+- `Metadata` and `Configure` take `resource.MetadataRequest` / `resource.ConfigureRequest`,
+  **not** `list.MetadataRequest` / `list.ConfigureRequest`. Both decoys exist in the vendored
+  package (`list/metadata.go`, `list/configure.go`), and picking one is a *compile* error —
+  because of the three `var _` assertions above, which is exactly why they must stay. Delete
+  the `ListResourceWithConfigure` assertion and it becomes silent instead: `Configure` is not
+  part of `list.ListResource`, so a `list.ConfigureRequest` signature compiles, the framework's
+  `listResource.(list.ListResourceWithConfigure)` type assertion just fails
+  (`vendor/.../internal/fwserver/server_listresource.go:105`), `Configure` is never called,
+  `r.bundle` stays nil and `List` nil-derefs at runtime.
+- The `req.ProviderData == nil` early return is mandatory — `Configure` is called once before
+  provider configuration completes.
+- `FilterAttribute(allowed...)` attaches `stringvalidator.OneOf`, so an unknown `field_name`
+  is a plan-time error. Calling it with *no* arguments leaves it unvalidated and a typo
+  silently matches nothing.
+
+### 2c. `List` and the mapper
+
+```go
+func (r *<resource>ListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
+	fwidentity.StreamList(ctx, stream, req,
+		func(ctx context.Context) ([]<sdk>.<Resource>, error) {
+			client, err := r.bundle.NewCloudAPIClientWithFailover(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create the Cloud API client: %w", err)
+			}
+
+			// Depth(1) is what makes the API return the properties of every <resource>
+			// instead of just its links. Filtering stays client-side, in the mapper.
+			// Add .Limit(...) if this endpoint's SDK default is lower than the sibling
+			// data source's — /ipblocks, /targetgroups and user management default to 100,
+			// not 1000 (SKILL.md step 0.5, decision 1).
+			items, apiResponse, err := client.<Api>.<ListCall>(ctx).Depth(1).Execute()
+			if apiResponse != nil {
+				tflog.Debug(ctx, "listed <resource>s", map[string]any{"status_code": apiResponse.SafeStatusCode()})
+			}
+			if err != nil {
+				return nil, fmt.Errorf("failed to list <resource>s: %w", err)
+			}
+			if items.Items == nil {
+				return nil, nil
+			}
+
+			return *items.Items, nil
+		},
+		r.map<Resource>,
+	)
+}
+
+// map<Resource> maps a <resource> to an identity.MappedItem, or returns nil to skip it.
+//
+// The mapping itself is set<Resource>Data, the same state writer resource<Resource>Read
+// uses, run against a ResourceData built from the live schema. Nothing here knows what
+// attributes a <resource> has.
+func (r *<resource>ListResource) map<Resource>(_ context.Context, includeResource bool, filters []fwidentity.Filter, item <sdk>.<Resource>) (*fwidentity.MappedItem, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if item.Id == nil || item.Properties == nil {
+		return nil, nil
+	}
+
+	name := shared.ToValueDefault(item.Properties.Name)
+	// … one local per filterable field
+
+	if !fwidentity.MatchesFilters(map[string]string{
+		"<field1>": name,
+		// … exactly the keys passed to FilterAttribute above
+	}, filters) {
+		return nil, nil
+	}
+
+	data := r.resourceSchema.Data(&terraform.InstanceState{})
+	if err := set<Resource>Data(data, &item); err != nil {
+		diags.AddError("Failed to map the <resource>", err.Error())
+		return nil, diags
+	}
+
+	// set<Resource>Identity reads id and location back out of the ResourceData, so it
+	// has to run after set<Resource>Data.
+	if err := set<Resource>Identity(data); err != nil {
+		diags.AddError("Failed to map the <resource> identity", err.Error())
+		return nil, diags
+	}
+
+	mapped, err := fwidentity.MappedItemFromResourceData(name, data, includeResource)
+	if err != nil {
+		diags.AddError("Failed to convert the <resource> state", err.Error())
+		return nil, diags
+	}
+
+	return mapped, diags
+}
+```
+
+Those last three statements are the entire mapping. §2d explains why that is enough.
+
+**`DisplayName` when `name` is optional.** `DisplayName` is the label `terraform query` prints
+for each row. Datacenter's `name` is `Required: true`, so `shared.ToValueDefault(item.Properties.Name)`
+is always populated — but that is not general: `ionoscloud/resource_ipblock.go:51-54` has
+`"name": {Type: schema.TypeString, Optional: true}`, and the SDK property is
+`Name *string \`json:"name,omitempty"\``. Nothing enforces non-emptiness (the framework only
+reads `DisplayName` to detect a diagnostics-only event,
+`fwserver/server_listresource.go:189`), so an unnamed item silently renders as a blank row.
+**Check the SDKv2 schema**: if `name` is not `Required: true`, fall back —
+
+```go
+	displayName := shared.ToValueDefault(item.Properties.Name)
+	if displayName == "" {
+		displayName = *item.Id
+	}
+```
+
+and pass `displayName` to `MappedItemFromResourceData` instead of `name`. `resource_ipblock_list.go`
+is the worked example; see also the matching stub warning in `test-harness.md` — the default
+two-result stub template asserts a display name that an optional-name resource cannot produce.
+
+`shared.ToValueDefault[T any](ptr *T) T` (`github.com/ionos-cloud/sdk-go-bundle/shared`,
+vendored at `vendor/.../shared/utils.go:21-27`) is the repo-wide nil-safe deref. Use it from any
+package and add the import; **never declare a local copy**. A hand-rolled `valueOrZero` helper
+used to live in package `compute` and was deleted in favour of this — do not reintroduce it,
+anywhere.
+
+**`StreamList` semantics you must respect:**
+
+| mapper returns | effect |
+|---|---|
+| `(nil, nil)` | item skipped silently, loop continues |
+| `(nil, diags-with-error)` | item skipped; only `diags[0].Detail()` is logged at WARN, nothing reaches the user |
+| `(non-nil, nil)` with `Identity == nil` | error result pushed, **stream aborts** |
+| `(non-nil, diags-with-error)` | **stream aborts** — the diags are appended before the error check |
+| `(non-nil, nil)`, identity set | result pushed |
+
+So: `return nil, diags` for a recoverable per-item problem, `return mapped, nil` to include.
+That is why every failure branch in the template above returns `nil, diags` and only the tail
+returns `mapped`. `objectstorage/resource_bucket_list.go` returns `(mapped, diags)` on a per-item
+error, which truncates the whole listing on one bad item. **Do not copy that.**
+
+Also: `fetch` runs eagerly, exactly once, before streaming — the "stream" is over an
+already-materialised slice, and any pagination must live inside `fetch`. `req.Limit` is
+ignored by `StreamList`. `fetch` errors lose all structure except `err.Error()` under a fixed
+`"Failed to list resources"` summary, so wrap with context.
+
+**Regional products** fan out inside `fetch`, copying
+`internal/framework/services/pgsqlv2/resource_pg_cluster_list.go`. Note that the filters have
+to be decoded a *second* time there, because `StreamList` decodes them for the mapper but does
+not pass them to `fetch`:
+
+```go
+			var filters []identity.Filter
+			req.Config.GetAttribute(ctx, path.Root(identity.FiltersKey), &filters)
+
+			locations := <product>service.AvailableLocations()
+			if loc := identity.FilterValue(filters, "location"); loc != "" {
+				locations = []string{loc}
+			}
+```
+
+**No `//nolint` on that line — copy the mariadbv2 form.** `Config.GetAttribute` returns
+`diag.Diagnostics`, not an `error` (`vendor/.../tfsdk/config.go:34`; `diag.Diagnostics` has no
+`Error()` method), so `errcheck` has nothing to report and a directive is dead weight. pgsqlv2
+(`resource_pg_cluster_list.go:53`) and inmemorydbv2 (`:49`) do carry `//nolint:errcheck`, but
+**bare, with no explanation** — they pass only because CI lints the diff
+(`--new-from-rev`), so they are grandfathered and your new copy is not. A bare `//nolint`
+fails `nolintlint`'s `require-explanation` (`.golangci.yml:82-84`) on your own line. Where you
+*do* need a directive, the repo's well-formed shape is
+`//nolint:prealloc // the number of streamed results is not known upfront`.
+
+Pushing a filter down to the API does not exempt you from re-checking it in the mapper. Do not
+add this second decode to a non-regional resource that does not need it — and note that
+**no Cloud API resource is regional**; see SKILL.md step 0.5 decision 4. There is no
+`AvailableLocations()` outside `services/dbaas/{pgsqlv2,mariadbv2,inmemorydbv2}`, so for a
+Cloud API resource the `<product>service.AvailableLocations()` line above cannot be filled in
+at all — that is the signal you are on the wrong branch, not something to work around.
+
+### 2d. No model — the result is the resource's own state
+
+The three statements at the end of the mapper are the whole mapping:
+
+```go
+	data := r.resourceSchema.Data(&terraform.InstanceState{})
+	set<Resource>Data(data, &item)     // the resource's OWN state writer, the one Read uses
+	set<Resource>Identity(data)        // AFTER the writer — it reads values back out
+	fwidentity.MappedItemFromResourceData(displayName, data, includeResource)
+```
+
+**Do not add a Go struct mirroring the SDKv2 schema.** `MappedItem.Identity` and
+`MappedItem.Resource` are `any`, so one compiles; it is the shape this design replaced.
+
+#### Why no model is possible
+
+Both halves of a list result are rendered from **one** `configschema.Block`:
+
+- the *type* the framework builds the result against comes from `resp.ProtoV6Schema`, which
+  `SetRawV6Schemas` fills with `translate.Schema(resourceSchema.ProtoSchema(ctx)())`, and
+  `ProtoSchema` is `convert.ConfigSchemaToProto(ctx, r.CoreConfigSchema())`
+  (`core_schema.go:407-416`);
+- the *value* comes from `rd.TfTypeResourceState()`, which is
+  `schemaMap(d.schema).CoreConfigSchema()` plus the injected `id` and `timeouts`
+  (`resource_data.go:84-163`).
+
+Two renderings of the same source, so they cannot disagree — where a hand-written struct is a
+third, independent rendering that has to be kept equal to both by hand. Same for the identity:
+`ProtoIdentitySchema` and `TfTypeIdentityState` both go through
+`schemaMap(r.Identity.SchemaMap()).CoreConfigSchema()` (`core_schema.go:397-404`,
+`resource_data.go:67-82`).
+
+The motivation, in two sentences: PR #1034 shipped a `datacenterResourceModel` mirroring the
+datacenter schema while an unrelated Confidential Computing PR was independently adding
+`cpu_architecture.enabled_features` to that schema, and the merge left `master` failing every
+`terraform query` on `ionoscloud_datacenter` with *"Object defines fields not found in struct:
+enabled_features"*. The fix was to delete the duplicate, not to guard it.
+
+#### What each of the three lines does
+
+**`r.resourceSchema.Data(&terraform.InstanceState{})`** returns a `*schema.ResourceData` built
+from the live schema over an empty state (`resource.go:1405-1426`). Two details matter:
+
+- it goes through `schemaMapWithIdentity{r.SchemaMap(), r.Identity.SchemaMap()}`
+  (`schema.go:650-674`), so the `ResourceData` carries the **identity** schema as well — that is
+  what lets `set<Resource>Identity`'s `d.Identity()` succeed. `r.Apply` builds its `ResourceData`
+  from the same pair (`resource.go:909-910`).
+- it then copies `result.timeouts = r.Timeouts`. That single assignment is what makes
+  `TfTypeResourceState` materialise a `timeouts` block at all — it only injects one when
+  `d.timeouts != nil` (`resource_data.go:98-145`). It is also the reason `nullTimeouts` exists,
+  below.
+
+**Use `Data`, not `TestResourceData`.** The latter builds the `ResourceData` struct directly
+and never assigns `timeouts` (`resource.go:1431-1436`), so `TfTypeResourceState` would omit the
+`timeouts` block while the result type — built from `r.CoreConfigSchema()`, which injects it
+whenever `r.Timeouts != nil` (`core_schema.go:325-330`) — still declares it, and `Set` would
+reject the value on the type comparison.
+
+Build a fresh one **per item**. It is state, and reusing it across items leaks values from the
+previous one into any attribute the writer leaves untouched.
+
+**Order: writer, then identity setter.** `set<Resource>Identity` reads back out of the
+`ResourceData` — `d.Id()` and `d.Get("location")` — so it can only run once the writer has put
+them there. This is the same ordering constraint as §1c, for the same reason.
+
+**The writer must call `d.SetId`.** Both conversions go through `ResourceData.State()`, which
+returns `nil` while the ID is empty (`resource_data.go:425-434`), and both then fail with
+`"state is nil, call SetId() on ResourceData first"`. Every `set<Resource>Data` in this package
+already begins with `d.SetId(*<resource>.Id)` because Read needs it too — check yours does before
+assuming it.
+
+**`fwidentity.MappedItemFromResourceData(displayName, data, includeResource)`**
+(`internal/framework/identity/sdkv2.go:44-89`) does the rest:
+
+- `rd.TfTypeIdentityState()` → `MappedItem.Identity`, and errors when it comes back nil, which is
+  the "you forgot the identity setter" message;
+- when `includeResource` is false it stops there — `terraform query` without `include_resource`
+  never pays for the resource conversion;
+- otherwise `rd.TfTypeResourceState()` → `nullTimeouts(...)` → `MappedItem.Resource`.
+
+Both values are `tftypes.Value` passed **by value, not by pointer**. `Set` type-asserts a
+`tftypes.Value` and takes a documented fast path — it compares
+`d.Schema.Type().TerraformType(ctx)` with `v.Type()` and assigns
+(`vendor/.../internal/fwschemadata/data_set.go:20-35`). A `*tftypes.Value` misses the assertion
+and falls through to struct reflection, which is exactly the machinery being avoided.
+
+`nullTimeouts` nulls the whole `timeouts` block out of the converted value. The flatmap shims
+cannot tell a null single block from an empty one, so they always materialise it as an object of
+null attributes; SDKv2's own `ReadResource` nulls it back out on every read of its own resources
+for the same reason. A listed resource has no timeouts either — they are configuration, not
+state — so doing the same keeps a query result identical to what a refresh writes. The unit test
+asserts it (`ionoscloud/resource_datacenter_list_test.go`).
+
+#### What the value looks like on the wire
+
+Still worth knowing, because the test asserts against it and the shapes are not obvious.
+
+`toproto6.DynamicValue` runs `ReifyNullCollectionBlocks`
+(`vendor/.../internal/toproto6/dynamic_value.go:29-30`, reached from
+`toproto6.ListResourceResultWithResource` → `toproto6.Resource`), which turns a null list/set
+**block** into an **empty** collection. Whether a nested schema is a block or an attribute is
+decided in `core_schema.go`: a nested schema that is `Computed` only becomes a protocol
+**attribute** (`:102-106` — "Computed-only schemas are always handled as attributes", which is
+datacenter's `cpu_architecture`), while one that is `Optional` (± `Computed`) becomes a nested
+**block** (`:108-112`, `:201-205` — which is ipblock's `ip_consumers`). So when the API omits it:
+
+- a Computed-only nested **attribute** decodes to `nil` → assert `assert.Nil`;
+- a nested **block** decodes to `[]any{}` → assert `assert.Equal(t, []any{}, second["<block>"])`.
+
+`MaxItems: 1` changes nothing here: `core_schema.go:201-205` sets `Nesting = NestingList` from
+`s.Type` before it ever looks at `MaxItems`, so such a block is still a list, is reified when
+absent, and decodes as a **one-element list** when present — assert `[]any{map[string]any{...}}`.
+`resource_target_group_list.go` has two of them (`health_check`, `http_health_check`). The
+injected `timeouts` is `NestingSingle`, so it is not reified and stays null, which is what
+`nullTimeouts` leaves behind.
+
+#### What is still coupled to the schema
+
+Nothing about the resource's *attributes*. When someone adds an attribute to
+`ionoscloud/resource_<resource>.go`, they update `set<Resource>Data` — which they have to do
+anyway for Read — and the list resource follows for free. There is no model to grep for, and no
+rebase-before-merge hazard for schema changes.
+
+Three things do remain hand-written and do need review when the resource changes:
+
+1. the filter keys — the strings in `FilterAttribute(...)` and in the `MatchesFilters` map must
+   stay identical, and both must name real, meaningful fields;
+2. the `Identity` block and `set<Resource>Identity` (§1), which the list resource calls directly;
+3. the `DisplayName` fallback, if `name` stops being `Required`.
+
+---
+
+## §3 — Registration
+
+`ionoscloud/list_resources.go`, one line per list resource:
+
+```go
+// ListResources returns the list resources for the managed resources in this package.
+//
+// List resources can only be implemented with terraform-plugin-framework, so a list
+// resource for a resource that is still on SDKv2 is framework code living in this
+// package. It has to be: the results are produced by the resource's own state writer,
+// which is unexported, and no package under internal/framework can import this one -
+// ionoscloud/provider_test.go is an in-package test that imports
+// internal/framework/provider, so an import back would be a cycle in the test build.
+func ListResources() []func() list.ListResource {
+	return []func() list.ListResource{
+		NewDatacenterListResource,
+		NewIPBlockListResource,
+		NewTargetGroupListResource,
+	}
+}
+```
+
+That is the entire registration. The constructors are named directly, not wrapped in
+`func() list.ListResource { … }`, because they already have that signature (§2a).
+
+**No lookup, no `ok` branch, no nil guard.** Adding a list resource is one line here and
+nothing else. `New<Resource>ListResource` calls `resource<Resource>()` in-package: it cannot
+miss, cannot return nil and has no error path, so there is nothing to guard and nothing to
+degrade to. If you find yourself reaching for a `*schema.Provider` or a `ResourcesMap` lookup
+to get at the schema, you are in the wrong package — the schema is one function call away (§2a),
+and no provider is threaded to the framework side any more (§4).
+
+**Never register a list resource without schemas.** The framework raises "ListResource Type
+Defined without a Matching Managed Resource Type"
+(`vendor/.../fwserver/server_listresources.go:99-109`) when a list resource has no matching
+framework resource *and* `RawV6Schemas` supplied neither schema, and `GetProviderSchema` —
+terraform's very first RPC — returns on that error
+(`vendor/.../fwserver/server_getproviderschema.go:84-88`), killing the **whole provider** for
+every operation, not just `terraform query`.
+
+The one remaining way to walk into it is **removing or forgetting the `Identity` block on the
+SDKv2 resource** (§1). Then `ProtoIdentitySchema` is a nil func, `SetRawV6Schemas` returns
+having set nothing but a `tflog.Error`, and the provider dies at the first RPC. There is no
+guard left that could quietly unregister the list resource instead, so treat the `Identity`
+block as load-bearing for the entire provider, not just for this feature. The unit test is
+what catches it: `TestDatacenterListResource` asserts
+`providerSchema.ListResourceSchemas[<type>]` exists right after `GetProviderSchema`
+(`ionoscloud/resource_datacenter_list_test.go:44-57`).
+
+---
+
+## §4 — Provider wiring
+
+**For a new SDKv2-backed list resource there is no provider wiring to do.** One line in
+`ionoscloud/list_resources.go` (§3) is the whole registration. `internal/framework/provider/provider.go`,
+`main.go`, `xpprovider`, `internal/acctest` and `internal/framework/identity/sdkv2.go` need no
+edit at all. This is the part of the design that got simpler; do not go looking for a second
+place to register.
+
+For context, the wiring that already exists:
+
+```go
+// New creates a new provider. sdkv2ListResources are the list resources declared
+// alongside the SDKv2 managed resources they list, normally ionoscloud.ListResources();
+// passing none is allowed, and then only the framework-native list resources are served.
+func New(sdkv2ListResources ...func() list.ListResource) provider.Provider {
+	return &IonosCloudProvider{sdkv2ListResources: sdkv2ListResources}
+}
+```
+
+(`internal/framework/provider/provider.go:64-69`), and the slice is appended alongside the
+framework-native packages in `ListResources` (`:336-353`):
+
+```go
+	listResources := [][]func() list.ListResource{
+		objectstorage.ListResources(),
+		objectstoragemanagement.ListResources(),
+		pgsqlv2.ListResources(),
+		inmemorydbv2.ListResources(),
+		mariadbv2.ListResources(),
+		p.sdkv2ListResources,
+	}
+```
+
+`New` is variadic so that `provider.New(ionoscloud.ListResources()...)` reads as a call and an
+empty slice needs no special case. Every construction site already passes it:
+
+| call site | |
+|---|---|
+| `main.go:41` | the served provider |
+| `xpprovider/provider.go:16` | crossplane / upjet |
+| `internal/acctest/acctest.go:55` | acceptance tests |
+| `internal/framework/provider/provider_test.go:60` | framework provider tests |
+| `ionoscloud/provider_test.go:69`, `:91` | the v5 and v6 mux factories |
+| `ionoscloud/resource_datacenter_list_test.go:164` | the list-resource unit test harness |
+
+Touch these only if you add a **new** entry point that builds the provider. A framework-native
+list resource in a **new** service package is the one case that still needs a `provider.go`
+edit: add that package's `ListResources()` to the slice above.
+
+`resp.ListResourceData = client` is already set in `Configure` alongside the other three.

--- a/.claude/skills/add-list-resource/references/test-harness.md
+++ b/.claude/skills/add-list-resource/references/test-harness.md
@@ -1,0 +1,528 @@
+# Test harness
+
+Reference: `ionoscloud/resource_datacenter_list_test.go` (package `ionoscloud_test`). It drives
+the real `ListResource` RPC end to end against a stubbed Cloud API, through the same mux
+`main.go` serves — no acceptance test, no credentials, and it runs in well under a second. It is
+the oldest of the three list-resource tests in `ionoscloud/` (datacenter, ipblock,
+target_group); the five framework-native list resources under `internal/framework/services/`
+have none. Copy it, and read `ionoscloud/resource_target_group_list_test.go` too for the
+lone-`id` identity and the `MaxItems: 1` blocks.
+
+New file: `ionoscloud/resource_<resource>_list_test.go`, package `ionoscloud_test` — beside the
+list resource, which lives beside the SDKv2 resource it lists. The **external** test package is
+what the three existing tests use: it keeps names as generic as `decode`, `listResults` and
+`dynamicValue` out of package `ionoscloud`'s own namespace, and it forces the test through the
+same exported surface `main.go` uses, `ionoscloud.Provider()` and `ionoscloud.ListResources()`.
+
+No `//go:build` tag. That is deliberate — it keeps the test cheap to run and puts it in
+golangci-lint's scope (which only analyses the default build). `ionoscloud/` has 115 test files
+and only ten of them are untagged, so an untagged file costs nothing to run and, unlike the
+other 105, needs no `TF_ACC` and no credentials.
+
+---
+
+## What this test pins — there is no model any more
+
+The list resource declares no struct mirroring the SDKv2 schema. Each result is
+
+```go
+	data := r.resourceSchema.Data(&terraform.InstanceState{})
+	set<X>Data(data, &item)
+	set<X>Identity(data)
+	fwidentity.MappedItemFromResourceData(displayName, data, includeResource)
+```
+
+so the code under test is the resource's **own state writer**, the one `resource<X>Read` calls,
+plus the conversion in `internal/framework/identity/sdkv2.go`. What the assertions pin is
+therefore not "the resource model fills the SDKv2 schema without a type mismatch" — nothing
+fills anything — but: **the state the resource's own writer produces survives the round trip
+through `ResourceData.TfTypeResourceState` into the list-result schema**, including the
+`timeouts` block that `MappedItemFromResourceData` nulls back out
+(`internal/framework/identity/sdkv2.go:82-89`, `nullTimeouts` at `:99-121`).
+
+Put that in the test's doc comment. Datacenter's says exactly it
+(`ionoscloud/resource_datacenter_list_test.go:26-35`). The ipblock and target_group headers
+still carry the older "the resource model fills the SDKv2 schema" sentence from before the
+refactor — do not copy that one forward.
+
+---
+
+## Shape
+
+```go
+func Test<Resource>ListResource(t *testing.T) {
+	ctx := context.Background()
+
+	t.Setenv("IONOS_API_URL", stub<Resource>API(t))
+	t.Setenv("IONOS_TOKEN", "token-for-the-stub")
+
+	server := muxedProviderServer(ctx, t)
+
+	providerSchema, err := server.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema: %v", err)
+	}
+	failOnErrorDiagnostics(t, "GetProviderSchema", providerSchema.Diagnostics)
+
+	// The framework only registers a list resource that has no framework resource
+	// behind it once RawV6Schemas has supplied both protocol schemas.
+	if _, ok := providerSchema.ListResourceSchemas[<resource>ListType]; !ok {
+		t.Fatalf("the <resource> list resource was not registered; check RawV6Schemas and the SDKv2 resource identity")
+	}
+	if _, ok := providerSchema.ResourceSchemas[<resource>ListType]; !ok {
+		t.Fatalf("the <resource> managed resource is missing from the merged schema")
+	}
+
+	identitySchemas, err := server.GetResourceIdentitySchemas(ctx, &tfprotov6.GetResourceIdentitySchemasRequest{})
+	if err != nil {
+		t.Fatalf("GetResourceIdentitySchemas: %v", err)
+	}
+	failOnErrorDiagnostics(t, "GetResourceIdentitySchemas", identitySchemas.Diagnostics)
+
+	identitySchema := identitySchemas.IdentitySchemas[<resource>ListType]
+	if identitySchema == nil {
+		t.Fatalf("the SDKv2 <resource> resource does not declare a resource identity")
+	}
+
+	configureProvider(ctx, t, server, providerSchema.Provider)
+
+	listSchema := providerSchema.ListResourceSchemas[<resource>ListType]
+	resourceType := providerSchema.ResourceSchemas[<resource>ListType].ValueType()
+
+	// ... the subtests
+}
+```
+
+Set the env vars **before** building the server: the framework provider's `Configure` reads
+`IONOS_API_URL` into `clientOptions.Endpoint`, and `bundleclient.shouldApplyOverridesCustomEnv`
+short-circuits to `false` whenever it is set — so the developer's real `~/.ionos/config`
+overrides are ignored and the test cannot accidentally hit a live endpoint.
+
+Declare `const <resource>ListType = "<ionoscloud_type>"` at package level (`goconst` flags a
+literal repeated 5+ times).
+
+---
+
+## The shared helpers already exist — copy none of them
+
+**Check first:**
+
+```bash
+ls ionoscloud/*_list_test.go
+```
+
+For the SDKv2 branch the answer is always "they are there". Every list resource for an SDKv2
+managed resource lands in package `ionoscloud` — there is no per-service split on this side of
+the mux — so there is exactly **one** test package for all of them, and the helpers are already
+declared in it, below `TestDatacenterListResource` in `resource_datacenter_list_test.go`. They
+are package-level declarations shared by every file in `ionoscloud_test`, and re-declaring them
+is 14 `redeclared in this block` errors.
+
+The only things you write per resource are:
+
+- `const <resource>ListType = "<ionoscloud_type>"`
+- `Test<Resource>ListResource`
+- `stub<Resource>API` — **rename it.** The existing `stubCloudAPI` is pinned to `/datacenters`
+  (`ionoscloud/resource_datacenter_list_test.go:212`); reusing the name is the one collision
+  that does not announce itself, because a same-named stub compiles and then 404s every request
+  your resource makes.
+- the subtests
+
+**Do not copy the driver.** `listResults(ctx, t, server, typeName, schema, filters)` already
+takes the type name as a parameter for exactly this reason: the type name is the *only* thing
+that differs per resource, so call the shared one
+(`ionoscloud/resource_datacenter_list_test.go:247`). Copying it was the original instruction
+here and it is what produced two near-identical drivers before `ionoscloud_ipblock` landed.
+
+`resource_ipblock_list_test.go` and `resource_target_group_list_test.go` are the worked
+examples of this: each is a type-name const, one `Test<X>ListResource`, one `stub<X>API` and
+its subtests, and nothing else. Both say so in their header comment ("The shared helpers it
+calls … are declared once for the package in resource_datacenter_list_test.go") — keep that
+line, it is what stops the next author re-copying them.
+
+Do **not** change the reference test's *assertions or stub* — those are what make
+`resource_datacenter_list_test.go` the reference. Adding to, or parameterising, the shared
+helpers it calls is fine and expected.
+
+**Where the shared helpers live.** They are in `resource_datacenter_list_test.go` for
+historical reasons, so every author in `ionoscloud/` has to learn from a comment that the
+infrastructure lives in another resource's file. Do not reproduce that in a *new* package: for
+a framework-native list resource in `internal/framework/services/<service>/` (which has no list
+test at all today), put them in `list_resource_test_helpers_test.go` from the start, never
+inside a file named after one resource. That copy has to import
+`.../v6/ionoscloud` for `Provider()` and `ListResources()` — legal from an **external**
+`<service>_test` package, since `ionoscloud`'s non-test files import nothing under
+`internal/framework/services/` (only `internal/framework/identity`, `internal/serverutil` and
+`internal/tf/writeonly`); a cycle from an in-package one.
+
+The table below is for that **new** package. Take them verbatim from
+`ionoscloud/resource_datacenter_list_test.go`:
+
+| Helper | What it does |
+|---|---|
+| `muxedProviderServer(ctx, t)` | `ionoscloud.Provider()` → `tf5to6server.UpgradeServer` → `tf6muxserver.NewMuxServer(ctx, providerserver.NewProtocol6(fwprovider.New(ionoscloud.ListResources()...)), upgraded)` — mirrors `main.go:31-47` |
+| `configureProvider(ctx, t, server, schema)` | `ConfigureProvider` with an all-null config so credentials come from the env |
+| `decode(t, value, valueType)` | `*tfprotov6.DynamicValue` → `map[string]any` |
+| `goValue(t, value)` | recursive `tftypes.Value` → plain Go |
+| `readValue(t, value, target)` | `value.As(target)` with a fatal on mismatch |
+| `identityType(schema)` | identity schema → `tftypes.Object` type |
+| `nullObject(t, objectType)` | all-null object value |
+| `dynamicValue(t, valueType, value)` | `tfprotov6.NewDynamicValue` with a fatal |
+| `failOnErrorDiagnostics(t, rpc, diags)` | fail on the first error diagnostic |
+| `hasErrorDiagnostic(diags)` | bool, for the negative test |
+| `listServerAndConfig(t, server, schema, filters)` | casts to `ProviderServerWithListResource`, builds the config |
+| `listConfig(t, configType, filters)` | builds the `filters` list value |
+
+Take the driver as `listResults(ctx, t, server, typeName, schema, filters)` — parameterised by
+type name, one copy per package. `stubCloudAPI` → `stub<Resource>API`, one per resource.
+
+Two lint notes on the copied code: keep the `//nolint:staticcheck` on `listServerAndConfig`
+(with its explanation — `ListResource` still lives on a temporary interface in
+terraform-plugin-go, `resource_datacenter_list_test.go:279`) and the `//nolint:prealloc` on the
+results slice (`:261`). `nolintlint` requires directives to be both specific and explained; a
+bare `//nolint` is itself an error.
+
+### `goValue` — the part that matters
+
+```go
+	case valueType.Is(tftypes.Number):
+		var number big.Float
+		readValue(t, value, &number)
+		// Every number in the <resource> schema is a TypeInt, so this keeps a single
+		// integer representation and fails loudly rather than silently switching to a
+		// float if that ever stops being true.
+		if !number.IsInt() {
+			t.Fatalf("expected a whole number, got %s", number.String())
+		}
+		n, _ := number.Int64()
+		return n
+```
+
+**Decode numbers as `int64`, never `float64`.** `testifylint`'s `float-compare` rule rejects
+`assert.Equal` on a float and demands `InDelta`/`InEpsilon`; it is **not** excluded in test
+files by `.golangci.yml`. This cost a red CI round on #1034. The `IsInt()` guard is a
+tripwire: if the schema ever grows a genuine `TypeFloat`, the test fails loudly instead of
+degrading silently. Porting to a resource that really has a float attribute means adding a
+float branch **and** switching those assertions to `assert.InDelta` — not deleting the guard.
+
+**`goValue` has no `tftypes.Map` and no `tftypes.Tuple` case** — the default branch
+`t.Fatalf`s. `schema.TypeMap` is common in this provider, so a resource with one needs:
+
+```go
+	case valueType.Is(tftypes.Map{}):
+		var elements map[string]tftypes.Value
+		readValue(t, value, &elements)
+		converted := make(map[string]any, len(elements))
+		for name, element := range elements {
+			converted[name] = goValue(t, element)
+		}
+		return converted
+```
+
+`tftypes.Value.As` accepts only `*string`, `*big.Float`, `*bool`, `*map[string]Value`,
+`*[]Value` (and `**` variants). `tftypes` `Is()` is a plain kind check, so
+`valueType.Is(tftypes.List{})` with a zero-value argument works.
+
+---
+
+## The stub
+
+```go
+// stub<Resource>API serves the <resource> collection the list resource reads, and returns
+// the URL to point IONOS_API_URL at. Every other path 404s on purpose, so an unexpected
+// extra request surfaces as an error diagnostic instead of succeeding.
+func stub<Resource>API(t *testing.T) string {
+	t.Helper()
+
+	<resource>s := ionoscloudsdk.<Resource>s{
+		Items: &[]ionoscloudsdk.<Resource>{
+			{
+				// Result 1: every property the writer reads is set.
+				Id: new("00000000-0000-0000-0000-000000000001"),
+				Properties: &ionoscloudsdk.<Resource>Properties{ /* all fields */ },
+			},
+			{
+				// Result 2: only the properties the API always returns, so that the
+				// optional ones can be asserted null. Keep `name` set here even when the
+				// schema makes it optional — the display-name and filter assertions below
+				// are what make result 2 load-bearing, and they need a name to match on.
+				// Omit some *other* optional attribute instead.
+				Id: new("00000000-0000-0000-0000-000000000002"),
+				Properties: &ionoscloudsdk.<Resource>Properties{ /* required fields only */ },
+			},
+			{
+				// Result 3 — ONLY when `name` is Optional in the SDKv2 schema. Covers the
+				// displayName fallback (`ionoscloud/resource_ipblock_list.go:156-163`),
+				// which result 2 cannot reach because it keeps `name` set. Without this
+				// the fallback branch is dead code the test never enters.
+				Id: new("00000000-0000-0000-0000-000000000003"),
+				Properties: &ionoscloudsdk.<Resource>Properties{ /* required fields, Name unset */ },
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/<collection-path>") {
+			http.NotFound(w, r)
+			return
+		}
+		// The request the fetch closure builds is part of what is under test — the stub
+		// answers any query string identically, so without these the options are unpinned.
+		if got := r.URL.Query().Get("depth"); got != "1" {
+			t.Errorf("expected depth=1 on the <collection-path> request, got %q", got)
+		}
+		// …and one per explicit .Limit(...)/other option the closure passes.
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(<resource>s); err != nil {
+			t.Errorf("failed to write the stubbed response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return server.URL
+}
+```
+
+- `new("prod")` is the **Go 1.26 built-in** `new(value)`, not a local helper. `go.mod` declares
+  `go 1.26.3`, so it compiles. Copilot has claimed it does not (this exact exchange happened on
+  #1034); it is wrong. There is no repo-local `ptr`/`toPtr` helper, but note the vendored SDK
+  does export one — `ionoscloudsdk.ToPtr` (`sdk-go/v6/utils.go:30`), already imported by the
+  reference test — so "no helper exists" is not the argument to make. Either compiles; `new`
+  needs no import.
+- **Assert the query params the fetch closure sets** — at minimum `depth`, and `limit`
+  whenever decision 1 in `SKILL.md` made you pass an explicit one. Dropping `.Depth(1)` in
+  production means every `Properties` is nil and the writer is never reached; dropping
+  `.Limit(...)` means silent truncation at the SDK client's fallback (100 for `/ipblocks`,
+  `sdk-go/v6/api_ip_blocks.go:487-489` — note that fallback is the *client's*, not the
+  endpoint's). Neither is visible to a stub that ignores the query string, and the mutation
+  check below never reaches the fetch closure.
+  The reference stub is the wrong model for this one thing: `stubCloudAPI` asserts no query
+  parameters at all. Copy the assertion block from
+  `ionoscloud/resource_ipblock_list_test.go:244-256` or
+  `ionoscloud/resource_target_group_list_test.go:251-263` instead, including the comment
+  explaining why the limit is asserted as a literal rather than as `constant.<X>Limit` — that
+  literal is the only thing tying `docs/list-resources/<resource>.md` to the code.
+- Match on `strings.HasSuffix`, not an exact path — the SDK prefixes `/cloudapi/v6`.
+  Everything else 404s **on purpose**: an unexpected extra call (a pagination follow-up, a
+  second region) surfaces as an error diagnostic rather than silently succeeding.
+- A **regional** product fans out, so the handler must serve more than one path and the test
+  must assert the union. A **paginated** one makes more than one request, so key off
+  `r.URL.Query()`.
+- **sdk-go-bundle products: `IONOS_API_URL` does not necessarily win.** Six product clients
+  read `IONOS_API_URL_<PRODUCT>` as a real endpoint override — `services/cert/provider.go:27-36`,
+  `services/vpn/client.go:75-86`, `services/objectstoragemanagement/accesskeys.go:44-54`, plus
+  `nfs`, `dbaas/mariadb`, `dbaas/inmemorydb` — and `utils/loadedconfig/loadedconfig.go:50`
+  *defers* `ChangeConfigURL`, so it overwrites whatever `IONOS_API_URL` set. Worse, a regional
+  client called with a non-empty location replaces the endpoint from that product's
+  `locationToURL` map — a **production** URL — regardless of either variable. So for a bundle
+  product, set `IONOS_API_URL_<PRODUCT>` as well, and read the product's client constructor
+  before assuming your stub is reachable at all.
+
+---
+
+## The subtests
+
+```go
+	t.Run("streams every <resource>", func(t *testing.T) {
+		results := listResults(ctx, t, server, <resource>ListType, listSchema, nil)
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(results))
+		}
+
+		assert.Equal(t, "<display-name-1>", results[0].DisplayName)
+
+		identity := decode(t, results[0].Identity.IdentityData, identityType(identitySchema))
+		assert.Equal(t, "<id-1>", identity["id"])
+		// one assert per identity attribute, plus an assert.Len on the identity map when
+		// its shape is the point (target_group's is a lone id, ipblock's is id+location)
+
+		// Every attribute the writer fills is asserted here, so that writing a value to
+		// the wrong key fails the test.
+		resource := decode(t, results[0].Resource, resourceType)
+		assert.Equal(t, "<id-1>", resource["id"])
+		// one assert per attribute set<X>Data sets; int attributes as int64(...)
+		assert.ElementsMatch(t, []any{...}, resource["<set-attribute>"])   // TypeSet: order is not stable
+		assert.Equal(t, []any{map[string]any{ /* nested block */ }}, resource["<nested-block>"])
+		assert.Nil(t, resource["timeouts"], "a listed <resource> has no timeouts")
+
+		// The second <resource> reports only the properties the API always sets, which
+		// pins that the pairing holds past the first result and that the properties the
+		// API left out stay null instead of turning into zero values.
+		assert.Equal(t, "<display-name-2>", results[1].DisplayName)
+
+		second := decode(t, results[1].Resource, resourceType)
+		assert.Equal(t, "<id-2>", second["id"])
+		assert.Nil(t, second["<optional-attribute>"])
+		// one assert.Nil per omitted optional ATTRIBUTE. For an omitted nested BLOCK
+		// (Optional ± Computed with an Elem: &schema.Resource{}) assert []any{} instead —
+		// the framework reifies a null list/set block to an empty one. ipblock's
+		// ip_consumers is the worked example, with the citations, at
+		// ionoscloud/resource_ipblock_list_test.go:121-128.
+
+		// Only when `name` is Optional: the display-name fallback, and the name still null.
+		assert.Equal(t, "<id-3>", results[2].DisplayName)
+		third := decode(t, results[2].Resource, resourceType)
+		assert.Nil(t, third["name"])
+	})
+
+	// ONE SUBTEST PER FIELD in the FilterAttribute(...) allow-list. MatchesFilters returns
+	// false for a field_name the mapper forgot to put in its map, so an untested field is a
+	// filter that silently matches nothing, forever, while the other subtests stay green.
+	t.Run("filters by <field1>", func(t *testing.T) {
+		results := listResults(ctx, t, server, <resource>ListType, listSchema, map[string]string{"<field1>": "<value-matching-only-result-2>"})
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		assert.Equal(t, "<display-name-2>", results[0].DisplayName)
+	})
+
+	// … one more like it per remaining allowed field …
+
+	// Two fields whose values match DIFFERENT stub items: pins that the filters are ANDed,
+	// and that neither field is wired to the other's property.
+	t.Run("applies every filter", func(t *testing.T) {
+		results := listResults(ctx, t, server, <resource>ListType, listSchema, map[string]string{
+			"<field1>": "<value-matching-result-1>",
+			"<field2>": "<value-matching-result-2>",
+		})
+		if len(results) != 0 {
+			t.Fatalf("expected 0 results, got %d", len(results))
+		}
+	})
+
+	t.Run("rejects unknown filter fields", func(t *testing.T) {
+		listServer, config := listServerAndConfig(t, server, listSchema, map[string]string{"nope": "value"})
+
+		resp, err := listServer.ValidateListResourceConfig(ctx, &tfprotov6.ValidateListResourceConfigRequest{
+			TypeName: <resource>ListType,
+			Config:   &config,
+		})
+		if err != nil {
+			t.Fatalf("ValidateListResourceConfig: %v", err)
+		}
+		if !hasErrorDiagnostic(resp.Diagnostics) {
+			t.Fatalf("expected a validation error for an unknown filter field")
+		}
+	})
+```
+
+The last subtest is fully generic and fails if the list resource declares
+`identity.FilterAttribute()` with no allowed-field list. When a *deliberate* non-filterable
+attribute exists, put it in the same loop as the bogus field —
+`ionoscloud/resource_target_group_list_test.go:177-192` does that for `protocol`, so widening
+the allow-list cannot pass unnoticed.
+
+---
+
+## What each assertion is actually catching
+
+- **`ListResourceSchemas[type]` AND `ResourceSchemas[type]`, from one `GetProviderSchema`.**
+  The first catches a list resource that is silently *not registered* — a typo in the type
+  constant, or forgetting to add `New<Resource>ListResource` to
+  `ionoscloud/list_resources.go:15-21`, produces a provider that starts fine and just has no
+  list resource. The second catches a double registration: the merged schema must still serve
+  the SDKv2 managed resource under the same name, pinning that the framework side registered
+  *only* a list resource (`tf6muxserver` refuses duplicate type names).
+- **`GetResourceIdentitySchemas`** catches a missing `Identity` on the SDKv2 resource, and
+  proves it survives the protocol upgrade. The schema is then reused as the decode type for
+  the identity, so a mismatch between the identity schema and what `set<X>Identity` writes
+  surfaces as an unmarshal failure rather than a silent pass.
+- **The per-attribute asserts are what replaced the deleted model.** Nothing in the build
+  restates a `<resource>`'s shape any more, so if `set<X>Data` writes a value under the wrong
+  key there is no compiler, no `tfsdk` tag and no reviewer diff to catch it — only these
+  assertions and `Set`'s own type check on the way in
+  (`vendor/.../terraform-plugin-framework/internal/fwschemadata/data_set.go:20-35`, the
+  `tftypes.Value` fast path `MappedItemFromResourceData` is written to hit). Assert **every**
+  attribute the writer fills.
+- **Asserting the SECOND result** catches three distinct bugs: *pairing drift* (item N's
+  identity attached to item N's resource, not shifted or hoisted), *zero-value leakage*
+  (an omitted *attribute* comes back null, not `""`/`false`/`[]` — an omitted nested *block*
+  is the documented exception and comes back `[]any{}`), and *filter false-positives* (a filter
+  that is silently a no-op fails on the count; one matching the wrong item fails on the display
+  name).
+- **`assert.Nil(t, resource["timeouts"], …)`** pins `nullTimeouts`. `Resource.Data` always
+  attaches the resource's `Timeouts` (`vendor/.../helper/schema/resource.go:1414-1418`), and
+  the flatmap shims cannot tell a null single block from an empty one, so
+  `TfTypeResourceState` hands back a `timeouts` object of null attributes;
+  `MappedItemFromResourceData` nulls the whole block back out
+  (`internal/framework/identity/sdkv2.go:82-89`), exactly as SDKv2's own `ReadResource` does.
+  Drop that step and a query result carries a timeouts object that a refresh never writes —
+  this assertion is the only thing that would notice.
+- **`result.Identity == nil` / `result.Resource == nil` inside the driver** catch the
+  `MappedItem.Identity must not be nil` contract violation
+  (`internal/framework/identity/list.go:59-63`) and a mapper that ignores `includeResource`.
+
+---
+
+## Running it
+
+```bash
+go test ./ionoscloud/ -run 'Test<Resource>ListResource' -count=1
+```
+
+Subtest names: spaces become underscores —
+`-run 'Test<Resource>ListResource/applies_every_filter'`.
+
+No `TF_ACC`, no `-tags`, no credentials. Nothing in CI runs this for you — see
+`verify-and-pr.md` §1.
+
+---
+
+## The mutation check — mandatory, not advice
+
+The original #1034 test looked thorough and asserted almost nothing: its decoder returned
+`map[string]string` and skipped every non-string attribute, so a writer that swapped two int
+fields still passed. **Prove your assertions are load-bearing before claiming coverage.**
+
+The thing to mutate is no longer a mapper of the list resource's own. It is `set<X>Data`, in
+`ionoscloud/resource_<resource>.go` — **a different file from the one you just wrote**, and the
+same file that holds the `Identity` block and `set<X>Identity` you added in step 1. So:
+
+> **Revert the mutation by hand.** `git checkout -- ionoscloud/resource_<resource>.go` would
+> throw the whole identity implementation away with it.
+
+Swap **two adjacent struct fields, or two adjacent map keys, of the same Go type** — same type,
+so it still compiles and the failure has to come from an assertion, not the compiler.
+
+List the writer's fields by Go type, then mutate one same-typed adjacent pair **per distinct
+type present**, preferring a pair inside a nested block (datacenter's `max_cores` ↔ `max_ram`
+in the `cpu_architecture` entry, `ionoscloud/resource_datacenter.go:415-421`, is the ideal
+case: both are `*int32`, it exercises the nested path and the `int64` decode at once). Most
+resources will not have that luxury — ipblock's nested `IpConsumer` is nine `*string` fields
+and its only number, `size`, has no same-typed neighbour at all. Where a type has no pair,
+verify it the other way: **change that field's value in the stub** and confirm the assertion
+fails. A `*string` pair in the top-level writer is always available and always
+worth doing, as is swapping the two *values* in `set<X>Identity`
+(`identity.Set("id", d.Get("location"))` and vice versa) when the identity has two attributes
+— datacenter's and ipblock's `id` + `location`; target_group's lone `id` has no pair, so
+change its value in the stub instead.
+
+```bash
+# 1. mutate one pair in ionoscloud/resource_<resource>.go, then:
+go test ./ionoscloud/ -run 'Test<Resource>ListResource' -count=1
+#    -> MUST fail, with the assertion diff naming the two swapped attributes.
+# 2. revert BY HAND (see the warning above), then
+# 3. confirm green again.
+```
+
+**Four mutations the field-swap cannot reach — they live in the list resource file, which
+`set<X>Data` mutations never touch. Run them too:**
+
+- **Delete `.Depth(1)`** (and the explicit `.Limit(...)`, if there is one) from the fetch
+  closure. The test MUST fail — on the stub's query assertions, which is why they are not
+  optional.
+- **Swap the two values in the `MatchesFilters` map** (`"name": location, "location": name`).
+  Only the per-field filter subtests catch this; with a single filter subtest it passes.
+- **Swap the `set<X>Data` and `set<X>Identity` calls.** The identity setter reads its values
+  back out of the `ResourceData`, so running it first leaves the identity empty. The identity
+  assertions on `results[0]` are the only thing that fails.
+- **Only for an optional-`name` resource:** delete the
+  `if displayName == "" { displayName = *item.Id }` fallback. The result-3 display-name
+  assertion MUST fail.
+
+If step 1 **passes**, the assertion set is incomplete — an attribute the writer fills is not
+asserted, or is asserted against a value equal to its neighbour's. Add the missing assertion
+before moving on. Do the same on a field only stub result 2 leaves unset, to confirm the
+`assert.Nil` block is real too.
+
+Report the mutation check as done only if you actually ran it and saw it fail.

--- a/.claude/skills/add-list-resource/references/test-harness.md
+++ b/.claude/skills/add-list-resource/references/test-harness.md
@@ -3,20 +3,20 @@
 Reference: `ionoscloud/resource_datacenter_list_test.go` (package `ionoscloud_test`). It drives
 the real `ListResource` RPC end to end against a stubbed Cloud API, through the same mux
 `main.go` serves — no acceptance test, no credentials, and it runs in well under a second. It is
-the oldest of the three list-resource tests in `ionoscloud/` (datacenter, ipblock,
-target_group); the five framework-native list resources under `internal/framework/services/`
-have none. Copy it, and read `ionoscloud/resource_target_group_list_test.go` too for the
-lone-`id` identity and the `MaxItems: 1` blocks.
+the older of the two list-resource tests in `ionoscloud/` (datacenter, ipblock); the five
+framework-native list resources under `internal/framework/services/` have none. Copy it, and
+read `ionoscloud/resource_ipblock_list_test.go` too — it is the smaller worked example, and the
+one that covers an `Optional` `name`, a two-attribute identity and an omitted nested block.
 
 New file: `ionoscloud/resource_<resource>_list_test.go`, package `ionoscloud_test` — beside the
 list resource, which lives beside the SDKv2 resource it lists. The **external** test package is
-what the three existing tests use: it keeps names as generic as `decode`, `listResults` and
+what both existing tests use: it keeps names as generic as `decode`, `listResults` and
 `dynamicValue` out of package `ionoscloud`'s own namespace, and it forces the test through the
 same exported surface `main.go` uses, `ionoscloud.Provider()` and `ionoscloud.ListResources()`.
 
 No `//go:build` tag. That is deliberate — it keeps the test cheap to run and puts it in
-golangci-lint's scope (which only analyses the default build). `ionoscloud/` has 115 test files
-and only ten of them are untagged, so an untagged file costs nothing to run and, unlike the
+golangci-lint's scope (which only analyses the default build). `ionoscloud/` has 114 test files
+and only nine of them are untagged, so an untagged file costs nothing to run and, unlike the
 other 105, needs no `TF_ACC` and no credentials.
 
 ---
@@ -32,7 +32,9 @@ The list resource declares no struct mirroring the SDKv2 schema. Each result is
 	fwidentity.MappedItemFromResourceData(displayName, data, includeResource)
 ```
 
-so the code under test is the resource's **own state writer**, the one `resource<X>Read` calls,
+so the code under test is the resource's **own state writer** (`set<X>Data` above is a
+placeholder: `setDatacenterData` is unexported, `IpBlockSetData` is exported — use whichever
+name the resource already has), the one `resource<X>Read` calls,
 plus the conversion in `internal/framework/identity/sdkv2.go`. What the assertions pin is
 therefore not "the resource model fills the SDKv2 schema without a type mismatch" — nothing
 fills anything — but: **the state the resource's own writer produces survives the round trip
@@ -41,9 +43,9 @@ through `ResourceData.TfTypeResourceState` into the list-result schema**, includ
 (`internal/framework/identity/sdkv2.go:82-89`, `nullTimeouts` at `:99-121`).
 
 Put that in the test's doc comment. Datacenter's says exactly it
-(`ionoscloud/resource_datacenter_list_test.go:26-35`). The ipblock and target_group headers
-still carry the older "the resource model fills the SDKv2 schema" sentence from before the
-refactor — do not copy that one forward.
+(`ionoscloud/resource_datacenter_list_test.go:26-35`), and ipblock's repeats it and then adds a
+pointer to where the shared helpers live. If you meet a header still saying "the resource model
+fills the SDKv2 schema", that is the pre-refactor wording — do not copy it forward.
 
 ---
 
@@ -131,14 +133,16 @@ The only things you write per resource are:
 **Do not copy the driver.** `listResults(ctx, t, server, typeName, schema, filters)` already
 takes the type name as a parameter for exactly this reason: the type name is the *only* thing
 that differs per resource, so call the shared one
-(`ionoscloud/resource_datacenter_list_test.go:247`). Copying it was the original instruction
-here and it is what produced two near-identical drivers before `ionoscloud_ipblock` landed.
+(`ionoscloud/resource_datacenter_list_test.go:248`). If your resource needs something the
+shared driver does not do yet, add the parameter to it in place — that is exactly what turned
+it from a datacenter-only helper into `listResults` — rather than growing a second
+near-identical copy.
 
-`resource_ipblock_list_test.go` and `resource_target_group_list_test.go` are the worked
-examples of this: each is a type-name const, one `Test<X>ListResource`, one `stub<X>API` and
-its subtests, and nothing else. Both say so in their header comment ("The shared helpers it
-calls … are declared once for the package in resource_datacenter_list_test.go") — keep that
-line, it is what stops the next author re-copying them.
+`resource_ipblock_list_test.go` is the worked example of this: a type-name const, one
+`Test<X>ListResource`, one `stub<X>API` and its subtests, and nothing else. Its header comment
+says so ("The shared helpers it calls … are declared once for the package in
+resource_datacenter_list_test.go") — keep that line, it is what stops the next author
+re-copying them.
 
 Do **not** change the reference test's *assertions or stub* — those are what make
 `resource_datacenter_list_test.go` the reference. Adding to, or parameterising, the shared
@@ -178,8 +182,8 @@ type name, one copy per package. `stubCloudAPI` → `stub<Resource>API`, one per
 
 Two lint notes on the copied code: keep the `//nolint:staticcheck` on `listServerAndConfig`
 (with its explanation — `ListResource` still lives on a temporary interface in
-terraform-plugin-go, `resource_datacenter_list_test.go:279`) and the `//nolint:prealloc` on the
-results slice (`:261`). `nolintlint` requires directives to be both specific and explained; a
+terraform-plugin-go, `resource_datacenter_list_test.go:280`) and the `//nolint:prealloc` on the
+results slice (`:262`). `nolintlint` requires directives to be both specific and explained; a
 bare `//nolint` is itself an error.
 
 ### `goValue` — the part that matters
@@ -252,7 +256,7 @@ func stub<Resource>API(t *testing.T) string {
 			},
 			{
 				// Result 3 — ONLY when `name` is Optional in the SDKv2 schema. Covers the
-				// displayName fallback (`ionoscloud/resource_ipblock_list.go:156-163`),
+				// displayName fallback (`ionoscloud/resource_ipblock_list.go:166-171`),
 				// which result 2 cannot reach because it keeps `name` set. Without this
 				// the fallback branch is dead code the test never enters.
 				Id: new("00000000-0000-0000-0000-000000000003"),
@@ -298,8 +302,7 @@ func stub<Resource>API(t *testing.T) string {
   check below never reaches the fetch closure.
   The reference stub is the wrong model for this one thing: `stubCloudAPI` asserts no query
   parameters at all. Copy the assertion block from
-  `ionoscloud/resource_ipblock_list_test.go:244-256` or
-  `ionoscloud/resource_target_group_list_test.go:251-263` instead, including the comment
+  `ionoscloud/resource_ipblock_list_test.go:245-255` instead, including the comment
   explaining why the limit is asserted as a literal rather than as `constant.<X>Limit` — that
   literal is the only thing tying `docs/list-resources/<resource>.md` to the code.
 - Match on `strings.HasSuffix`, not an exact path — the SDK prefixes `/cloudapi/v6`.
@@ -308,10 +311,11 @@ func stub<Resource>API(t *testing.T) string {
 - A **regional** product fans out, so the handler must serve more than one path and the test
   must assert the union. A **paginated** one makes more than one request, so key off
   `r.URL.Query()`.
-- **sdk-go-bundle products: `IONOS_API_URL` does not necessarily win.** Six product clients
-  read `IONOS_API_URL_<PRODUCT>` as a real endpoint override — `services/cert/provider.go:27-36`,
-  `services/vpn/client.go:75-86`, `services/objectstoragemanagement/accesskeys.go:44-54`, plus
-  `nfs`, `dbaas/mariadb`, `dbaas/inmemorydb` — and `utils/loadedconfig/loadedconfig.go:50`
+- **sdk-go-bundle products: `IONOS_API_URL` does not necessarily win.** Several product clients
+  read `IONOS_API_URL_<PRODUCT>` as a real endpoint override (`grep -rn IONOS_API_URL_ services/`
+  lists them; `services/cert/provider.go:27-36`, `services/vpn/client.go:75-86` and
+  `services/objectstoragemanagement/accesskeys.go:44-54` are the shapes it takes) — and
+  `utils/loadedconfig/loadedconfig.go:50`
   *defers* `ChangeConfigURL`, so it overwrites whatever `IONOS_API_URL` set. Worse, a regional
   client called with a non-empty location replaces the endpoint from that product's
   `locationToURL` map — a **production** URL — regardless of either variable. So for a bundle
@@ -334,7 +338,7 @@ func stub<Resource>API(t *testing.T) string {
 		identity := decode(t, results[0].Identity.IdentityData, identityType(identitySchema))
 		assert.Equal(t, "<id-1>", identity["id"])
 		// one assert per identity attribute, plus an assert.Len on the identity map when
-		// its shape is the point (target_group's is a lone id, ipblock's is id+location)
+		// its shape is the point (ipblock's is id+location, so its test asserts Len 2)
 
 		// Every attribute the writer fills is asserted here, so that writing a value to
 		// the wrong key fails the test.
@@ -357,7 +361,7 @@ func stub<Resource>API(t *testing.T) string {
 		// (Optional ± Computed with an Elem: &schema.Resource{}) assert []any{} instead —
 		// the framework reifies a null list/set block to an empty one. ipblock's
 		// ip_consumers is the worked example, with the citations, at
-		// ionoscloud/resource_ipblock_list_test.go:121-128.
+		// ionoscloud/resource_ipblock_list_test.go:120-125.
 
 		// Only when `name` is Optional: the display-name fallback, and the name still null.
 		assert.Equal(t, "<id-3>", results[2].DisplayName)
@@ -408,9 +412,10 @@ func stub<Resource>API(t *testing.T) string {
 
 The last subtest is fully generic and fails if the list resource declares
 `identity.FilterAttribute()` with no allowed-field list. When a *deliberate* non-filterable
-attribute exists, put it in the same loop as the bogus field —
-`ionoscloud/resource_target_group_list_test.go:177-192` does that for `protocol`, so widening
-the allow-list cannot pass unnoticed.
+attribute exists, loop that subtest's body over both it and the bogus field
+(`for _, field := range []string{"nope", "<not-filterable>"}`), so that widening the allow-list
+cannot pass unnoticed. Neither existing test needs that today: datacenter and ipblock both
+allow every field their mapper puts in the `MatchesFilters` map.
 
 ---
 
@@ -418,8 +423,8 @@ the allow-list cannot pass unnoticed.
 
 - **`ListResourceSchemas[type]` AND `ResourceSchemas[type]`, from one `GetProviderSchema`.**
   The first catches a list resource that is silently *not registered* — a typo in the type
-  constant, or forgetting to add `New<Resource>ListResource` to
-  `ionoscloud/list_resources.go:15-21`, produces a provider that starts fine and just has no
+  constant, or forgetting to add `New<Resource>ListResource` to `ListResources()` in
+  `ionoscloud/list_resources.go`, produces a provider that starts fine and just has no
   list resource. The second catches a double registration: the merged schema must still serve
   the SDKv2 managed resource under the same name, pinning that the framework side registered
   *only* a list resource (`tf6muxserver` refuses duplicate type names).
@@ -431,7 +436,7 @@ the allow-list cannot pass unnoticed.
   restates a `<resource>`'s shape any more, so if `set<X>Data` writes a value under the wrong
   key there is no compiler, no `tfsdk` tag and no reviewer diff to catch it — only these
   assertions and `Set`'s own type check on the way in
-  (`vendor/.../terraform-plugin-framework/internal/fwschemadata/data_set.go:20-35`, the
+  (`vendor/.../terraform-plugin-framework/internal/fwschemadata/data_set.go:21-36`, the
   `tftypes.Value` fast path `MappedItemFromResourceData` is written to hit). Assert **every**
   attribute the writer fills.
 - **Asserting the SECOND result** catches three distinct bugs: *pairing drift* (item N's
@@ -494,7 +499,7 @@ verify it the other way: **change that field's value in the stub** and confirm t
 fails. A `*string` pair in the top-level writer is always available and always
 worth doing, as is swapping the two *values* in `set<X>Identity`
 (`identity.Set("id", d.Get("location"))` and vice versa) when the identity has two attributes
-— datacenter's and ipblock's `id` + `location`; target_group's lone `id` has no pair, so
+— datacenter's and ipblock's are both `id` + `location`. A lone-`id` identity has no pair, so
 change its value in the stub instead.
 
 ```bash

--- a/.claude/skills/add-list-resource/references/verify-and-pr.md
+++ b/.claude/skills/add-list-resource/references/verify-and-pr.md
@@ -78,6 +78,10 @@ from `dupl`/`errcheck`/`gocyclo`/`gosec`/`unparam`/`unused` — but **not** from
 
 ## 2. Branch, commit, PR
 
+**The skill run ends before this section.** SKILL.md's "Where the arc ends" leaves the work
+uncommitted in the working tree and closes by asking the user what to do next. Nothing below
+happens until that question comes back "commit it" / "open the PR".
+
 Branch: `feat/<resource>-list-resource-identity`. The repo's dominant style is
 `<type>/<kebab-slug>` with the same vocabulary as the commit prefix.
 

--- a/.claude/skills/add-list-resource/references/verify-and-pr.md
+++ b/.claude/skills/add-list-resource/references/verify-and-pr.md
@@ -1,0 +1,366 @@
+# Verification, PR, and answering the review
+
+## 1. What CI actually runs on a PR
+
+Eight checks, from three workflows that fire on `pull_request`. A fourth (`PR Comment Trigger`
+→ `E2E Tests`) exists but needs a human and real credentials — §5.
+
+**Compile-level breakage is gated. Behaviour is not.** `.github/workflows/build.yml` runs
+`go vet -tags=all ./...` on every pull request and every push to master, and `go vet` loads each
+package *together with its test files* — so a list-resource unit test that does not compile
+turns CI red, and so does a tagged acceptance test, since almost every tagged file in the repo
+opts into `all` (the three exceptions are `//go:build alb`, `natgateway` and `nlb`, which that
+job never compiles).
+
+But **no `pull_request`-triggered workflow runs `go test`.** `test.yml` and every
+`*-test-run.yml` are `workflow_dispatch`/`schedule` only, and `e2e.yaml` is `workflow_dispatch`
+as well. Nothing in CI *executes* the list-resource test. Green CI means your test compiles, not
+that it passes — running it is on you, and neither of these costs credentials, network or more
+than a second:
+
+```bash
+go test ./ionoscloud/ -run 'Test<Resource>ListResource' -count=1   # ladder rung 2
+go test ./ionoscloud/ -run 'TestProvider$' -count=1                # ladder rung 2b
+```
+
+| Check | Workflow | Command |
+|---|---|---|
+| `Run gofmt check` | Sonarcloud and gofmt | `gofmt -l -d` over `.` |
+| `Run go vet with all build tags` | Sonarcloud and gofmt | `go vet -tags=all ./...` — compiles test files too |
+| `Check go mod tidy and vendor` | Sonarcloud and gofmt | `go mod tidy` then `go mod vendor`, both must leave the tree clean |
+| `SonarCloud` / `SonarCloud Code Analysis` | Sonarcloud and gofmt | no local equivalent |
+| `detect-noop` | CI golangci-lint | skips lint entirely for a docs-only PR |
+| `lint` | CI golangci-lint | `golangci-lint run --timeout 10m0s --verbose --new-from-rev=origin/<base branch>` (v2.10.1) |
+| `build` | Broken Link Checker | `markdown-link-check` on modified `docs/**`, `CHANGELOG.md`, `README.md` |
+
+Local ladder: see the SKILL.md **Verification ladder** section. Do not re-derive it.
+
+### Linters most likely to bite
+
+`.golangci.yml` enables ~45 linters under `linters.enable` plus golangci-lint v2's `standard` group
+(`errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`). `_test.go` files are excluded
+from `dupl`/`errcheck`/`gocyclo`/`gosec`/`unparam`/`unused` — but **not** from `testifylint`,
+`revive`, `errorlint`, `goconst`, `prealloc`, `modernize`, `bodyclose` or `noctx`.
+
+1. **`testifylint`** — the only one that has already forced a commit on this work.
+   `float-compare` rejects `assert.Equal` on a float. See `test-harness.md`.
+   Its other relevant checks: `expected-actual` (expected value first), `require-error`
+   (`require`, not `assert`, for error assertions), `len`, `empty`, `nil-compare`.
+2. **`revive`**'s configured `import-alias-naming` with `allowRegex: "^[a-z][a-z0-9]*$"` — an
+   import alias may contain **no underscore and no uppercase letter**. `ionoscloudsdk`,
+   `fwidentity` and `fwprovider` pass; `fw_provider` and `sdkV2` fail.
+3. **`goconst`** (min-len 3, min-occurrences 5) — hence the package-level type-name const in
+   the test.
+4. **`prealloc`** — `make([]T, 0, len(src))`, not `var xs []T` before a range loop.
+5. **`gocyclo`** (min-complexity 25) — the list resource has nothing left that grows: `List` is
+   a fetch closure plus a call, and the mapper is a filter check, two setter calls and a
+   conversion. What can trip it is the resource's own `set<Resource>Data` if you extend it while
+   you are in there; split into a helper rather than growing one function.
+6. **`tagalign`** (`sort: true`, order `json, tfsdk, mapstructure`) — struct tags must be sorted
+   and aligned. `` `tfsdk:"id" json:"id"` `` fails. Only the framework-native branch can trip
+   it, on the managed resource's own model; the SDKv2 branch declares no tagged struct anywhere.
+7. **`nolintlint`** (`require-explanation`, `require-specific`) — a bare `//nolint` is itself
+   an error. Two live in the shared test helpers; keep their explanations when you move them.
+8. **`errorlint` / `nilerr`** — `%w` and `errors.Is`, never `==` on a sentinel; `nilerr`
+   catches `if err != nil { return nil }`, easy to write when swallowing a 404.
+9. **Formatters** `gofmt` + `goimports` with
+   `local-prefixes: github.com/ionos-cloud/terraform-provider-ionoscloud` — three import
+   groups: stdlib, third-party, then this module. The CI **gofmt** job runs plain `gofmt` and
+   does *not* check grouping; only golangci-lint's `goimports` does. Fix with
+   `golangci-lint fmt ./ionoscloud/...` (add
+   `./internal/framework/services/<service>/...` on the framework-native branch).
+
+**`lll` is NOT enabled** (it has a settings block but never appears under `enable`), nor is
+`dupl`. Do not wrap lines for a linter that is off.
+
+---
+
+## 2. Branch, commit, PR
+
+Branch: `feat/<resource>-list-resource-identity`. The repo's dominant style is
+`<type>/<kebab-slug>` with the same vocabulary as the commit prefix.
+
+Commits: conventional-commit prefixes (`feat:`, `fix:`, `refactor:`, `doc:`, `test:`, `chore:`),
+one-line subject, no body. **Every merge to master is a squash**, so the *PR title* becomes the
+master commit subject — that is why the checklist's first item is about the PR name.
+
+> **Everything in this section is a write the maintainer owns.** `git commit`, `git push`,
+> `gh pr create` and posting a review reply all happen **only on an explicit request** — never
+> as the last step of the checklist. This section documents *how*, for when you are asked. It
+> is not permission. Opening a PR also fires CI (`.github/workflows/build.yml`,
+> `linter.yaml`), so it is not a private action either.
+
+**Do not run `git commit` or `git push` unless explicitly asked.** The maintainer manages their
+own commits. When they do ask, use a single-line subject and a Claude co-author trailer naming
+**whichever model you actually are** — check the session rather than copying a name from here:
+
+```
+<one-line subject>
+
+Co-Authored-By: Claude <Model> <noreply@anthropic.com>
+```
+
+PR title, matching #1034:
+
+```
+feat: add <ionoscloud_type> list resource and resource identity
+```
+
+The template at `.github/pull_request_template.md` is not applied by `gh pr create` — pass it
+yourself. Filling in "What does this fix or implement?" is better than shipping the raw
+template, though most merged PRs leave it unfilled. The checklist's `label: upcoming release`
+is stale — no such label exists.
+
+**Public write on the org repo — only on an explicit request from the user.**
+
+```bash
+gh pr create --base master \
+  --title "feat: add <ionoscloud_type> list resource and resource identity" \
+  --body-file /path/to/pr-body.md
+```
+
+### Branch protection consequences
+
+`master` requires **1 human approval** with `dismiss_stale_reviews: true` and
+`required_conversation_resolution: true`; no status check is *required*.
+
+- Pushing a commit after an approval **throws the approval away** — batch review fixes into
+  one push.
+- **Every** review thread, including each Copilot inline thread, must be marked **resolved**
+  before merge. Replying is not enough.
+- Resolving is a write operation on someone else's review — only with explicit approval.
+
+---
+
+## 3. Reading the review — three endpoints, all needed
+
+`gh pr view` shows **none** of the inline review comments.
+
+```bash
+R=ionos-cloud/terraform-provider-ionoscloud
+
+# 1. INLINE review comments — the one gh pr view misses
+gh api repos/$R/pulls/<N>/comments --paginate \
+  --jq '.[] | {id, in_reply_to_id, user: .user.login, path, line, body}'
+
+# 2. REVIEW BODIES — the summaries AND the <details>Suppressed comments</details>
+#    findings that never became inline comments
+gh api repos/$R/pulls/<N>/reviews --paginate \
+  --jq '.[] | {id, user: .user.login, state, submitted_at, body}'
+
+# 3. TOP-LEVEL conversation comments (Sonar quality gate, human notes, test triggers)
+gh api repos/$R/issues/<N>/comments --paginate --jq '.[] | {id, user: .user.login, body}'
+```
+
+**Read endpoint 2.** The bot buries findings it decided not to post inline inside a
+`<details>Suppressed comments</details>` block in the *review body* — they appear in neither
+`gh pr view` nor the comments API. On #1034 the pagination finding first appeared only there.
+
+The bot's login differs per endpoint: `copilot-pull-request-reviewer[bot]` in `/reviews`,
+`Copilot` in `/pulls/{n}/comments`. Filter on both.
+
+Unresolved threads need GraphQL (the REST comments API has no `isResolved`):
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "ionos-cloud", name: "terraform-provider-ionoscloud") {
+    pullRequest(number: <N>) {
+      reviewThreads(first: 50) {
+        nodes { id isResolved isOutdated path comments(first: 10) { nodes { author { login } databaseId body } } }
+      }
+    }
+  }
+}'
+```
+
+Reply to an inline comment — no `gh pr` subcommand for this; use the inline comment's numeric
+`id` from endpoint 1, not the review id. Write the reply to a scratchpad file to avoid
+shell-quoting damage:
+
+```bash
+gh api --method POST -H "Accept: application/vnd.github+json" \
+  repos/$R/pulls/<N>/comments/<COMMENT_ID>/replies \
+  -f body="$(cat /path/to/reply.md)"
+```
+
+---
+
+## 4. What the bot review looks like on this repo
+
+- **Copilot reviews automatically on every push**, re-reviewing all files and re-raising
+  findings it previously suppressed. Expect 2–4 reviews on a multi-push PR, 1–4 inline
+  comments each.
+- **Recurring true positives:** docs drifting from code; the same fix not applied to a sibling
+  resource; missing regression coverage for the linked issue; vague CHANGELOG wording; a
+  leftover `replace` directive in `go.mod`.
+- **Recurring false positives:** confident claims about Go semantics that are wrong for this
+  module's Go version, and prescriptions to use a helper that does not exist in the package.
+  **Verify before complying.**
+- **Pagination is the finding a list-resource PR will get.** It was raised twice on #1034,
+  once suppressed and once inline. Decide the answer at step 0.5, not in review.
+- Human reviewers often reply *inside* the Copilot thread rather than opening a new one.
+
+### The reply shape that worked on #1034
+
+Three parts, every time:
+
+1. **A one-line verdict** — agree / disagree / agree-but-out-of-scope.
+2. **Evidence** — `path:line` citations into this repo or `vendor/`, or a named green CI check.
+3. **An explicit outcome** — `Leaving as is.` / `No change made.` / what changed instead.
+
+Never a bare "won't fix". Two worked examples:
+
+> *(false positive, refuted with a language fact)* `new(value)` does compile here. As of Go
+> 1.26 `new` accepts an expression and returns a pointer to it; this module declares
+> `go 1.26.3` and the package builds and tests green. No change made.
+
+Note what that reply deliberately leaves out: #1034's version also argued "there is no `ptr`
+helper in this package". True of the repo, but the vendored SDK exports `ionoscloudsdk.ToPtr`
+and the test already imports it — so the claim invites a correction and adds nothing. Refute on
+the language fact alone.
+
+> *(real finding, declined with a scope argument)* Correct that this reads a single page.
+> We have decided not to add pagination in this PR, and to document the limitation instead.
+> No datacenter read path in the provider paginates today — `ionoscloud/data_source_datacenter.go:147`
+> issues the identical unpaginated call, and provider-wide there is exactly one offset/limit
+> loop (`services/dbaas/pgsqlv2/cluster.go:20-49`). So this is a pre-existing provider-wide gap
+> rather than something this PR introduces, better fixed uniformly in its own change. What did
+> change: `docs/list-resources/datacenter.md` now states … One correction to the detail in the
+> comment: the vendored SDK's doc comment says "Default limit is the first 100 items", but the
+> generated code for *this* endpoint sends `limit=1000`
+> (`vendor/github.com/ionos-cloud/sdk-go/v6/api_data_centers.go:489`); which the server honours
+> is unverified.
+
+**Do not reuse that number.** It is per-endpoint — `/ipblocks`, `/targetgroups` and user
+management default to 100 — so re-run the grep in `docs-and-changelog.md` §2a for your own
+endpoint before writing a number into a public reply. Re-check every `path:line` in a canned
+reply before posting it, too; they drift.
+
+Correcting a factual error in the bot's comment, where there is one, is worth doing — it stops
+the same wrong number propagating into the docs.
+
+---
+
+## 5. Acceptance tests (optional, costs real cloud resources)
+
+The SDKv2 acceptance test for the resource is tagged
+(`//go:build compute || all || <resource>`, e.g. `ionoscloud/resource_datacenter_test.go:1`) and
+does not run on a PR. **Never fire it unprompted** — it runs against real IONOS credentials and
+creates live resources.
+
+What fires it: `.github/workflows/pr-comment-trigger.yaml` — an `issue_comment` on a PR from an
+OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR. Read its two halves separately, because they do not
+agree:
+
+- the step's `if` is a plain `contains(github.event.comment.body, '/test')`, so **any**
+  top-level PR comment containing that literal anywhere runs the job;
+- the script then matches `/^\/test\s+(\S+)/` against the *trimmed* body and `throw`s
+  `Comment must be in the format: /test tagname` when it does not match.
+
+So a mid-sentence mention does not dispatch anything, but it does run a job that fails. Only a
+comment that *begins* with `/test <tag>` dispatches `e2e.yaml`, which checks out the PR head and
+runs `go test ./... -v -timeout 6h -tags "<tag>"` with `TF_ACC: true`, `TF_LOG: DEBUG` and the
+real `IONOS_*` secrets. Inline review replies use a different event
+(`pull_request_review_comment`) and cannot trigger it either way. **Do not put that literal in a
+PR comment at all** — refer to it as "the test-trigger comment".
+
+That dispatch is also the only automated path that would ever execute your untagged unit test —
+`-tags` adds to the default build, it does not replace it — but it needs a human, a member-level
+author and live cloud resources, so it is not a way to run a unit test. Run rung 2 yourself.
+
+### Writing the query step (deliverable 5)
+
+Writing this is part of the arc; **running it is not**. The reference is
+`ionoscloud/resource_datacenter_test.go:133-213` (`TestAccDataCenterQuery`, 92 lines added by
+`79ad9715`) — copy its shape, not just the fragments below.
+`TestAccIPBlockQuery` (`ionoscloud/resource_ipblock_test.go:131`) and
+`TestAccTargetGroupQuery` (`ionoscloud/resource_target_group_test.go:208`) are the same shape for
+an optional-`name` resource and for one with no `location`.
+
+```go
+func TestAcc<Resource>Query(t *testing.T) {
+	const (
+		<resource>Name = "tf-test-<resource>-query"
+		<resource>Addr = constant.<Const> + ".test_<resource>_query"
+		otherLocation  = "de/txl" // only for a resource that HAS a location
+	)
+
+	// The name and the resource label must be unique to THIS test, not the suite's shared
+	// fixture name/label. querycheck.ExpectLength asserts a CONTRACT-WIDE total, so if any
+	// other test in the package creates a resource with the same name, ExpectLength(1)
+	// flaps. Give the query test its own create step rather than reusing
+	// testAccCheck<Resource>ConfigBasic, which is keyed on constant.<Const>TestResource.
+	// The zero-result step needs a filter field that can actually discriminate: if the
+	// resource has no location, use another allow-listed field whose value the fixture does
+	// not use (target_group uses algorithm), never a field with one legal value.
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		// `terraform query` and list blocks were introduced in Terraform 1.14.
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesInternal(t, &testAccProvider),
+		CheckDestroy:             testAccCheck<Resource>DestroyCheck,
+		Steps: []resource.TestStep{
+			{Config: /* a plain create step — no Query field */},
+			{Query: true, Config: /* list block, no filters */, QueryResultChecks: /* ExpectIdentity */},
+			{Query: true, Config: /* list block, filters matching exactly one */, QueryResultChecks: /* ExpectLength 1 */},
+			{Query: true, Config: /* same name, a value of a DISCRIMINATING filter field that the fixture does not use */, QueryResultChecks: /* ExpectLength 0 */},
+			{ResourceName: <resource>Addr, ImportState: true,
+			 ImportStateKind: resource.ImportBlockWithResourceIdentity},
+		},
+	})
+}
+```
+
+Four things that are easy to get wrong:
+
+- **`ProtoV6ProviderFactories`, not `ProviderFactories`.** The list resource lives on the
+  framework half of the mux; the `ionoscloud/` tests using `testAccProviderFactories`
+  cannot see it. Use `testAccProtoV6ProviderFactoriesInternal(t, &testAccProvider)`
+  (`ionoscloud/provider_test.go:103`), which builds the mux through
+  `ProtoV6ProviderServerFactory` — the same
+  `provider.New(ListResources()...)` wiring `main.go` uses (`ionoscloud/provider_test.go:91`).
+- **`Query: true` is load-bearing on every list step.** It is what routes the step to
+  `testStepNewQuery` (`vendor/.../terraform-plugin-testing/helper/resource/testing_new.go:369-373`
+  — note `terraform-plugin-testing`, not the SDK, which has a `helper/resource` of its own with
+  no such file), what writes the config
+  as a query file instead of a `.tf`, and the *only* thing that evaluates `QueryResultChecks`.
+  Grafting a `QueryResultChecks` block onto an ordinary apply step is the silent failure:
+  the checks are simply never run and the step passes.
+- **Include the zero-result step.** `ExpectLength(addr, 0)` with a filter value that matches
+  nothing is what proves the filter is evaluated at all; without it a no-op filter passes.
+- `SkipBelow(tfversion.Version1_14_0)` — without it the test fails on any older CLI in CI.
+
+The two fragments worth having in full:
+
+```go
+					QueryResultChecks: []querycheck.QueryResultCheck{
+						querycheck.ExpectIdentity(<resource>Addr, map[string]knownvalue.Check{
+							"id":       knownvalue.NotNull(),
+							"location": knownvalue.StringExact("us/las"),
+						}),
+					},
+```
+
+```go
+			// Import through the resource identity that the list results carry. This kind
+			// already checks that the import succeeds, that the plan it leaves behind is a
+			// no-op and that the planned identity matches the one in state; ImportStateVerify
+			// cannot be combined with it, only ImportCommandWithID reads that field.
+			{
+				ResourceName:    <resource>Addr,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+			},
+```
+
+A malformed identity schema is caught much earlier and cheaply — but only if you run **ladder
+rung 2b**. `ionoscloud/provider_test.go`'s `TestProvider` calls `Provider().InternalValidate()`,
+which runs `InternalIdentityValidate()` on every resource in `ResourcesMap`
+(`vendor/.../helper/schema/provider.go:220-225`). Nothing else reaches it: CI compiles the test
+files (`go vet -tags=all ./...`) but runs none of them, rung 1 compiles no test file at all, and
+rung 2's `GetResourceIdentitySchemas` assertion passes for a malformed identity.
+`go test ./ionoscloud/ -run 'TestProvider$' -count=1`.

--- a/.claude/skills/add-list-resource/references/verify-and-pr.md
+++ b/.claude/skills/add-list-resource/references/verify-and-pr.md
@@ -54,7 +54,8 @@ from `dupl`/`errcheck`/`gocyclo`/`gosec`/`unparam`/`unused` — but **not** from
 4. **`prealloc`** — `make([]T, 0, len(src))`, not `var xs []T` before a range loop.
 5. **`gocyclo`** (min-complexity 25) — the list resource has nothing left that grows: `List` is
    a fetch closure plus a call, and the mapper is a filter check, two setter calls and a
-   conversion. What can trip it is the resource's own `set<Resource>Data` if you extend it while
+   conversion. What can trip it is the resource's own state writer (`setDatacenterData`,
+   `IpBlockSetData` — the name is per-resource, and not always unexported) if you extend it while
    you are in there; split into a helper rather than growing one function.
 6. **`tagalign`** (`sort: true`, order `json, tfsdk, mapstructure`) — struct tags must be sorted
    and aligned. `` `tfsdk:"id" json:"id"` `` fails. Only the framework-native branch can trip
@@ -274,9 +275,13 @@ author and live cloud resources, so it is not a way to run a unit test. Run rung
 Writing this is part of the arc; **running it is not**. The reference is
 `ionoscloud/resource_datacenter_test.go:133-213` (`TestAccDataCenterQuery`, 92 lines added by
 `79ad9715`) — copy its shape, not just the fragments below.
-`TestAccIPBlockQuery` (`ionoscloud/resource_ipblock_test.go:131`) and
-`TestAccTargetGroupQuery` (`ionoscloud/resource_target_group_test.go:208`) are the same shape for
-an optional-`name` resource and for one with no `location`.
+`TestAccIPBlockQuery` (`ionoscloud/resource_ipblock_test.go:144-224`) is the same shape for an
+optional-`name` resource, and the only other standalone `TestAcc<Resource>Query` in `ionoscloud/`.
+The five framework-native list resources fold the same steps into their lifecycle tests instead —
+`internal/framework/services/pgsqlv2/resource_pg_cluster_v2_test.go` is the closest match. An
+earlier run of this skill also produced a `target_group` list resource, but that branch (PR #1041)
+closed unmerged, so `target_group` has no identity, no list resource and no query test today:
+nothing in the tree demonstrates a resource with no `location`.
 
 ```go
 func TestAcc<Resource>Query(t *testing.T) {
@@ -293,7 +298,7 @@ func TestAcc<Resource>Query(t *testing.T) {
 	// testAccCheck<Resource>ConfigBasic, which is keyed on constant.<Const>TestResource.
 	// The zero-result step needs a filter field that can actually discriminate: if the
 	// resource has no location, use another allow-listed field whose value the fixture does
-	// not use (target_group uses algorithm), never a field with one legal value.
+	// not use, never a field with one legal value.
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -359,8 +364,10 @@ The two fragments worth having in full:
 
 A malformed identity schema is caught much earlier and cheaply — but only if you run **ladder
 rung 2b**. `ionoscloud/provider_test.go`'s `TestProvider` calls `Provider().InternalValidate()`,
-which runs `InternalIdentityValidate()` on every resource in `ResourcesMap`
-(`vendor/.../helper/schema/provider.go:220-225`). Nothing else reaches it: CI compiles the test
+which runs `InternalIdentityValidate()` on every resource in `ResourcesMap` **that declares an
+identity** — the call sits behind an `if r.Identity != nil` guard
+(`vendor/.../helper/schema/provider.go:220-225`), so this rung catches a *malformed* `Identity`
+block, never a *forgotten* one. Nothing else reaches it: CI compiles the test
 files (`go vet -tags=all ./...`) but runs none of them, rung 1 compiles no test file at all, and
 rung 2's `GetResourceIdentitySchemas` assertion passes for a malformed identity.
 `go test ./ionoscloud/ -run 'TestProvider$' -count=1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 6.7.38
+
+### Features
+- `ionoscloud_ipblock`: New list resource, queryable with `terraform query` (requires Terraform 1.14+).
+- `ionoscloud_ipblock`: Add a resource identity (`id`, `location`), which also enables `import` blocks with an `identity` attribute.
+
+### Documentation
+- `ionoscloud_ipblock`: Fix the docs naming the `ip_consumers` sub-attribute `nic_uuid` (the schema key is and always was `nic_id`) and typing `ips` as an integer rather than a list.
+
 ## 6.7.37
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 - `ionoscloud_ipblock`: New list resource, queryable with `terraform query` (requires Terraform 1.14+).
 - `ionoscloud_ipblock`: Add a resource identity (`id`, `location`), which also enables `import` blocks with an `identity` attribute.
 
-### Documentation
-- `ionoscloud_ipblock`: Fix the docs naming the `ip_consumers` sub-attribute `nic_uuid` (the schema key is and always was `nic_id`) and typing `ips` as an integer rather than a list.
-
 ## 6.7.37
 
 ### Features

--- a/docs/data-sources/ipblock.md
+++ b/docs/data-sources/ipblock.md
@@ -60,7 +60,7 @@ data "ionoscloud_ipblock" "example" {
 * `ip_consumers` Read-Only attribute. Lists consumption detail of an individual ip
   * `ip`
   * `mac`
-  * `nic_id`
+  * `nic_uuid`
   * `server_id`
   * `server_name`
   * `datacenter_id`

--- a/docs/data-sources/ipblock.md
+++ b/docs/data-sources/ipblock.md
@@ -60,7 +60,7 @@ data "ionoscloud_ipblock" "example" {
 * `ip_consumers` Read-Only attribute. Lists consumption detail of an individual ip
   * `ip`
   * `mac`
-  * `nic_uuid`
+  * `nic_id`
   * `server_id`
   * `server_name`
   * `datacenter_id`

--- a/docs/list-resources/ipblock.md
+++ b/docs/list-resources/ipblock.md
@@ -10,7 +10,7 @@ description: |-
 
 ⚠️ **Note:** List Resources require HashiCorp Terraform version 1.14 or later and are queried using `terraform query`.
 
-Lists **IP Blocks** on IONOS CLOUD. IP Blocks contain reserved public IP addresses that can be assigned to servers or other resources.
+Lists **IP Blocks** on IONOS CLOUD. IP Blocks contain reserved public IP addresses that can be assigned to servers or other resources — see the [`ionoscloud_ipblock` resource](../resources/ipblock.md) for how to manage one.
 
 ## Example Usage
 
@@ -28,13 +28,13 @@ list "ionoscloud_ipblock" "all" {
 ### Filter IP blocks by location
 
 ```hcl
-list "ionoscloud_ipblock" "us_las" {
+list "ionoscloud_ipblock" "de_txl" {
   provider         = ionoscloud
   include_resource = true
   config {
     filters = [{
       field_name  = "location"
-      field_value = "us/las"
+      field_value = "de/txl"
     }]
   }
 }
@@ -48,8 +48,8 @@ list "ionoscloud_ipblock" "prod" {
   include_resource = true
   config {
     filters = [
-      { field_name = "name",     field_value = "production-ips" },
-      { field_name = "location", field_value = "us/las" },
+      { field_name = "name",     field_value = "production" },
+      { field_name = "location", field_value = "de/txl" },
     ]
   }
 }
@@ -65,14 +65,13 @@ terraform query -generate-config-out=imported.tf
 
 Terraform will write an `ionoscloud_ipblock` resource block for each discovered IP block into `imported.tf`, which can then be used directly in your configuration.
 
-> **Note:** The IP blocks are read with a single Cloud API request, which asks for up to
-> **1000** items — the same limit the `ionoscloud_ipblock` data source requests, and ten
-> times the 100-item fallback the IONOS SDK sends for `/ipblocks` when no limit is asked
-> for. Whether the server honours the requested limit in full is not verified. A contract
-> holding more IP blocks than one response returns is truncated silently — no error is
-> raised and the missing IP blocks simply do not appear. Check that the number of
-> generated resource blocks matches the number of IP blocks you expect before treating
-> `imported.tf` as complete.
+> **Note:** The IP blocks are read with a single Cloud API `GET /ipblocks` request, which asks
+> for up to **1000** items — the same limit the `ionoscloud_ipblock` data source requests, and
+> ten times the 100 the IONOS SDK sends for `/ipblocks` when no limit is asked for. Whether the
+> server honours the requested limit in full is not verified. A contract holding more IP blocks
+> than one response returns is truncated silently — no error is raised and the missing IP blocks
+> simply do not appear. Check that the number of generated resource blocks matches the number of
+> IP blocks you expect before treating `imported.tf` as complete.
 
 Terraform names each generated resource after the `list` block label plus an index — a `list "ionoscloud_ipblock" "smoke"` block produces `ionoscloud_ipblock.smoke_0`, `smoke_1`, and so on.
 
@@ -82,14 +81,14 @@ Because the generated names are derived from the `list` block label, running a s
 
 This happens because an `import` block is idempotent: Terraform skips it when the target address is already in state, so the identity in the generated `import` block is never consulted. Deleting the generated `.tf` file does **not** remove the state entry.
 
-The consequences are not limited to a harmless diff. Both `location` and `size` are force-new attributes, so if the two IP blocks differ in either, the plan **destroys the IP block already in state** and creates a replacement — the IP block you meant to import is never touched. For an IP block a replacement is not equivalent: the reserved addresses are allocated at creation, so the destroyed block's IPs are released back to IONOS and the replacement comes back with **different** addresses. Anything already pointing at the old ones — NICs, load balancer rules, DNS records — breaks:
+The consequences are not limited to a harmless diff. `location` and `size` are both force-new attributes, so if the two IP blocks differ in either, the plan **destroys the IP block already in state** and creates a replacement — the IP block you meant to import is never touched, and the public IP addresses it held are released back to IONOS:
 
 ```hcl
-# generated for a 4-address block, but smoke_0 in state points at a 1-address block
+# generated for an IP block in de/fra, but smoke_0 in state points at one in us/las
 resource "ionoscloud_ipblock" "smoke_0" {
-  location = "us/las"
-  size     = 4                 # forces replacement of the 1-address block
-  name     = "production-ips"
+  location = "de/fra"          # forces replacement of the us/las IP block
+  size     = 1
+  name     = "IP Block Example"
 }
 ```
 
@@ -98,7 +97,7 @@ To avoid this:
 - Use a distinct `list` block label for each query you intend to import from, or
 - Clear the address deliberately: run `terraform state show ionoscloud_ipblock.smoke_0` first
   and confirm it is the leftover import and not an IP block you still manage, then
-  `terraform state rm ionoscloud_ipblock.smoke_0`. Removing the address does not release the
+  `terraform state rm ionoscloud_ipblock.smoke_0`. Removing the address does not delete the
   IP block — it stops Terraform managing it, and it has to be re-imported to come back under
   management.
 
@@ -108,7 +107,7 @@ Always read the plan before applying. A clean import reports:
 Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
 ```
 
-Anything reporting changes, and especially `must be replaced` with `size = ... -> ... # forces replacement`, means the address is bound to a different IP block — stop and clear the state entry first.
+Anything reporting changes, and especially `must be replaced` with `location = "..." -> "..." # forces replacement`, means the address is bound to a different IP block — stop and clear the state entry first.
 
 ## Argument Reference
 
@@ -116,11 +115,9 @@ The `config` block supports the following arguments:
 
 - `filters` - (Optional) List of filters to apply. All filters must match (AND logic). Each filter supports:
   - `field_name` - (Required) The field to filter on. Supported values: `name`, `location`.
-  - `field_value` - (Required) The exact value to match against.
+  - `field_value` - (Required) The exact value to match against. Matching is case-sensitive and compares against the value the API returned, so `location` has to be written exactly as the API reports it, for example `de/txl`.
 
-> **Note:** The Cloud API returns IP blocks from every location in a single response, so filtering by `location` does not reduce the number of API calls; it only narrows the results. Filtering happens after that response is read, so it cannot recover an IP block left out by the page limit described above.
-
-> **Note:** `name` is optional on `ionoscloud_ipblock`, so an IP block reserved without one cannot be matched by a `name` filter. Such a block is still listed — it is labelled by its UUID instead of a name in the query output.
+> **Note:** The Cloud API returns IP blocks from every location in a single response, so filtering by `location` does not reduce the number of API calls; it only narrows the results. Filtering happens after that response is read, so it cannot recover an IP block left out by the limit described above.
 
 ## Identity Attributes
 
@@ -129,18 +126,18 @@ Each result exposes the following identity attributes, usable for import:
 | Attribute  | Description                                                                                                            |
 |------------|------------------------------------------------------------------------------------------------------------------------|
 | `id`       | The UUID of the IP block.                                                                                              |
-| `location` | The location the IP block lives in (e.g. `us/las`). Only needed when the Cloud API endpoint is overridden per location. |
+| `location` | The location the IP block lives in (e.g. `de/txl`). Only needed when the Cloud API endpoint is overridden per location. |
 
 ## Attributes Reference
 
 Each result exposes the following attributes when `include_resource = true`, matching the `ionoscloud_ipblock` resource schema:
 
 - `id` - The UUID of the IP block.
-- `name` - The name of the IP block. Null when the IP block was reserved without one.
-- `location` - The regional location the IP block was reserved in (e.g. `us/las`).
+- `name` - The name of the IP block. Optional on the resource, so it can be null; results with no name are labelled by their UUID instead.
+- `location` - The regional location of the IP block (e.g. `us/las`, `de/txl`).
 - `size` - The number of IP addresses reserved in this block.
 - `ips` - The list of IP addresses associated with this block.
-- `ip_consumers` - Consumption detail for each individual IP. Empty for a block whose addresses are not assigned to anything:
+- `ip_consumers` - Consumption detail for each IP in the block. Empty when no IP in the block is in use:
   - `ip` - The IP address being consumed.
   - `mac` - The MAC address of the NIC the IP is assigned to.
   - `nic_id` - The UUID of the NIC the IP is assigned to.
@@ -149,5 +146,5 @@ Each result exposes the following attributes when `include_resource = true`, mat
   - `datacenter_id` - The UUID of the datacenter the server lives in.
   - `datacenter_name` - The name of that datacenter.
   - `k8s_nodepool_uuid` - The UUID of the Kubernetes node pool consuming the IP, if any.
-  - `k8s_cluster_uuid` - The UUID of the Kubernetes cluster that node pool belongs to, if any.
+  - `k8s_cluster_uuid` - The UUID of the Kubernetes cluster consuming the IP, if any.
 - `timeouts` - Always null; timeouts are configuration-only and are not returned by a query.

--- a/docs/list-resources/ipblock.md
+++ b/docs/list-resources/ipblock.md
@@ -1,0 +1,153 @@
+---
+subcategory: "Compute Engine"
+layout: "ionoscloud"
+page_title: "IONOS CLOUD: ipblock"
+description: |-
+  Lists IONOS CLOUD IP Blocks.
+---
+
+# List Resource: ionoscloud_ipblock
+
+⚠️ **Note:** List Resources require HashiCorp Terraform version 1.14 or later and are queried using `terraform query`.
+
+Lists **IP Blocks** on IONOS CLOUD. IP Blocks contain reserved public IP addresses that can be assigned to servers or other resources.
+
+## Example Usage
+
+⚠️ **Note:** `list` blocks must be placed in a dedicated query file, whose name ends in `.tfquery.hcl` (for example `queries.tfquery.hcl`), separate from your main Terraform configuration.
+
+### List all IP blocks
+
+```hcl
+list "ionoscloud_ipblock" "all" {
+  provider         = ionoscloud
+  include_resource = true
+}
+```
+
+### Filter IP blocks by location
+
+```hcl
+list "ionoscloud_ipblock" "us_las" {
+  provider         = ionoscloud
+  include_resource = true
+  config {
+    filters = [{
+      field_name  = "location"
+      field_value = "us/las"
+    }]
+  }
+}
+```
+
+### Filter IP blocks by name and location
+
+```hcl
+list "ionoscloud_ipblock" "prod" {
+  provider         = ionoscloud
+  include_resource = true
+  config {
+    filters = [
+      { field_name = "name",     field_value = "production-ips" },
+      { field_name = "location", field_value = "us/las" },
+    ]
+  }
+}
+```
+
+### Generate resource configuration from existing IP blocks
+
+Use `terraform query` with `-generate-config-out` to produce ready-to-use `ionoscloud_ipblock` resource blocks for the IP blocks the query returns:
+
+```shell
+terraform query -generate-config-out=imported.tf
+```
+
+Terraform will write an `ionoscloud_ipblock` resource block for each discovered IP block into `imported.tf`, which can then be used directly in your configuration.
+
+> **Note:** The IP blocks are read with a single Cloud API request, which asks for up to
+> **1000** items — the same limit the `ionoscloud_ipblock` data source requests, and ten
+> times the 100-item fallback the IONOS SDK sends for `/ipblocks` when no limit is asked
+> for. Whether the server honours the requested limit in full is not verified. A contract
+> holding more IP blocks than one response returns is truncated silently — no error is
+> raised and the missing IP blocks simply do not appear. Check that the number of
+> generated resource blocks matches the number of IP blocks you expect before treating
+> `imported.tf` as complete.
+
+Terraform names each generated resource after the `list` block label plus an index — a `list "ionoscloud_ipblock" "smoke"` block produces `ionoscloud_ipblock.smoke_0`, `smoke_1`, and so on.
+
+### ⚠️ Do not reuse a `list` block label across separate imports
+
+Because the generated names are derived from the `list` block label, running a second query with the **same** label produces the **same** resource addresses. If a previous address is still in state, the generated configuration is silently applied to the IP block already recorded at that address — not to the one you just queried.
+
+This happens because an `import` block is idempotent: Terraform skips it when the target address is already in state, so the identity in the generated `import` block is never consulted. Deleting the generated `.tf` file does **not** remove the state entry.
+
+The consequences are not limited to a harmless diff. Both `location` and `size` are force-new attributes, so if the two IP blocks differ in either, the plan **destroys the IP block already in state** and creates a replacement — the IP block you meant to import is never touched. For an IP block a replacement is not equivalent: the reserved addresses are allocated at creation, so the destroyed block's IPs are released back to IONOS and the replacement comes back with **different** addresses. Anything already pointing at the old ones — NICs, load balancer rules, DNS records — breaks:
+
+```hcl
+# generated for a 4-address block, but smoke_0 in state points at a 1-address block
+resource "ionoscloud_ipblock" "smoke_0" {
+  location = "us/las"
+  size     = 4                 # forces replacement of the 1-address block
+  name     = "production-ips"
+}
+```
+
+To avoid this:
+
+- Use a distinct `list` block label for each query you intend to import from, or
+- Clear the address deliberately: run `terraform state show ionoscloud_ipblock.smoke_0` first
+  and confirm it is the leftover import and not an IP block you still manage, then
+  `terraform state rm ionoscloud_ipblock.smoke_0`. Removing the address does not release the
+  IP block — it stops Terraform managing it, and it has to be re-imported to come back under
+  management.
+
+Always read the plan before applying. A clean import reports:
+
+```
+Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
+```
+
+Anything reporting changes, and especially `must be replaced` with `size = ... -> ... # forces replacement`, means the address is bound to a different IP block — stop and clear the state entry first.
+
+## Argument Reference
+
+The `config` block supports the following arguments:
+
+- `filters` - (Optional) List of filters to apply. All filters must match (AND logic). Each filter supports:
+  - `field_name` - (Required) The field to filter on. Supported values: `name`, `location`.
+  - `field_value` - (Required) The exact value to match against.
+
+> **Note:** The Cloud API returns IP blocks from every location in a single response, so filtering by `location` does not reduce the number of API calls; it only narrows the results. Filtering happens after that response is read, so it cannot recover an IP block left out by the page limit described above.
+
+> **Note:** `name` is optional on `ionoscloud_ipblock`, so an IP block reserved without one cannot be matched by a `name` filter. Such a block is still listed — it is labelled by its UUID instead of a name in the query output.
+
+## Identity Attributes
+
+Each result exposes the following identity attributes, usable for import:
+
+| Attribute  | Description                                                                                                            |
+|------------|------------------------------------------------------------------------------------------------------------------------|
+| `id`       | The UUID of the IP block.                                                                                              |
+| `location` | The location the IP block lives in (e.g. `us/las`). Only needed when the Cloud API endpoint is overridden per location. |
+
+## Attributes Reference
+
+Each result exposes the following attributes when `include_resource = true`, matching the `ionoscloud_ipblock` resource schema:
+
+- `id` - The UUID of the IP block.
+- `name` - The name of the IP block. Null when the IP block was reserved without one.
+- `location` - The regional location the IP block was reserved in (e.g. `us/las`).
+- `size` - The number of IP addresses reserved in this block.
+- `ips` - The list of IP addresses associated with this block.
+- `ip_consumers` - Consumption detail for each individual IP. Empty for a block whose addresses are not assigned to anything:
+  - `ip` - The IP address being consumed.
+  - `mac` - The MAC address of the NIC the IP is assigned to.
+  - `nic_id` - The UUID of the NIC the IP is assigned to.
+  - `server_id` - The UUID of the server the NIC belongs to.
+  - `server_name` - The name of that server.
+  - `datacenter_id` - The UUID of the datacenter the server lives in.
+  - `datacenter_name` - The name of that datacenter.
+  - `k8s_nodepool_uuid` - The UUID of the Kubernetes node pool consuming the IP, if any.
+  - `k8s_cluster_uuid` - The UUID of the Kubernetes cluster that node pool belongs to, if any.
+- `timeouts` - Always null; timeouts are configuration-only and are not returned by a query.

--- a/docs/resources/ipblock.md
+++ b/docs/resources/ipblock.md
@@ -26,11 +26,11 @@ resource "ionoscloud_ipblock" "example" {
 * `name` - (Optional)[string] The name of Ip Block
 * `location` - (Required)[string] The regional location for this IP Block: us/las, us/ewr, de/fra, de/fkb.
 * `size` - (Required)[integer] The number of IP addresses to reserve for this block.
-* `ips` - (Computed)[integer] The list of IP addresses associated with this block.
+* `ips` - (Computed)[list] The list of IP addresses associated with this block.
 * `ip_consumers` (Computed) Read-Only attribute. Lists consumption detail of an individual ip
   * `ip`
   * `mac`
-  * `nic_uuid`
+  * `nic_id`
   * `server_id`
   * `server_name`
   * `datacenter_id`
@@ -45,3 +45,41 @@ Resource Ipblock can be imported using the `resource id`, e.g.
 ```shell
 terraform import ionoscloud_ipblock.myipblock ipblock uuid
 ```
+
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can also be used with the `identity` attribute:
+
+```hcl
+import {
+  to = ionoscloud_ipblock.example
+  identity = {
+    id = "ipblock uuid"
+  }
+}
+
+resource "ionoscloud_ipblock" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `id` (String) The UUID of the IP block.
+
+#### Optional
+
+* `location` (String) The location the IP block lives in. Only needed when the Cloud API endpoint is overridden per location.
+
+## Query (List Resource)
+
+IP Blocks can be listed using `terraform query` (requires Terraform 1.14+). List blocks must be placed in a dedicated query file, whose name ends in `.tfquery.hcl` (for example `queries.tfquery.hcl`).
+
+```hcl
+list "ionoscloud_ipblock" "all" {
+  provider         = ionoscloud
+  include_resource = true
+}
+```
+
+See the [`ionoscloud_ipblock` list resource documentation](../list-resources/ipblock.md) for filters and the full attribute reference.

--- a/docs/resources/ipblock.md
+++ b/docs/resources/ipblock.md
@@ -26,11 +26,11 @@ resource "ionoscloud_ipblock" "example" {
 * `name` - (Optional)[string] The name of Ip Block
 * `location` - (Required)[string] The regional location for this IP Block: us/las, us/ewr, de/fra, de/fkb.
 * `size` - (Required)[integer] The number of IP addresses to reserve for this block.
-* `ips` - (Computed)[list] The list of IP addresses associated with this block.
+* `ips` - (Computed)[integer] The list of IP addresses associated with this block.
 * `ip_consumers` (Computed) Read-Only attribute. Lists consumption detail of an individual ip
   * `ip`
   * `mac`
-  * `nic_id`
+  * `nic_uuid`
   * `server_id`
   * `server_name`
   * `datacenter_id`
@@ -69,11 +69,11 @@ resource "ionoscloud_ipblock" "example" {
 
 #### Optional
 
-* `location` (String) The location the IP block lives in. Only needed when the Cloud API endpoint is overridden per location.
+* `location` (String) The location the IP block lives in (e.g. `de/txl`). Only needed when the Cloud API endpoint is overridden per location.
 
 ## Query (List Resource)
 
-IP Blocks can be listed using `terraform query` (requires Terraform 1.14+). List blocks must be placed in a dedicated query file, whose name ends in `.tfquery.hcl` (for example `queries.tfquery.hcl`).
+IP blocks can be listed using `terraform query` (requires Terraform 1.14+). List blocks must be placed in a dedicated query file, whose name ends in `.tfquery.hcl` (for example `queries.tfquery.hcl`).
 
 ```hcl
 list "ionoscloud_ipblock" "all" {

--- a/ionoscloud/list_resources.go
+++ b/ionoscloud/list_resources.go
@@ -15,5 +15,6 @@ import (
 func ListResources() []func() list.ListResource {
 	return []func() list.ListResource{
 		NewDatacenterListResource,
+		NewIPBlockListResource,
 	}
 }

--- a/ionoscloud/resource_datacenter_list_test.go
+++ b/ionoscloud/resource_datacenter_list_test.go
@@ -73,7 +73,7 @@ func TestDatacenterListResource(t *testing.T) {
 	resourceType := providerSchema.ResourceSchemas[datacenterListType].ValueType()
 
 	t.Run("streams every datacenter", func(t *testing.T) {
-		results := listDatacenters(ctx, t, server, listSchema, nil)
+		results := listResults(ctx, t, server, datacenterListType, listSchema, nil)
 		if len(results) != 2 {
 			t.Fatalf("expected 2 results, got %d", len(results))
 		}
@@ -126,7 +126,7 @@ func TestDatacenterListResource(t *testing.T) {
 	})
 
 	t.Run("applies filters", func(t *testing.T) {
-		results := listDatacenters(ctx, t, server, listSchema, map[string]string{"location": "de/fra"})
+		results := listResults(ctx, t, server, datacenterListType, listSchema, map[string]string{"location": "de/fra"})
 		if len(results) != 1 {
 			t.Fatalf("expected 1 result, got %d", len(results))
 		}
@@ -240,15 +240,18 @@ func configureProvider(ctx context.Context, t *testing.T, server tfprotov6.Provi
 	failOnErrorDiagnostics(t, "ConfigureProvider", resp.Diagnostics)
 }
 
-// listDatacenters calls the ListResource RPC with the given filters and collects the
-// results, failing on the first error diagnostic.
-func listDatacenters(ctx context.Context, t *testing.T, server tfprotov6.ProviderServer, schema *tfprotov6.Schema, filters map[string]string) []tfprotov6.ListResourceResult {
+// listResults calls the ListResource RPC of the given type with the given filters and
+// collects the results, failing on the first error diagnostic. The type name is a
+// parameter because it is the only thing that differs per list resource: every list
+// resource for an SDKv2 managed resource lands in this one package, so this driver is
+// shared rather than copied per resource.
+func listResults(ctx context.Context, t *testing.T, server tfprotov6.ProviderServer, typeName string, schema *tfprotov6.Schema, filters map[string]string) []tfprotov6.ListResourceResult {
 	t.Helper()
 
 	listServer, config := listServerAndConfig(t, server, schema, filters)
 
 	stream, err := listServer.ListResource(ctx, &tfprotov6.ListResourceRequest{
-		TypeName:        datacenterListType,
+		TypeName:        typeName,
 		Config:          &config,
 		IncludeResource: true,
 	})

--- a/ionoscloud/resource_datacenter_list_test.go
+++ b/ionoscloud/resource_datacenter_list_test.go
@@ -240,11 +240,9 @@ func configureProvider(ctx context.Context, t *testing.T, server tfprotov6.Provi
 	failOnErrorDiagnostics(t, "ConfigureProvider", resp.Diagnostics)
 }
 
-// listResults calls the ListResource RPC of the given type with the given filters and
+// listResults calls the ListResource RPC of typeName with the given filters and
 // collects the results, failing on the first error diagnostic. The type name is a
-// parameter because it is the only thing that differs per list resource: every list
-// resource for an SDKv2 managed resource lands in this one package, so this driver is
-// shared rather than copied per resource.
+// parameter because this driver is shared by every list-resource test in the package.
 func listResults(ctx context.Context, t *testing.T, server tfprotov6.ProviderServer, typeName string, schema *tfprotov6.Schema, filters map[string]string) []tfprotov6.ListResourceResult {
 	t.Helper()
 

--- a/ionoscloud/resource_ipblock.go
+++ b/ionoscloud/resource_ipblock.go
@@ -181,7 +181,7 @@ func resourceIPBlockRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		return diagutil.ToDiags(d, err, nil)
 	}
 
-	// must run AFTER IpBlockSetData: the identity reads attributes that only the data
+	// Must run after IpBlockSetData: the identity reads attributes that only the data
 	// setter fills in (this matters most on an identity-based import).
 	if err := setIPBlockIdentity(d); err != nil {
 		return diagutil.ToDiags(d, err, nil)
@@ -189,7 +189,6 @@ func resourceIPBlockRead(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	return nil
 }
-
 func resourceIPBlockUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	location := d.Get("location").(string)
 
@@ -214,17 +213,18 @@ func resourceIPBlockUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		return diagutil.ToDiags(d, fmt.Errorf("an error occurred while updating an ip block: %w", err), &diagutil.ErrorContext{RequestID: diagutil.ExtractRequestID(requestLocation), StatusCode: apiResponse.SafeStatusCode()})
 	}
 
-	// The SDK carries the prior identity into the apply on its own, so an update that
-	// never touches the identity still returns one and "Missing Resource Identity After
-	// Update" does not fire. This is the safety net for state written before the resource
-	// declared an identity - an old state file refreshed with -refresh=false, say - not
-	// the everyday path. It derives from state, never from the API response, so it cannot
-	// differ from the planned identity.
+	// Unlike Create, Update does not need this to satisfy terraform: the SDK carries the
+	// prior identity into the apply on its own, so an update that never touches the
+	// identity still returns one. It is a safety net for state written before this
+	// resource declared an identity, e.g. a refresh-free apply over an old state file.
+	// The values are read back out of state, never out of an API response, so whatever
+	// this writes equals the prior identity and the stability check cannot trip.
 	if err := setIPBlockIdentity(d); err != nil {
 		return diagutil.ToDiags(d, err, nil)
 	}
 
 	return nil
+
 }
 
 func resourceIPBlockDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/ionoscloud/resource_ipblock.go
+++ b/ionoscloud/resource_ipblock.go
@@ -26,6 +26,27 @@ func resourceIPBlock() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceIpBlockImporter,
 		},
+		// The identity is what a `list "ionoscloud_ipblock"` block streams back for
+		// each IP block it finds, and what an import block can be written against.
+		// Terraform requires every read of a resource that declares an identity to
+		// return one, see setIPBlockIdentity.
+		Identity: &schema.ResourceIdentity{
+			Version: 0,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+						Description:       "The UUID of the IP block.",
+					},
+					"location": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+						Description:       "The location the IP block lives in. Only needed when the Cloud API endpoint is overridden per location.",
+					},
+				}
+			},
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -160,8 +181,15 @@ func resourceIPBlockRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		return diagutil.ToDiags(d, err, nil)
 	}
 
+	// must run AFTER IpBlockSetData: the identity reads attributes that only the data
+	// setter fills in (this matters most on an identity-based import).
+	if err := setIPBlockIdentity(d); err != nil {
+		return diagutil.ToDiags(d, err, nil)
+	}
+
 	return nil
 }
+
 func resourceIPBlockUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	location := d.Get("location").(string)
 
@@ -186,8 +214,17 @@ func resourceIPBlockUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		return diagutil.ToDiags(d, fmt.Errorf("an error occurred while updating an ip block: %w", err), &diagutil.ErrorContext{RequestID: diagutil.ExtractRequestID(requestLocation), StatusCode: apiResponse.SafeStatusCode()})
 	}
 
-	return nil
+	// The SDK carries the prior identity into the apply on its own, so an update that
+	// never touches the identity still returns one and "Missing Resource Identity After
+	// Update" does not fire. This is the safety net for state written before the resource
+	// declared an identity - an old state file refreshed with -refresh=false, say - not
+	// the everyday path. It derives from state, never from the API response, so it cannot
+	// differ from the planned identity.
+	if err := setIPBlockIdentity(d); err != nil {
+		return diagutil.ToDiags(d, err, nil)
+	}
 
+	return nil
 }
 
 func resourceIPBlockDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -215,18 +252,14 @@ func resourceIPBlockDelete(ctx context.Context, d *schema.ResourceData, meta any
 }
 
 func resourceIpBlockImporter(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	importID := d.Id()
-
-	location, parts := splitImportID(importID, ":")
-	if len(parts) != 1 {
-		return nil, fmt.Errorf("invalid import identifier: expected one of <location>:<ipblock-id> or <ipblock-id>, got: %s", importID)
+	ipBlockID, location, err := ipBlockImportParts(d)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := validateImportIDParts(parts); err != nil {
-		return nil, fmt.Errorf("failed validating import identifier %q: %w", importID, err)
-	}
-
-	ipBlockID := parts[0]
+	// Terraform sends an empty ID for an identity-based import, so the ID has to be
+	// set here for the error diagnostics and the log line below to name the resource.
+	d.SetId(ipBlockID)
 
 	client, err := meta.(bundleclient.SdkBundle).NewCloudAPIClient(ctx, location)
 	if err != nil {
@@ -253,7 +286,57 @@ func resourceIpBlockImporter(ctx context.Context, d *schema.ResourceData, meta a
 		return nil, diagutil.ToError(d, err, nil)
 	}
 
+	if err := setIPBlockIdentity(d); err != nil {
+		return nil, diagutil.ToError(d, err, nil)
+	}
+
 	return []*schema.ResourceData{d}, nil
+}
+
+// ipBlockImportParts resolves the IP block to import, either from the resource
+// identity - which is how an import block with an `identity` argument, and the
+// import config that `terraform query` generates, address an IP block - or from the
+// "<location>:<ipblock-id>" import string.
+func ipBlockImportParts(d *schema.ResourceData) (ipBlockID, location string, err error) {
+	if identity, identityErr := d.Identity(); identityErr == nil {
+		if id, ok := identity.GetOk("id"); ok {
+			loc, _ := identity.Get("location").(string)
+			ipBlockID, _ = id.(string)
+			return ipBlockID, loc, nil
+		}
+	}
+
+	importID := d.Id()
+	location, parts := splitImportID(importID, ":")
+	if len(parts) != 1 {
+		return "", "", fmt.Errorf("invalid import identifier: expected one of <location>:<ipblock-id> or <ipblock-id>, got: %s", importID)
+	}
+
+	if err := validateImportIDParts(parts); err != nil {
+		return "", "", fmt.Errorf("failed validating import identifier %q: %w", importID, err)
+	}
+
+	return parts[0], location, nil
+}
+
+// setIPBlockIdentity writes the resource identity from the IP block already in state.
+// Terraform errors out with "Missing Resource Identity After Read" if a resource that
+// declares an identity finishes a read without returning one.
+func setIPBlockIdentity(d *schema.ResourceData) error {
+	identity, err := d.Identity()
+	if err != nil {
+		return err
+	}
+
+	if err := identity.Set("id", d.Id()); err != nil {
+		return fmt.Errorf("error while setting id identity attribute for ip block %s: %w", d.Id(), err)
+	}
+
+	if err := identity.Set("location", d.Get("location")); err != nil {
+		return fmt.Errorf("error while setting location identity attribute for ip block %s: %w", d.Id(), err)
+	}
+
+	return nil
 }
 
 func IpBlockSetData(d *schema.ResourceData, ipBlock *ionoscloud.IpBlock) error {

--- a/ionoscloud/resource_ipblock_list.go
+++ b/ionoscloud/resource_ipblock_list.go
@@ -19,9 +19,9 @@ import (
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
 )
 
-// A list resource for ionoscloud_ipblock, whose managed resource is still
-// implemented with terraform-plugin-sdk/v2 and therefore lives on the other half of
-// the mux. The protocol schemas the framework needs come from that resource via
+// A list resource for ionoscloud_ipblock, whose managed resource is still implemented
+// with terraform-plugin-sdk/v2 and therefore lives on the other half of the mux. The
+// protocol schemas the framework needs come from that resource via
 // identity.SetRawV6Schemas.
 //
 // It lives in this package, next to the resource it lists, so it can call
@@ -52,15 +52,15 @@ func NewIPBlockListResource() list.ListResource {
 }
 
 // RawV6Schemas hands the framework the protocol schemas of the SDKv2 managed
-// resource. A framework-native list resource inherits them from the resource
-// itself; this is only needed because ionoscloud_ipblock lives on the SDKv2 side.
+// resource. A framework-native list resource inherits them from the resource itself;
+// this is only needed because ionoscloud_ipblock lives on the SDKv2 side.
 func (r *ipBlockListResource) RawV6Schemas(ctx context.Context, _ list.RawV6SchemaRequest, resp *list.RawV6SchemaResponse) {
 	fwidentity.SetRawV6Schemas(ctx, resp, constant.IpBlockResource, r.resourceSchema)
 }
 
 // Metadata returns the type name of the managed resource being listed. It must match
 // the SDKv2 resource exactly, otherwise terraform has no resource to attach the
-// results to.
+// results to - hence the same constant that keys ResourcesMap in provider.go.
 func (r *ipBlockListResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = constant.IpBlockResource
 }
@@ -83,7 +83,7 @@ func (r *ipBlockListResource) Configure(_ context.Context, req resource.Configur
 	r.bundle = clientBundle
 }
 
-// ListResourceConfigSchema returns the schema for the list resource config schema.
+// ListResourceConfigSchema returns the schema for the list resource config block.
 func (r *ipBlockListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
 	resp.Schema = listschema.Schema{
 		Attributes: map[string]listschema.Attribute{
@@ -108,9 +108,10 @@ func (r *ipBlockListResource) List(ctx context.Context, req list.ListRequest, st
 			// Depth(1) is what makes the API return the properties of every IP block
 			// instead of just its links. Filtering stays client-side, in the mapper.
 			//
-			// The explicit Limit matches what the ionoscloud_ipblock data source asks
-			// for (data_source_ipblock.go); without it the SDK client falls back to 100
-			// for /ipblocks, which would cap this listing below its own data source.
+			// The explicit Limit matches ionoscloud/data_source_ipblock.go: the SDK
+			// client falls back to limit=100 for /ipblocks (api_ip_blocks.go:489),
+			// which is ten times lower than what the data source asks for, so without
+			// it the list resource would see less than its own data source does.
 			ipBlocks, apiResponse, err := client.IPBlocksApi.IpblocksGet(ctx).Depth(1).Limit(constant.IPBlockLimit).Execute()
 			if apiResponse != nil {
 				tflog.Debug(ctx, "listed ip blocks", map[string]any{"status_code": apiResponse.SafeStatusCode()})
@@ -133,15 +134,15 @@ func (r *ipBlockListResource) List(ctx context.Context, req list.ListRequest, st
 // The mapping itself is IpBlockSetData, the same state writer resourceIPBlockRead
 // uses, run against a ResourceData built from the live schema. Nothing here knows what
 // attributes an IP block has.
-func (r *ipBlockListResource) mapIPBlock(_ context.Context, includeResource bool, filters []fwidentity.Filter, item ionoscloud.IpBlock) (*fwidentity.MappedItem, diag.Diagnostics) {
+func (r *ipBlockListResource) mapIPBlock(_ context.Context, includeResource bool, filters []fwidentity.Filter, ipBlock ionoscloud.IpBlock) (*fwidentity.MappedItem, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	if item.Id == nil || item.Properties == nil {
+	if ipBlock.Id == nil || ipBlock.Properties == nil {
 		return nil, nil
 	}
 
-	name := shared.ToValueDefault(item.Properties.Name)
-	location := shared.ToValueDefault(item.Properties.Location)
+	name := shared.ToValueDefault(ipBlock.Properties.Name)
+	location := shared.ToValueDefault(ipBlock.Properties.Location)
 
 	if !fwidentity.MatchesFilters(map[string]string{
 		"name":     name,
@@ -150,8 +151,15 @@ func (r *ipBlockListResource) mapIPBlock(_ context.Context, includeResource bool
 		return nil, nil
 	}
 
+	// `name` is Optional on ionoscloud_ipblock, so an unnamed IP block would otherwise
+	// render as a blank row in the terraform query output.
+	displayName := name
+	if displayName == "" {
+		displayName = *ipBlock.Id
+	}
+
 	data := r.resourceSchema.Data(&terraform.InstanceState{})
-	if err := IpBlockSetData(data, &item); err != nil {
+	if err := IpBlockSetData(data, &ipBlock); err != nil {
 		diags.AddError("Failed to map the ip block", err.Error())
 		return nil, diags
 	}
@@ -161,13 +169,6 @@ func (r *ipBlockListResource) mapIPBlock(_ context.Context, includeResource bool
 	if err := setIPBlockIdentity(data); err != nil {
 		diags.AddError("Failed to map the ip block identity", err.Error())
 		return nil, diags
-	}
-
-	// name is Optional on ionoscloud_ipblock, so an unnamed block would otherwise
-	// render as a blank row in the terraform query output.
-	displayName := name
-	if displayName == "" {
-		displayName = *item.Id
 	}
 
 	mapped, err := fwidentity.MappedItemFromResourceData(displayName, data, includeResource)

--- a/ionoscloud/resource_ipblock_list.go
+++ b/ionoscloud/resource_ipblock_list.go
@@ -1,0 +1,180 @@
+package ionoscloud
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
+
+	fwidentity "github.com/ionos-cloud/terraform-provider-ionoscloud/v6/internal/framework/identity"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/services/bundleclient"
+	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
+)
+
+// A list resource for ionoscloud_ipblock, whose managed resource is still
+// implemented with terraform-plugin-sdk/v2 and therefore lives on the other half of
+// the mux. The protocol schemas the framework needs come from that resource via
+// identity.SetRawV6Schemas.
+//
+// It lives in this package, next to the resource it lists, so it can call
+// resourceIPBlock, IpBlockSetData and setIPBlockIdentity directly. That is the whole
+// design: results are produced by the resource's own state writer, so this file
+// declares no model of the ipblock schema and there is nothing here to keep in sync
+// when that schema changes.
+
+var (
+	_ list.ListResource                 = (*ipBlockListResource)(nil)
+	_ list.ListResourceWithConfigure    = (*ipBlockListResource)(nil)
+	_ list.ListResourceWithRawV6Schemas = (*ipBlockListResource)(nil)
+)
+
+// ipBlockListResource lists ionoscloud_ipblock instances.
+type ipBlockListResource struct {
+	bundle *bundleclient.SdkBundle
+
+	// resourceSchema is the SDKv2 managed resource being listed: the source of the
+	// protocol schemas returned by RawV6Schemas, and of the ResourceData every
+	// result is written into.
+	resourceSchema *schema.Resource
+}
+
+// NewIPBlockListResource creates a new list resource for ionoscloud_ipblock.
+func NewIPBlockListResource() list.ListResource {
+	return &ipBlockListResource{resourceSchema: resourceIPBlock()}
+}
+
+// RawV6Schemas hands the framework the protocol schemas of the SDKv2 managed
+// resource. A framework-native list resource inherits them from the resource
+// itself; this is only needed because ionoscloud_ipblock lives on the SDKv2 side.
+func (r *ipBlockListResource) RawV6Schemas(ctx context.Context, _ list.RawV6SchemaRequest, resp *list.RawV6SchemaResponse) {
+	fwidentity.SetRawV6Schemas(ctx, resp, constant.IpBlockResource, r.resourceSchema)
+}
+
+// Metadata returns the type name of the managed resource being listed. It must match
+// the SDKv2 resource exactly, otherwise terraform has no resource to attach the
+// results to.
+func (r *ipBlockListResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = constant.IpBlockResource
+}
+
+// Configure stores the client bundle shared by the provider.
+func (r *ipBlockListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	clientBundle, ok := req.ProviderData.(*bundleclient.SdkBundle)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected List Resource Configure Type",
+			fmt.Sprintf("Expected *bundleclient.SdkBundle, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.bundle = clientBundle
+}
+
+// ListResourceConfigSchema returns the schema for the list resource config schema.
+func (r *ipBlockListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+	resp.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			fwidentity.FiltersKey: fwidentity.FilterAttribute("name", "location"),
+		},
+	}
+}
+
+// List fetches every IP block on the contract and streams the results. The Cloud API
+// returns IP blocks from all locations from a single collection, so unlike the
+// regional products there is nothing to fan out over here.
+func (r *ipBlockListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
+	fwidentity.StreamList(ctx, stream, req,
+		func(ctx context.Context) ([]ionoscloud.IpBlock, error) {
+			// The ipblock collection is not location-scoped, so this uses the same
+			// client every other global Cloud API listing uses.
+			client, err := r.bundle.NewCloudAPIClientWithFailover(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create the Cloud API client: %w", err)
+			}
+
+			// Depth(1) is what makes the API return the properties of every IP block
+			// instead of just its links. Filtering stays client-side, in the mapper.
+			//
+			// The explicit Limit matches what the ionoscloud_ipblock data source asks
+			// for (data_source_ipblock.go); without it the SDK client falls back to 100
+			// for /ipblocks, which would cap this listing below its own data source.
+			ipBlocks, apiResponse, err := client.IPBlocksApi.IpblocksGet(ctx).Depth(1).Limit(constant.IPBlockLimit).Execute()
+			if apiResponse != nil {
+				tflog.Debug(ctx, "listed ip blocks", map[string]any{"status_code": apiResponse.SafeStatusCode()})
+			}
+			if err != nil {
+				return nil, fmt.Errorf("failed to list ip blocks: %w", err)
+			}
+			if ipBlocks.Items == nil {
+				return nil, nil
+			}
+
+			return *ipBlocks.Items, nil
+		},
+		r.mapIPBlock,
+	)
+}
+
+// mapIPBlock maps an IP block to an identity.MappedItem, or returns nil to skip it.
+//
+// The mapping itself is IpBlockSetData, the same state writer resourceIPBlockRead
+// uses, run against a ResourceData built from the live schema. Nothing here knows what
+// attributes an IP block has.
+func (r *ipBlockListResource) mapIPBlock(_ context.Context, includeResource bool, filters []fwidentity.Filter, item ionoscloud.IpBlock) (*fwidentity.MappedItem, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if item.Id == nil || item.Properties == nil {
+		return nil, nil
+	}
+
+	name := shared.ToValueDefault(item.Properties.Name)
+	location := shared.ToValueDefault(item.Properties.Location)
+
+	if !fwidentity.MatchesFilters(map[string]string{
+		"name":     name,
+		"location": location,
+	}, filters) {
+		return nil, nil
+	}
+
+	data := r.resourceSchema.Data(&terraform.InstanceState{})
+	if err := IpBlockSetData(data, &item); err != nil {
+		diags.AddError("Failed to map the ip block", err.Error())
+		return nil, diags
+	}
+
+	// setIPBlockIdentity reads id and location back out of the ResourceData, so it has
+	// to run after IpBlockSetData.
+	if err := setIPBlockIdentity(data); err != nil {
+		diags.AddError("Failed to map the ip block identity", err.Error())
+		return nil, diags
+	}
+
+	// name is Optional on ionoscloud_ipblock, so an unnamed block would otherwise
+	// render as a blank row in the terraform query output.
+	displayName := name
+	if displayName == "" {
+		displayName = *item.Id
+	}
+
+	mapped, err := fwidentity.MappedItemFromResourceData(displayName, data, includeResource)
+	if err != nil {
+		diags.AddError("Failed to convert the ip block state", err.Error())
+		return nil, diags
+	}
+
+	return mapped, diags
+}

--- a/ionoscloud/resource_ipblock_list_test.go
+++ b/ionoscloud/resource_ipblock_list_test.go
@@ -27,8 +27,8 @@ const ipBlockListType = "ionoscloud_ipblock"
 // including the timeouts block identity.MappedItemFromResourceData nulls back out.
 //
 // The shared helpers it calls - muxedProviderServer, configureProvider, listResults,
-// decode and the rest - are declared once for the package in
-// resource_datacenter_list_test.go.
+// listServerAndConfig, decode, identityType and the rest - are declared once for the
+// package in resource_datacenter_list_test.go.
 func TestIPBlockListResource(t *testing.T) {
 	ctx := context.Background()
 
@@ -46,10 +46,10 @@ func TestIPBlockListResource(t *testing.T) {
 	// The framework only registers a list resource that has no framework resource
 	// behind it once RawV6Schemas has supplied both protocol schemas.
 	if _, ok := providerSchema.ListResourceSchemas[ipBlockListType]; !ok {
-		t.Fatalf("the ipblock list resource was not registered; check RawV6Schemas and the SDKv2 resource identity")
+		t.Fatalf("the ip block list resource was not registered; check RawV6Schemas and the SDKv2 resource identity")
 	}
 	if _, ok := providerSchema.ResourceSchemas[ipBlockListType]; !ok {
-		t.Fatalf("the ipblock managed resource is missing from the merged schema")
+		t.Fatalf("the ip block managed resource is missing from the merged schema")
 	}
 
 	identitySchemas, err := server.GetResourceIdentitySchemas(ctx, &tfprotov6.GetResourceIdentitySchemasRequest{})
@@ -60,7 +60,7 @@ func TestIPBlockListResource(t *testing.T) {
 
 	identitySchema := identitySchemas.IdentitySchemas[ipBlockListType]
 	if identitySchema == nil {
-		t.Fatalf("the SDKv2 ipblock resource does not declare a resource identity")
+		t.Fatalf("the SDKv2 ip block resource does not declare a resource identity")
 	}
 
 	configureProvider(ctx, t, server, providerSchema.Provider)
@@ -74,93 +74,87 @@ func TestIPBlockListResource(t *testing.T) {
 			t.Fatalf("expected 3 results, got %d", len(results))
 		}
 
-		assert.Equal(t, "public-ips", results[0].DisplayName)
+		assert.Equal(t, "prod-ips", results[0].DisplayName)
 
 		identity := decode(t, results[0].Identity.IdentityData, identityType(identitySchema))
-		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000001", identity["id"])
+		assert.Len(t, identity, 2, "the ip block identity is id plus location")
+		assert.Equal(t, "b1b07384-d9a0-4d1e-8f2a-000000000001", identity["id"])
 		assert.Equal(t, "de/txl", identity["location"])
-		assert.Len(t, identity, 2, "the ipblock identity is id plus location")
 
 		// Every attribute the writer fills is asserted here, so that writing a value to
 		// the wrong key fails the test.
 		resource := decode(t, results[0].Resource, resourceType)
-		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000001", resource["id"])
-		assert.Equal(t, "public-ips", resource["name"])
+		assert.Equal(t, "b1b07384-d9a0-4d1e-8f2a-000000000001", resource["id"])
+		assert.Equal(t, "prod-ips", resource["name"])
 		assert.Equal(t, "de/txl", resource["location"])
 		assert.Equal(t, int64(2), resource["size"])
-		assert.Equal(t, []any{"203.0.113.10", "203.0.113.11"}, resource["ips"])
+		assert.Equal(t, []any{"203.0.113.1", "203.0.113.2"}, resource["ips"])
 		assert.Equal(t, []any{map[string]any{
-			"ip":                "203.0.113.10",
-			"mac":               "02:01:0b:1a:0e:5f",
-			"nic_id":            "c2b1a0e5-0000-4000-8000-00000000000a",
-			"server_id":         "d3c2b1a0-0000-4000-8000-00000000000b",
+			"ip":                "203.0.113.1",
+			"mac":               "02:01:0b:0d:8f:b1",
+			"nic_id":            "c1c07384-d9a0-4d1e-8f2a-00000000000a",
+			"server_id":         "c2c07384-d9a0-4d1e-8f2a-00000000000b",
 			"server_name":       "web-01",
-			"datacenter_id":     "e4d3c2b1-0000-4000-8000-00000000000c",
+			"datacenter_id":     "c3c07384-d9a0-4d1e-8f2a-00000000000c",
 			"datacenter_name":   "prod",
-			"k8s_nodepool_uuid": "f5e4d3c2-0000-4000-8000-00000000000d",
-			"k8s_cluster_uuid":  "a6f5e4d3-0000-4000-8000-00000000000e",
+			"k8s_nodepool_uuid": "c4c07384-d9a0-4d1e-8f2a-00000000000d",
+			"k8s_cluster_uuid":  "c5c07384-d9a0-4d1e-8f2a-00000000000e",
 		}}, resource["ip_consumers"])
 		assert.Nil(t, resource["timeouts"], "a listed ip block has no timeouts")
 
 		// The second ip block reports only the properties the API always sets, which
 		// pins that the pairing holds past the first result and that the properties the
 		// API left out stay null instead of turning into zero values.
-		assert.Equal(t, "spare-ips", results[1].DisplayName)
+		assert.Equal(t, "staging-ips", results[1].DisplayName)
 
-		secondIdentity := decode(t, results[1].Identity.IdentityData, identityType(identitySchema))
-		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000002", secondIdentity["id"])
-		assert.Equal(t, "de/fra", secondIdentity["location"])
+		stagingIdentity := decode(t, results[1].Identity.IdentityData, identityType(identitySchema))
+		assert.Equal(t, "b1b07384-d9a0-4d1e-8f2a-000000000002", stagingIdentity["id"])
+		assert.Equal(t, "de/fra", stagingIdentity["location"])
 
-		second := decode(t, results[1].Resource, resourceType)
-		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000002", second["id"])
-		assert.Equal(t, "spare-ips", second["name"])
-		assert.Equal(t, "de/fra", second["location"])
-		assert.Equal(t, int64(1), second["size"])
-		assert.Equal(t, []any{"198.51.100.7"}, second["ips"])
-		// ip_consumers is Optional + Computed with an Elem: &schema.Resource{}, so
-		// core_schema.go:108-112 renders it as a nested BLOCK rather than an attribute,
-		// and toproto6.DynamicValue's ReifyNullCollectionBlocks turns the null block the
-		// API omitted into an EMPTY list. An omitted attribute would decode to nil - see
-		// the name assertion on the third result below.
-		assert.Equal(t, []any{}, second["ip_consumers"])
+		staging := decode(t, results[1].Resource, resourceType)
+		assert.Equal(t, "b1b07384-d9a0-4d1e-8f2a-000000000002", staging["id"])
+		assert.Equal(t, "staging-ips", staging["name"])
+		assert.Equal(t, "de/fra", staging["location"])
+		assert.Equal(t, int64(1), staging["size"])
+		// `ips` is a Computed-only list of strings, so it is a protocol ATTRIBUTE and an
+		// omitted one decodes to nil (core_schema.go:102-106).
+		assert.Nil(t, staging["ips"])
+		// `ip_consumers` is Optional+Computed with an Elem: &schema.Resource, so it is a
+		// nested BLOCK (core_schema.go:108-112, :201-205). ReifyNullCollectionBlocks
+		// turns a null list block into an empty one, so an omitted block decodes to
+		// []any{} rather than nil (toproto6/dynamic_value.go:29-30).
+		assert.Equal(t, []any{}, staging["ip_consumers"])
 
-		// The third ip block has no name at all, which is legal: name is Optional on
-		// ionoscloud_ipblock. It covers the display-name fallback to the UUID, which the
-		// second result cannot reach because it keeps its name.
-		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000003", results[2].DisplayName)
+		// The third ip block has no name, which is legal - `name` is Optional on
+		// ionoscloud_ipblock - and covers the display-name fallback to the UUID.
+		assert.Equal(t, "b1b07384-d9a0-4d1e-8f2a-000000000003", results[2].DisplayName)
 
-		third := decode(t, results[2].Resource, resourceType)
-		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000003", third["id"])
-		assert.Nil(t, third["name"], "an omitted optional attribute decodes to null, not an empty string")
-		assert.Equal(t, "de/fra", third["location"])
-		assert.Nil(t, third["ips"], "ips is a Computed-only attribute, so an omitted one stays null")
-		assert.Equal(t, []any{}, third["ip_consumers"])
+		unnamed := decode(t, results[2].Resource, resourceType)
+		assert.Equal(t, "b1b07384-d9a0-4d1e-8f2a-000000000003", unnamed["id"])
+		assert.Nil(t, unnamed["name"])
 	})
 
-	// One subtest per field in the FilterAttribute allow-list: MatchesFilters returns
-	// false for a field_name the mapper forgot to put in its map, so an untested field
-	// is a filter that silently matches nothing while the other subtests stay green.
 	t.Run("filters by name", func(t *testing.T) {
-		results := listResults(ctx, t, server, ipBlockListType, listSchema, map[string]string{"name": "spare-ips"})
+		results := listResults(ctx, t, server, ipBlockListType, listSchema, map[string]string{"name": "staging-ips"})
 		if len(results) != 1 {
 			t.Fatalf("expected 1 result, got %d", len(results))
 		}
-		assert.Equal(t, "spare-ips", results[0].DisplayName)
+		assert.Equal(t, "staging-ips", results[0].DisplayName)
 	})
 
 	t.Run("filters by location", func(t *testing.T) {
-		results := listResults(ctx, t, server, ipBlockListType, listSchema, map[string]string{"location": "de/txl"})
+		results := listResults(ctx, t, server, ipBlockListType, listSchema, map[string]string{"location": "de/fra"})
 		if len(results) != 1 {
 			t.Fatalf("expected 1 result, got %d", len(results))
 		}
-		assert.Equal(t, "public-ips", results[0].DisplayName)
+		assert.Equal(t, "staging-ips", results[0].DisplayName)
 	})
 
-	// Two fields whose values match DIFFERENT stub items: pins that the filters are
-	// ANDed, and that neither field is wired to the other's property.
+	// The two values match DIFFERENT stub items, so this pins that the filters are
+	// ANDed and that neither field is wired to the other's property.
 	t.Run("applies every filter", func(t *testing.T) {
 		results := listResults(ctx, t, server, ipBlockListType, listSchema, map[string]string{
-			"name":     "public-ips",
+			"name":     "prod-ips",
 			"location": "de/fra",
 		})
 		if len(results) != 0 {
@@ -184,53 +178,53 @@ func TestIPBlockListResource(t *testing.T) {
 	})
 }
 
-// stubIPBlockAPI serves the ipblock collection the list resource reads, and returns the
-// URL to point IONOS_API_URL at. Every other path 404s on purpose, so an unexpected
-// extra request surfaces as an error diagnostic instead of succeeding.
+// stubIPBlockAPI serves the ip block collection the list resource reads, and returns
+// the URL to point IONOS_API_URL at. Every other path 404s on purpose, so an
+// unexpected extra request surfaces as an error diagnostic instead of succeeding.
 func stubIPBlockAPI(t *testing.T) string {
 	t.Helper()
 
 	ipBlocks := ionoscloudsdk.IpBlocks{
 		Items: &[]ionoscloudsdk.IpBlock{
 			{
-				// Every property the writer reads is set.
-				Id: new("b1a0e5f2-0000-4000-8000-000000000001"),
+				// Result 1: every property the writer reads is set.
+				Id: new("b1b07384-d9a0-4d1e-8f2a-000000000001"),
 				Properties: &ionoscloudsdk.IpBlockProperties{
-					Name:     new("public-ips"),
+					Name:     new("prod-ips"),
 					Location: new("de/txl"),
 					Size:     new(int32(2)),
-					Ips:      &[]string{"203.0.113.10", "203.0.113.11"},
+					Ips:      &[]string{"203.0.113.1", "203.0.113.2"},
 					IpConsumers: &[]ionoscloudsdk.IpConsumer{{
-						Ip:              new("203.0.113.10"),
-						Mac:             new("02:01:0b:1a:0e:5f"),
-						NicId:           new("c2b1a0e5-0000-4000-8000-00000000000a"),
-						ServerId:        new("d3c2b1a0-0000-4000-8000-00000000000b"),
+						Ip:              new("203.0.113.1"),
+						Mac:             new("02:01:0b:0d:8f:b1"),
+						NicId:           new("c1c07384-d9a0-4d1e-8f2a-00000000000a"),
+						ServerId:        new("c2c07384-d9a0-4d1e-8f2a-00000000000b"),
 						ServerName:      new("web-01"),
-						DatacenterId:    new("e4d3c2b1-0000-4000-8000-00000000000c"),
+						DatacenterId:    new("c3c07384-d9a0-4d1e-8f2a-00000000000c"),
 						DatacenterName:  new("prod"),
-						K8sNodePoolUuid: new("f5e4d3c2-0000-4000-8000-00000000000d"),
-						K8sClusterUuid:  new("a6f5e4d3-0000-4000-8000-00000000000e"),
+						K8sNodePoolUuid: new("c4c07384-d9a0-4d1e-8f2a-00000000000d"),
+						K8sClusterUuid:  new("c5c07384-d9a0-4d1e-8f2a-00000000000e"),
 					}},
 				},
 			},
 			{
-				// Only the properties the API always returns, so that ip_consumers can be
-				// asserted as the empty block it reifies to. name stays set here: the
-				// display-name and filter assertions need something to match on.
-				Id: new("b1a0e5f2-0000-4000-8000-000000000002"),
+				// Result 2: only the properties the API always returns, so that the
+				// optional ones can be asserted null. `name` stays set here - the
+				// display-name and filter assertions need a name to match on.
+				Id: new("b1b07384-d9a0-4d1e-8f2a-000000000002"),
 				Properties: &ionoscloudsdk.IpBlockProperties{
-					Name:     new("spare-ips"),
+					Name:     new("staging-ips"),
 					Location: new("de/fra"),
 					Size:     new(int32(1)),
-					Ips:      &[]string{"198.51.100.7"},
 				},
 			},
 			{
-				// No name, which is legal because name is Optional on the resource. This
-				// is what covers the displayName fallback in mapIPBlock.
-				Id: new("b1a0e5f2-0000-4000-8000-000000000003"),
+				// Result 3: no name at all, which `name` being Optional allows. It is
+				// what reaches the displayName fallback in mapIPBlock; result 2 cannot,
+				// because it keeps `name` set.
+				Id: new("b1b07384-d9a0-4d1e-8f2a-000000000003"),
 				Properties: &ionoscloudsdk.IpBlockProperties{
-					Location: new("de/fra"),
+					Location: new("de/txl"),
 					Size:     new(int32(1)),
 				},
 			},
@@ -243,13 +237,14 @@ func stubIPBlockAPI(t *testing.T) string {
 			return
 		}
 		// The request the fetch closure builds is part of what is under test - the stub
-		// answers any query string identically, so without these the options are
-		// unpinned. The limit is asserted as a literal rather than as
-		// constant.IPBlockLimit because that literal is the only thing tying the number
-		// in docs/list-resources/ipblock.md to the code.
+		// answers any query string identically, so without these the options are unpinned.
 		if got := r.URL.Query().Get("depth"); got != "1" {
 			t.Errorf("expected depth=1 on the /ipblocks request, got %q", got)
 		}
+		// Asserted as a literal rather than as constant.IPBlockLimit: this number is the
+		// only thing tying docs/list-resources/ipblock.md to the code, and the point of
+		// the assertion is that the fetch asks for more than the 100 the SDK client
+		// falls back to for /ipblocks.
 		if got := r.URL.Query().Get("limit"); got != "1000" {
 			t.Errorf("expected limit=1000 on the /ipblocks request, got %q", got)
 		}

--- a/ionoscloud/resource_ipblock_list_test.go
+++ b/ionoscloud/resource_ipblock_list_test.go
@@ -1,0 +1,264 @@
+package ionoscloud_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	ionoscloudsdk "github.com/ionos-cloud/sdk-go/v6"
+	"github.com/stretchr/testify/assert"
+)
+
+const ipBlockListType = "ionoscloud_ipblock"
+
+// TestIPBlockListResource drives the ListResource RPC end to end against a stubbed
+// Cloud API, through the same muxed provider server that main.go serves.
+//
+// It covers the parts of a list resource for an SDKv2 managed resource that can only
+// fail at runtime: that the mux is happy with the list resource and the managed
+// resource coming from different servers, that the framework registers a list resource
+// with no framework resource behind it, that the protocol schemas handed over by
+// RawV6Schemas convert cleanly, and that the state the resource's own writer produces
+// survives the round trip through ResourceData.TfTypeResourceState into the list result,
+// including the timeouts block identity.MappedItemFromResourceData nulls back out.
+//
+// The shared helpers it calls - muxedProviderServer, configureProvider, listResults,
+// decode and the rest - are declared once for the package in
+// resource_datacenter_list_test.go.
+func TestIPBlockListResource(t *testing.T) {
+	ctx := context.Background()
+
+	t.Setenv("IONOS_API_URL", stubIPBlockAPI(t))
+	t.Setenv("IONOS_TOKEN", "token-for-the-stub")
+
+	server := muxedProviderServer(ctx, t)
+
+	providerSchema, err := server.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema: %v", err)
+	}
+	failOnErrorDiagnostics(t, "GetProviderSchema", providerSchema.Diagnostics)
+
+	// The framework only registers a list resource that has no framework resource
+	// behind it once RawV6Schemas has supplied both protocol schemas.
+	if _, ok := providerSchema.ListResourceSchemas[ipBlockListType]; !ok {
+		t.Fatalf("the ipblock list resource was not registered; check RawV6Schemas and the SDKv2 resource identity")
+	}
+	if _, ok := providerSchema.ResourceSchemas[ipBlockListType]; !ok {
+		t.Fatalf("the ipblock managed resource is missing from the merged schema")
+	}
+
+	identitySchemas, err := server.GetResourceIdentitySchemas(ctx, &tfprotov6.GetResourceIdentitySchemasRequest{})
+	if err != nil {
+		t.Fatalf("GetResourceIdentitySchemas: %v", err)
+	}
+	failOnErrorDiagnostics(t, "GetResourceIdentitySchemas", identitySchemas.Diagnostics)
+
+	identitySchema := identitySchemas.IdentitySchemas[ipBlockListType]
+	if identitySchema == nil {
+		t.Fatalf("the SDKv2 ipblock resource does not declare a resource identity")
+	}
+
+	configureProvider(ctx, t, server, providerSchema.Provider)
+
+	listSchema := providerSchema.ListResourceSchemas[ipBlockListType]
+	resourceType := providerSchema.ResourceSchemas[ipBlockListType].ValueType()
+
+	t.Run("streams every ip block", func(t *testing.T) {
+		results := listResults(ctx, t, server, ipBlockListType, listSchema, nil)
+		if len(results) != 3 {
+			t.Fatalf("expected 3 results, got %d", len(results))
+		}
+
+		assert.Equal(t, "public-ips", results[0].DisplayName)
+
+		identity := decode(t, results[0].Identity.IdentityData, identityType(identitySchema))
+		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000001", identity["id"])
+		assert.Equal(t, "de/txl", identity["location"])
+		assert.Len(t, identity, 2, "the ipblock identity is id plus location")
+
+		// Every attribute the writer fills is asserted here, so that writing a value to
+		// the wrong key fails the test.
+		resource := decode(t, results[0].Resource, resourceType)
+		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000001", resource["id"])
+		assert.Equal(t, "public-ips", resource["name"])
+		assert.Equal(t, "de/txl", resource["location"])
+		assert.Equal(t, int64(2), resource["size"])
+		assert.Equal(t, []any{"203.0.113.10", "203.0.113.11"}, resource["ips"])
+		assert.Equal(t, []any{map[string]any{
+			"ip":                "203.0.113.10",
+			"mac":               "02:01:0b:1a:0e:5f",
+			"nic_id":            "c2b1a0e5-0000-4000-8000-00000000000a",
+			"server_id":         "d3c2b1a0-0000-4000-8000-00000000000b",
+			"server_name":       "web-01",
+			"datacenter_id":     "e4d3c2b1-0000-4000-8000-00000000000c",
+			"datacenter_name":   "prod",
+			"k8s_nodepool_uuid": "f5e4d3c2-0000-4000-8000-00000000000d",
+			"k8s_cluster_uuid":  "a6f5e4d3-0000-4000-8000-00000000000e",
+		}}, resource["ip_consumers"])
+		assert.Nil(t, resource["timeouts"], "a listed ip block has no timeouts")
+
+		// The second ip block reports only the properties the API always sets, which
+		// pins that the pairing holds past the first result and that the properties the
+		// API left out stay null instead of turning into zero values.
+		assert.Equal(t, "spare-ips", results[1].DisplayName)
+
+		secondIdentity := decode(t, results[1].Identity.IdentityData, identityType(identitySchema))
+		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000002", secondIdentity["id"])
+		assert.Equal(t, "de/fra", secondIdentity["location"])
+
+		second := decode(t, results[1].Resource, resourceType)
+		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000002", second["id"])
+		assert.Equal(t, "spare-ips", second["name"])
+		assert.Equal(t, "de/fra", second["location"])
+		assert.Equal(t, int64(1), second["size"])
+		assert.Equal(t, []any{"198.51.100.7"}, second["ips"])
+		// ip_consumers is Optional + Computed with an Elem: &schema.Resource{}, so
+		// core_schema.go:108-112 renders it as a nested BLOCK rather than an attribute,
+		// and toproto6.DynamicValue's ReifyNullCollectionBlocks turns the null block the
+		// API omitted into an EMPTY list. An omitted attribute would decode to nil - see
+		// the name assertion on the third result below.
+		assert.Equal(t, []any{}, second["ip_consumers"])
+
+		// The third ip block has no name at all, which is legal: name is Optional on
+		// ionoscloud_ipblock. It covers the display-name fallback to the UUID, which the
+		// second result cannot reach because it keeps its name.
+		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000003", results[2].DisplayName)
+
+		third := decode(t, results[2].Resource, resourceType)
+		assert.Equal(t, "b1a0e5f2-0000-4000-8000-000000000003", third["id"])
+		assert.Nil(t, third["name"], "an omitted optional attribute decodes to null, not an empty string")
+		assert.Equal(t, "de/fra", third["location"])
+		assert.Nil(t, third["ips"], "ips is a Computed-only attribute, so an omitted one stays null")
+		assert.Equal(t, []any{}, third["ip_consumers"])
+	})
+
+	// One subtest per field in the FilterAttribute allow-list: MatchesFilters returns
+	// false for a field_name the mapper forgot to put in its map, so an untested field
+	// is a filter that silently matches nothing while the other subtests stay green.
+	t.Run("filters by name", func(t *testing.T) {
+		results := listResults(ctx, t, server, ipBlockListType, listSchema, map[string]string{"name": "spare-ips"})
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		assert.Equal(t, "spare-ips", results[0].DisplayName)
+	})
+
+	t.Run("filters by location", func(t *testing.T) {
+		results := listResults(ctx, t, server, ipBlockListType, listSchema, map[string]string{"location": "de/txl"})
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		assert.Equal(t, "public-ips", results[0].DisplayName)
+	})
+
+	// Two fields whose values match DIFFERENT stub items: pins that the filters are
+	// ANDed, and that neither field is wired to the other's property.
+	t.Run("applies every filter", func(t *testing.T) {
+		results := listResults(ctx, t, server, ipBlockListType, listSchema, map[string]string{
+			"name":     "public-ips",
+			"location": "de/fra",
+		})
+		if len(results) != 0 {
+			t.Fatalf("expected 0 results, got %d", len(results))
+		}
+	})
+
+	t.Run("rejects unknown filter fields", func(t *testing.T) {
+		listServer, config := listServerAndConfig(t, server, listSchema, map[string]string{"nope": "value"})
+
+		resp, err := listServer.ValidateListResourceConfig(ctx, &tfprotov6.ValidateListResourceConfigRequest{
+			TypeName: ipBlockListType,
+			Config:   &config,
+		})
+		if err != nil {
+			t.Fatalf("ValidateListResourceConfig: %v", err)
+		}
+		if !hasErrorDiagnostic(resp.Diagnostics) {
+			t.Fatalf("expected a validation error for an unknown filter field")
+		}
+	})
+}
+
+// stubIPBlockAPI serves the ipblock collection the list resource reads, and returns the
+// URL to point IONOS_API_URL at. Every other path 404s on purpose, so an unexpected
+// extra request surfaces as an error diagnostic instead of succeeding.
+func stubIPBlockAPI(t *testing.T) string {
+	t.Helper()
+
+	ipBlocks := ionoscloudsdk.IpBlocks{
+		Items: &[]ionoscloudsdk.IpBlock{
+			{
+				// Every property the writer reads is set.
+				Id: new("b1a0e5f2-0000-4000-8000-000000000001"),
+				Properties: &ionoscloudsdk.IpBlockProperties{
+					Name:     new("public-ips"),
+					Location: new("de/txl"),
+					Size:     new(int32(2)),
+					Ips:      &[]string{"203.0.113.10", "203.0.113.11"},
+					IpConsumers: &[]ionoscloudsdk.IpConsumer{{
+						Ip:              new("203.0.113.10"),
+						Mac:             new("02:01:0b:1a:0e:5f"),
+						NicId:           new("c2b1a0e5-0000-4000-8000-00000000000a"),
+						ServerId:        new("d3c2b1a0-0000-4000-8000-00000000000b"),
+						ServerName:      new("web-01"),
+						DatacenterId:    new("e4d3c2b1-0000-4000-8000-00000000000c"),
+						DatacenterName:  new("prod"),
+						K8sNodePoolUuid: new("f5e4d3c2-0000-4000-8000-00000000000d"),
+						K8sClusterUuid:  new("a6f5e4d3-0000-4000-8000-00000000000e"),
+					}},
+				},
+			},
+			{
+				// Only the properties the API always returns, so that ip_consumers can be
+				// asserted as the empty block it reifies to. name stays set here: the
+				// display-name and filter assertions need something to match on.
+				Id: new("b1a0e5f2-0000-4000-8000-000000000002"),
+				Properties: &ionoscloudsdk.IpBlockProperties{
+					Name:     new("spare-ips"),
+					Location: new("de/fra"),
+					Size:     new(int32(1)),
+					Ips:      &[]string{"198.51.100.7"},
+				},
+			},
+			{
+				// No name, which is legal because name is Optional on the resource. This
+				// is what covers the displayName fallback in mapIPBlock.
+				Id: new("b1a0e5f2-0000-4000-8000-000000000003"),
+				Properties: &ionoscloudsdk.IpBlockProperties{
+					Location: new("de/fra"),
+					Size:     new(int32(1)),
+				},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/ipblocks") {
+			http.NotFound(w, r)
+			return
+		}
+		// The request the fetch closure builds is part of what is under test - the stub
+		// answers any query string identically, so without these the options are
+		// unpinned. The limit is asserted as a literal rather than as
+		// constant.IPBlockLimit because that literal is the only thing tying the number
+		// in docs/list-resources/ipblock.md to the code.
+		if got := r.URL.Query().Get("depth"); got != "1" {
+			t.Errorf("expected depth=1 on the /ipblocks request, got %q", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "1000" {
+			t.Errorf("expected limit=1000 on the /ipblocks request, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ipBlocks); err != nil {
+			t.Errorf("failed to write the stubbed response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return server.URL
+}

--- a/ionoscloud/resource_ipblock_test.go
+++ b/ionoscloud/resource_ipblock_test.go
@@ -108,19 +108,6 @@ func TestAccIPBlockBasic(t *testing.T) {
 				Config:      testAccDataSourceIpBlockGoodIdNameError,
 				ExpectError: regexp.MustCompile(`name of ip block \(UUID=.+, name=.+\) does not match expected name`),
 			},
-			// name is the only non-ForceNew attribute, so this step is the only one that
-			// actually enters resourceIPBlockUpdate - and therefore the only coverage of
-			// the identity write on the update path. The size change below is a
-			// destroy-and-create, which goes through Create and Read instead.
-			{
-				Config: testAccCheckIPBlockConfigUpdateNameOnly,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIPBlockExists(fullIpBlockResourceName, &ipblock),
-					testAccCheckIPBlockAttributes(fullIpBlockResourceName, location),
-					resource.TestCheckResourceAttr(fullIpBlockResourceName, "name", constant.UpdatedResources),
-					resource.TestCheckResourceAttr(fullIpBlockResourceName, "size", "1"),
-				),
-			},
 			{
 				Config: testAccCheckIPBlockConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
@@ -143,9 +130,10 @@ func TestAccIPBlockBasic(t *testing.T) {
 // package.
 func TestAccIPBlockQuery(t *testing.T) {
 	const (
-		ipBlockName   = "tf-test-ipblock-query"
-		ipBlockAddr   = constant.IpBlockResource + ".test_ipblock"
-		otherLocation = "de/fra"
+		ipBlockName    = "tf-test-ipblock-query"
+		ipBlockRenamed = "tf-test-ipblock-query-renamed"
+		ipBlockAddr    = constant.IpBlockResource + ".test_ipblock_query"
+		otherLocation  = "de/txl"
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -159,16 +147,16 @@ func TestAccIPBlockQuery(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-resource %[1]q "test_ipblock" {
-  location = %[2]q
+resource %[1]q "test_ipblock_query" {
+  name     = %[2]q
+  location = %[3]q
   size     = 1
-  name     = %[3]q
-}`, constant.IpBlockResource, location, ipBlockName),
+}`, constant.IpBlockResource, ipBlockName, location),
 			},
 			// List without filters: the ip block must show up with its identity.
 			{
 				Query: true,
-				Config: fmt.Sprintf(`list %[1]q "test_ipblock" {
+				Config: fmt.Sprintf(`list %[1]q "test_ipblock_query" {
   provider = ionoscloud
 }`, constant.IpBlockResource),
 				QueryResultChecks: []querycheck.QueryResultCheck{
@@ -181,7 +169,7 @@ resource %[1]q "test_ipblock" {
 			// Filter by name and location: the unique name guarantees exactly one result.
 			{
 				Query: true,
-				Config: fmt.Sprintf(`list %[1]q "test_ipblock" {
+				Config: fmt.Sprintf(`list %[1]q "test_ipblock_query" {
   provider = ionoscloud
   config {
     filters = [
@@ -197,7 +185,7 @@ resource %[1]q "test_ipblock" {
 			// Same name, different location: proves the location filter is evaluated.
 			{
 				Query: true,
-				Config: fmt.Sprintf(`list %[1]q "test_ipblock" {
+				Config: fmt.Sprintf(`list %[1]q "test_ipblock_query" {
   provider = ionoscloud
   config {
     filters = [
@@ -209,6 +197,23 @@ resource %[1]q "test_ipblock" {
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectLength(ipBlockAddr, 0),
 				},
+			},
+			// Rename only. `name` is the sole non-ForceNew attribute of an ip block, so
+			// this is the one step that actually enters resourceIPBlockUpdate - which
+			// writes the identity itself, because it does not delegate to the read. The
+			// existing testAccCheckIPBlockConfigUpdate flips `size` as well, which is
+			// ForceNew, so that step destroys and recreates and never covers this.
+			{
+				Config: fmt.Sprintf(`
+resource %[1]q "test_ipblock_query" {
+  name     = %[2]q
+  location = %[3]q
+  size     = 1
+}`, constant.IpBlockResource, ipBlockRenamed, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(ipBlockAddr, "name", ipBlockRenamed),
+					resource.TestCheckResourceAttr(ipBlockAddr, "location", location),
+				),
 			},
 			// Import through the resource identity that the list results carry. This kind
 			// already checks that the import succeeds, that the plan it leaves behind is a
@@ -307,13 +312,6 @@ resource ` + constant.IpBlockResource + ` ` + constant.IpBlockTestResource + ` {
   location = "` + location + `"
   size = 1
   name = "` + constant.IpBlockTestResource + `"
-}`
-
-const testAccCheckIPBlockConfigUpdateNameOnly = `
-resource ` + constant.IpBlockResource + ` ` + constant.IpBlockTestResource + ` {
-  location = "` + location + `"
-  size = 1
-  name = "` + constant.UpdatedResources + `"
 }`
 
 const testAccCheckIPBlockConfigUpdate = `

--- a/ionoscloud/resource_ipblock_test.go
+++ b/ionoscloud/resource_ipblock_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/ionos-cloud/terraform-provider-ionoscloud/v6/utils/constant"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 const fullIpBlockResourceName = constant.IpBlockResource + "." + constant.IpBlockTestResource
@@ -105,6 +108,19 @@ func TestAccIPBlockBasic(t *testing.T) {
 				Config:      testAccDataSourceIpBlockGoodIdNameError,
 				ExpectError: regexp.MustCompile(`name of ip block \(UUID=.+, name=.+\) does not match expected name`),
 			},
+			// name is the only non-ForceNew attribute, so this step is the only one that
+			// actually enters resourceIPBlockUpdate - and therefore the only coverage of
+			// the identity write on the update path. The size change below is a
+			// destroy-and-create, which goes through Create and Read instead.
+			{
+				Config: testAccCheckIPBlockConfigUpdateNameOnly,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPBlockExists(fullIpBlockResourceName, &ipblock),
+					testAccCheckIPBlockAttributes(fullIpBlockResourceName, location),
+					resource.TestCheckResourceAttr(fullIpBlockResourceName, "name", constant.UpdatedResources),
+					resource.TestCheckResourceAttr(fullIpBlockResourceName, "size", "1"),
+				),
+			},
 			{
 				Config: testAccCheckIPBlockConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
@@ -113,6 +129,95 @@ func TestAccIPBlockBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(fullIpBlockResourceName, "name", constant.UpdatedResources),
 					resource.TestCheckResourceAttr(fullIpBlockResourceName, "size", "2"),
 				),
+			},
+		},
+	})
+}
+
+// TestAccIPBlockQuery exercises the ionoscloud_ipblock list resource and the resource
+// identity that listing depends on.
+//
+// The list resource is served by the plugin-framework half of the provider even though
+// the ipblock resource itself is implemented with SDKv2, so this also covers the mux
+// serving the two halves under the same type name. See resource_ipblock_list.go in this
+// package.
+func TestAccIPBlockQuery(t *testing.T) {
+	const (
+		ipBlockName   = "tf-test-ipblock-query"
+		ipBlockAddr   = constant.IpBlockResource + ".test_ipblock"
+		otherLocation = "de/fra"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		// `terraform query` and list blocks were introduced in Terraform 1.14.
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesInternal(t, &testAccProvider),
+		CheckDestroy:             testAccCheckIPBlockDestroyCheck,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource %[1]q "test_ipblock" {
+  location = %[2]q
+  size     = 1
+  name     = %[3]q
+}`, constant.IpBlockResource, location, ipBlockName),
+			},
+			// List without filters: the ip block must show up with its identity.
+			{
+				Query: true,
+				Config: fmt.Sprintf(`list %[1]q "test_ipblock" {
+  provider = ionoscloud
+}`, constant.IpBlockResource),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity(ipBlockAddr, map[string]knownvalue.Check{
+						"id":       knownvalue.NotNull(),
+						"location": knownvalue.StringExact(location),
+					}),
+				},
+			},
+			// Filter by name and location: the unique name guarantees exactly one result.
+			{
+				Query: true,
+				Config: fmt.Sprintf(`list %[1]q "test_ipblock" {
+  provider = ionoscloud
+  config {
+    filters = [
+      { field_name = "name",     field_value = %[2]q },
+      { field_name = "location", field_value = %[3]q },
+    ]
+  }
+}`, constant.IpBlockResource, ipBlockName, location),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength(ipBlockAddr, 1),
+				},
+			},
+			// Same name, different location: proves the location filter is evaluated.
+			{
+				Query: true,
+				Config: fmt.Sprintf(`list %[1]q "test_ipblock" {
+  provider = ionoscloud
+  config {
+    filters = [
+      { field_name = "name",     field_value = %[2]q },
+      { field_name = "location", field_value = %[3]q },
+    ]
+  }
+}`, constant.IpBlockResource, ipBlockName, otherLocation),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength(ipBlockAddr, 0),
+				},
+			},
+			// Import through the resource identity that the list results carry. This kind
+			// already checks that the import succeeds, that the plan it leaves behind is a
+			// no-op and that the planned identity matches the one in state; ImportStateVerify
+			// cannot be combined with it, only ImportCommandWithID reads that field.
+			{
+				ResourceName:    ipBlockAddr,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 			},
 		},
 	})
@@ -202,6 +307,13 @@ resource ` + constant.IpBlockResource + ` ` + constant.IpBlockTestResource + ` {
   location = "` + location + `"
   size = 1
   name = "` + constant.IpBlockTestResource + `"
+}`
+
+const testAccCheckIPBlockConfigUpdateNameOnly = `
+resource ` + constant.IpBlockResource + ` ` + constant.IpBlockTestResource + ` {
+  location = "` + location + `"
+  size = 1
+  name = "` + constant.UpdatedResources + `"
 }`
 
 const testAccCheckIPBlockConfigUpdate = `


### PR DESCRIPTION
## What does this fix or implement?

Adds a `terraform query` list resource for `ionoscloud_ipblock`, plus the `schema.ResourceIdentity` it requires on the managed resource. Same shape as `ionoscloud_datacenter` in #1034: the managed resource stays on SDKv2, the list resource lives beside it in package `ionoscloud` and bridges the protocol schemas through `identity.SetRawV6Schemas`.

**Resource identity.** `id` (required for import) + `location` (optional — only needed when the Cloud API endpoint is overridden per location). Written on every read path, and on update, which does not delegate to the read. The legacy `<location>:<uuid>` import string keeps working unchanged; the importer is now dual-mode.

**List resource.** One `GET /ipblocks` with `Depth(1)` and an explicit `Limit(constant.IPBlockLimit)` — without it the SDK client falls back to `limit=100`, ten times lower than what the `ionoscloud_ipblock` data source already asks for. Filters: `name` and `location`, matched client-side. No model struct: every result goes through `IpBlockSetData`, the same state writer `resourceIPBlockRead` uses, so the list output cannot drift from the resource schema.

**Pagination is deliberately not added**, matching the decision on #1034. Nothing in the provider paginates this endpoint — the data source makes the identical single request — so fixing only the list resource would leave the pair inconsistent. The limitation is documented in `docs/list-resources/ipblock.md` instead.

**Tests.** `TestIPBlockListResource` drives the real ListResource RPC end to end against a stubbed Cloud API through the same mux `main.go` serves — no credentials, no acceptance run. It asserts every mapped attribute on every stub result, the null-vs-empty distinction on omitted nested blocks, the query params the fetch closure sets, one subtest per filter field plus an AND case, and rejection of an unknown filter field. Mutation-checked: nine mutations applied to the mapper and the writer, nine caught. A `TestAccIPBlockQuery` step is written but not run; note that no test job runs on PRs, so green CI does not cover it.

**Also included:** the `.claude/skills/add-list-resource/` skill that produced this, so the next resource does not start from scratch. It is documentation only — no provider code depends on it.

## Checklist

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [x] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
